### PR TITLE
fix(ci): restore repository validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^10.2.1",
     "globals": "^17.5.0",
+    "js-yaml": "^4.1.1",
     "payload": "3.84.1",
     "prettier": "^3.8.3",
     "tsx": "^4.21.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
         NEXT_PUBLIC_API_BASE_URL: apiBaseUrl
       },
       reuseExistingServer: !process.env.CI,
-      timeout: 45_000,
+      timeout: 120_000,
       url: gameBaseUrl
     }
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       globals:
         specifier: ^17.5.0
         version: 17.5.0
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
       payload:
         specifier: 3.84.1
         version: 3.84.1(graphql@16.13.2)(typescript@5.9.3)

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -23,7 +23,7 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByText('Cuisine', { exact: true })).toBeVisible();
     await expect(page.getByText('Compétence implicite à 0').first()).toBeVisible();
     await expect(page.getByText('Cuisine corteganne')).toBeVisible();
-    await expect(page.getByText(/Catalogue implicite : 12 entrées, 8 notées/)).toBeVisible();
+    await expect(page.getByText(/Catalogue implicite : 10 entrées, 7 notées/)).toBeVisible();
 
     await page.getByRole('button', { name: /Force/ }).click();
     await expect(page.getByText('Dernier jet')).toBeVisible();
@@ -55,10 +55,10 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByText('20/20').first()).toBeVisible();
 
     await openCreationStep(page, 'Competences');
-    await increaseStepper(page, 'Art occulte', 4);
-    await increaseStepper(page, 'Armes longues', 4);
-    await increaseStepper(page, 'Survie', 4);
-    await increaseStepper(page, 'Artisanat', 4);
+    await increaseStepper(page, 'Arcanologie', 4);
+    await increaseStepper(page, 'Épée bâtarde', 4);
+    await increaseStepper(page, 'Chasse', 4);
+    await increaseStepper(page, 'Forge', 4);
     await increaseStepper(page, 'Commandement', 4);
     await expect(page.getByText('20/20').first()).toBeVisible();
 
@@ -126,6 +126,6 @@ async function openCreationStep(page: Page, stepName: string): Promise<void> {
 
 async function increaseStepper(page: Page, label: string, times: number): Promise<void> {
   for (let index = 0; index < times; index += 1) {
-    await page.getByTitle(`Augmenter ${label}`).click();
+    await page.getByTitle(`Augmenter ${label}`, { exact: true }).click();
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
+    testTimeout: 15000,
     include: [
       'packages/**/*.test.ts',
       'apps/server/src/**/*.test.ts',


### PR DESCRIPTION
## Summary
- declare the missing js-yaml runtime dependency used by canonical tooling
- give corpus/integration Vitest tests a 15s timeout budget
- give the Next game webServer enough time for cold-route compilation in Playwright
- align E2E expectations with current canonical character fixtures and exact nested-skill controls

Refs #49

## Verification
- pnpm test
- pnpm test:e2e
- pnpm validate

Browser plugin note: Codex in-app Browser blocked localhost/127.0.0.1 with ERR_BLOCKED_BY_CLIENT, so rendered validation was performed through the repository Playwright E2E suite.