### PR TITLE
feat(catalogs): require canonical entry status

### DIFF
--- a/data/catalogs/atouts.yaml
+++ b/data/catalogs/atouts.yaml
@@ -13,6 +13,7 @@ metadata:
 atouts:
   - id: abordage
     name: Abordage
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un combat sur un navire.
     value: 2000
     activation: permanent
@@ -23,6 +24,7 @@ atouts:
         ref: entry:abordage
   - id: accoutumance-a-la-douleur
     name: Accoutumance à la douleur
+    status: active
     effect: Diminue la difficulté des jets d’endurance de 1.
     value: 3000
     activation: permanent
@@ -33,6 +35,7 @@ atouts:
         ref: entry:accoutumance-a-la-douleur
   - id: adrenaline
     name: Adrénaline
+    status: active
     effect: >-
       Pendant toute la durée d’un combat, le personnage peut augmenter sa force, son endurance, ses réflexes  et sa
       dextérité de 1.
@@ -45,6 +48,7 @@ atouts:
         ref: entry:adrenaline
   - id: affinite-arcanique
     name: Affinité arcanique
+    status: active
     effect: "Le personnage apprend de nouveaux sorts, avec une aisance déconcertante. Le nombre de jours de son apprentissage sont divisés par son niveau en «\_Affinité arcanique » + 1. Soit s’il n’a qu’un point dans cet atout, ses jours d’apprentissage seront divisés par 2."
     value: 3000
     activation: permanent
@@ -55,6 +59,7 @@ atouts:
         ref: entry:affinite-arcanique
   - id: affinite-avec-les-illusions
     name: Affinité avec les illusions
+    status: active
     effect: >-
       Le personnage à tellement l'habitude de vivre entouré d'illusion que son sens de détection de celles-ci s'est
       fortement aiguisé. Il bénéficie d'une difficulté baissée de 3 pour tout jet de détection d'illusions.
@@ -67,6 +72,7 @@ atouts:
         ref: entry:affinite-avec-les-illusions
   - id: agilite
     name: Agilité
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un jet de danse.
     value: 2000
     activation: permanent
@@ -77,6 +83,7 @@ atouts:
         ref: entry:agilite
   - id: agitateur
     name: Agitateur
+    status: active
     effect: "Le personnage peut prendre son niveau en «\_Agitateur\_» en dès supplémentaire lors d’un combat dont il est responsable."
     value: 2000
     activation: permanent
@@ -87,6 +94,7 @@ atouts:
         ref: entry:agitateur
   - id: alcool-violent
     name: Alcool violent
+    status: active
     effect: "Lorsque le personnage combat ivre, il peut ajouter un dés par point dans «\_Alcool violent\_» à choix dans sa force ou endurance. Cette répartition peut être changée d’un combat à l’autre."
     value: 2000
     activation: permanent
@@ -97,6 +105,7 @@ atouts:
         ref: entry:alcool-violent
   - id: allegement
     name: Allègement
+    status: active
     effect: >-
       Le personnage peut confectionner des objets pesant X % de poids de moins que la normal (arrondi a l’inférieur)
       dans son domaine.
@@ -109,6 +118,7 @@ atouts:
         ref: entry:allegement
   - id: ambidextrie
     name: Ambidextrie
+    status: active
     effect: "Annule les pénalités dues à l’usage de la «\_mauvaise main\_»."
     value: 2000
     activation: permanent
@@ -119,6 +129,7 @@ atouts:
         ref: entry:ambidextrie
   - id: ames-jumelles
     name: Ames jumelles
+    status: active
     effect: >-
       Le personnage ressent ce que ressent son âme jumelle, peut connaître son état et sait dans quelle direction aller
       pour la retrouver, même si celle-ci se trouve a l’autre bout du monde.
@@ -131,6 +142,7 @@ atouts:
         ref: entry:ames-jumelles
   - id: ami-des-touts-petits
     name: Ami des touts petits
+    status: active
     effect: Le personnage est très vite accepter et apprécier par les enfants.
     value: 2000
     activation: permanent
@@ -141,6 +153,7 @@ atouts:
         ref: entry:ami-des-touts-petits
   - id: amnesie
     name: Amnésie
+    status: active
     effect: >-
       Le personnage peut effacer sa présence de la mémoire d’une personne en remontant dans celle-ci jusqu'à un maximum
       d’une minute par niveau. La victime effectue un test de volonté (difficulté plus le niveau ennemi) pour ne pas
@@ -154,6 +167,7 @@ atouts:
         ref: entry:amnesie
   - id: analyse
     name: Analyse
+    status: active
     effect: >-
       Le personnage peut prendre connaissance du nombre de points d’un autre personnage dans une aptitude, compétence ou
       spécialisation que celui-ci laisse transparaître.
@@ -166,6 +180,7 @@ atouts:
         ref: entry:analyse
   - id: ancrage
     name: Ancrage
+    status: active
     effect: >-
       Le personnage peut, suite aux pas d’araignée rester au mur ou même au plafond la tête en bas. Cet effet dure aussi
       longtemps que le désire le personnage, mais celui-ci ne peut ni se mouvoir, ni dormir et de plus il en viendrait à
@@ -179,6 +194,7 @@ atouts:
         ref: entry:ancrage
   - id: anosmie
     name: Anosmie
+    status: active
     effect: Le personnage ne possède aucun sens de l'odorat.
     value: -1500
     activation: permanent
@@ -189,6 +205,7 @@ atouts:
         ref: entry:anosmie
   - id: anti-bluff
     name: Anti-bluff
+    status: active
     effect: Additionne le niveau au nombre de dés pour déceler les mensonges.
     value: 2000
     activation: permanent
@@ -199,6 +216,7 @@ atouts:
         ref: entry:anti-bluff
   - id: anti-delivrance
     name: Anti-délivrance
+    status: active
     effect: >-
       Un personnage utilisant cet atout peut déduire son niveau aux malus d’affaiblissement du personnage qu’il
       maltraite (et ainsi lui faire mal plus longtemps). Cet atout ne s’applique que lorsque celui qui le possède le
@@ -212,6 +230,7 @@ atouts:
         ref: entry:anti-delivrance
   - id: anticipation-magique
     name: Anticipation magique
+    status: active
     effect: >-
       Le magicien peut incanter un sort sans le lancer, celui-ci est alors anticipé. Une fois le sort anticipé, le
       magicien peut le lancer à tout moment en 1 DT. Le magicien peut anticiper 1 sort par niveau en anticipation
@@ -227,6 +246,7 @@ atouts:
         ref: entry:anticipation-magique
   - id: antilimite-physique
     name: Antilimite physique
+    status: active
     effect: Le coût d’un point supplémentaire dans une aptitude, une fois la limite physique atteinte, est de NA x 10.
     value: 1800
     activation: permanent
@@ -237,6 +257,7 @@ atouts:
         ref: entry:antilimite-physique
   - id: apaisement
     name: Apaisement
+    status: active
     effect: Soigne les blessures par le touché. La vitalité ainsi récupérée est égale au niveau du soignant.
     value: 2000
     activation: ephemere
@@ -247,6 +268,7 @@ atouts:
         ref: entry:apaisement
   - id: apprentissage-rapide
     name: Apprentissage rapide
+    status: active
     effect: Le personnage additionne son niveau au nombre de réussites qu’il obtient lors d’un jet d’apprentissage.
     value: 2000
     activation: permanent
@@ -257,6 +279,7 @@ atouts:
         ref: entry:apprentissage-rapide
   - id: armure-partielle
     name: Armure partielle
+    status: active
     effect: >-
       Si dans sa touche (après une éventuelle esquive), un adversaire ne dépasse pas le score d’armure partielle du
       personnage, son coups sera alors dévier automatiquement dans une partie d’armure que possède le personnage (la
@@ -273,6 +296,7 @@ atouts:
         ref: entry:armure-partielle
   - id: art-de-la-charpente
     name: Art de la charpente
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage fait des travaux de charpenterie.
     value: 2000
     activation: permanent
@@ -283,6 +307,7 @@ atouts:
         ref: entry:art-de-la-charpente
   - id: art-de-la-chasse
     name: Art de la chasse
+    status: active
     effect: Additionne le niveau au nombre de dès lorsque le personnage chasse.
     value: 2000
     activation: permanent
@@ -293,6 +318,7 @@ atouts:
         ref: entry:art-de-la-chasse
   - id: art-de-la-peche
     name: Art de la pêche
+    status: active
     effect: Cet atout additionne le niveau au nombre de dès lorsque le personnage pêche.
     value: 2000
     activation: permanent
@@ -303,6 +329,7 @@ atouts:
         ref: entry:art-de-la-peche
   - id: art-de-la-table
     name: Art de la table
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage fait des travaux liés à la restauration.
     value: 2000
     activation: permanent
@@ -313,6 +340,7 @@ atouts:
         ref: entry:art-de-la-table
   - id: art-de-la-vannerie
     name: Art de la vannerie
+    status: active
     effect: Cet atout additionne le niveau au nombre de dès lorsque le personnage fait un travail de vannerie.
     value: 2000
     activation: permanent
@@ -323,6 +351,7 @@ atouts:
         ref: entry:art-de-la-vannerie
   - id: art-de-recevoir
     name: Art de recevoir
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage fait des travaux d'hôtellerie.
     value: 2000
     activation: permanent
@@ -333,6 +362,7 @@ atouts:
         ref: entry:art-de-recevoir
   - id: art-du-tonneau
     name: Art du tonneau
+    status: active
     effect: Cet atout additionne le niveau au nombre de dès lorsque le personnage confectionne un tonneau.
     value: 2000
     activation: permanent
@@ -343,6 +373,7 @@ atouts:
         ref: entry:art-du-tonneau
   - id: art-litteraire
     name: Art littéraire
+    status: active
     effect: Additionne le niveau au nombre de dès lorsque le personnage écrit.
     value: 2000
     activation: permanent
@@ -353,6 +384,7 @@ atouts:
         ref: entry:art-litteraire
   - id: art-occulte
     name: Art occulte
+    status: active
     effect: >-
       Le personnage peut choisir un sort de magie noire qu’il ajoute à sa feuille de personnage, comme s'il était
       magicien. Ce sort doit, bien sur être appris pour pouvoir être lancé. Le personnage débute avec un score de 0 dans
@@ -369,6 +401,7 @@ atouts:
         ref: entry:art-occulte
   - id: artisan-du-mensonge
     name: Artisan du mensonge
+    status: active
     effect: Diminue la difficulté d’un jet de mensonge de 1 par point dans cet atout.
     value: 2000
     activation: permanent
@@ -379,6 +412,7 @@ atouts:
         ref: entry:artisan-du-mensonge
   - id: assassinat
     name: Assassinat
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage assassine quelqu’un.
     value: 2000
     activation: permanent
@@ -389,6 +423,7 @@ atouts:
         ref: entry:assassinat
   - id: astre-regenerateur
     name: Astre régénérateur
+    status: active
     effect: >-
       Le personnage choisit un astre ainsi qu’un moment de la journée (par exemple le soleil de midi). Quand celui-ci
       regarde son astre au moment choisit, il récupère tous ses points de vitalité et perd toute trace fatigue.
@@ -401,6 +436,7 @@ atouts:
         ref: entry:astre-regenerateur
   - id: atterrissage
     name: Atterrissage
+    status: active
     effect: >-
       Le personnage peut amortir une chute de 1m par niveau sans être aucunement blessé à condition qu’il retombe sur
       ses jambes.
@@ -413,6 +449,7 @@ atouts:
         ref: entry:atterrissage
   - id: attrait-du-gain
     name: Attrait du gain
+    status: active
     effect: Cet atout permet à un personnage d’ignorer un test de volonté lorsque son intérêt financier est en jeu.
     value: 2000
     activation: permanent
@@ -423,6 +460,7 @@ atouts:
         ref: entry:attrait-du-gain
   - id: aube-meurtriere
     name: Aube meurtrière
+    status: active
     effect: Les rayons de soleil brûlent le personnage comme le feraient des flammes.
     value: -5000
     activation: permanent
@@ -433,6 +471,7 @@ atouts:
         ref: entry:aube-meurtriere
   - id: audition
     name: Audition
+    status: active
     effect: >-
       L'audition est représentée en pourcentage, ce qui signifie qu’un homme en bonne forme possède une audition de
       100%. Un personnage ayant 200% d'audition entendra donc deux fois mieux.
@@ -445,6 +484,7 @@ atouts:
         ref: entry:audition
   - id: aura-benefique
     name: Aura bénéfique
+    status: active
     effect: >-
       Le personnage dégage une aura qui empêche tout sort de magie noire d’être incantée sur un rayon d’un mètre par
       niveau, par un magicien d’un niveau inférieur.
@@ -457,6 +497,7 @@ atouts:
         ref: entry:aura-benefique
   - id: aura-magique
     name: Aura magique
+    status: active
     effect: >-
       Le magicien peut manifester son énergie visuellement autour de lui sous la forme et la couleur la plus proche de
       sa magie. Par exemple, des éclairs parcourront le corp d'un élémentaliste de foudre.
@@ -469,6 +510,7 @@ atouts:
         ref: entry:aura-magique
   - id: aura-malefique
     name: Aura maléfique
+    status: active
     effect: >-
       Le personnage dégage une aura qui empêche tout sort de magie blanche d’être incantée sur un rayon d’un mètre par
       niveau, par un magicien d’un niveau inférieur.
@@ -481,6 +523,7 @@ atouts:
         ref: entry:aura-malefique
   - id: auto-soin
     name: Auto-soin
+    status: active
     effect: Soigne les blessures du personnage, par sa propre concentration. La vitalité ainsi récupérée est égale au niveau.
     value: 2000
     activation: ephemere
@@ -491,6 +534,7 @@ atouts:
         ref: entry:auto-soin
   - id: autocombustion
     name: Autocombustion
+    status: active
     effect: >-
       Le corps du personnage se met subitement à brûler. Ces flammes infligent 1 point de dégâts par point dans cet
       atout par DT au personnage ainsi qu'à tout ceux qui entrent en contact avec lui durant la durée de son
@@ -504,6 +548,7 @@ atouts:
         ref: entry:autocombustion
   - id: autodidacte
     name: Autodidacte
+    status: active
     effect: >-
       Le personnage peut apprendre par lui-même des sorts qu’il a vu et entendu incanter. Le temps d’apprentissage est
       le double du temps normal (moins le jet d’autodidacticité).
@@ -516,6 +561,7 @@ atouts:
         ref: entry:autodidacte
   - id: autoregeneration
     name: Autorégénération
+    status: active
     effect: >-
       Le corps du personnage se régénère de lui-même en permanence. Ses membres perdus repoussent et ses plaies se
       referment à vue d’œil. Tout les 10 DT, le personnage récupère un point de vitalité. Cet atout prend fin à la mort
@@ -529,6 +575,7 @@ atouts:
         ref: entry:autoregeneration
   - id: aveugle
     name: Aveugle
+    status: active
     effect: Le personnage est incapable de voir.
     value: -5000
     activation: permanent
@@ -539,6 +586,7 @@ atouts:
         ref: entry:aveugle
   - id: baiser-de-la-nuit
     name: Baiser de la nuit
+    status: active
     effect: >-
       Le personnage peut faire boire à un humain, un peu de son sang vampirique pour transformer sa proie en goule. La
       quantité de sang nécéssaire à la transformation peut être ingérée en une ou plusieurs fois.
@@ -551,6 +599,7 @@ atouts:
         ref: entry:baiser-de-la-nuit
   - id: baiser-des-tenebres
     name: Baiser des ténèbres
+    status: active
     effect: >-
       Le personnage peut, après avoir vider un humain d’une partie de son sang, lui faire boire de son sang vampirique
       pour transformer sa proie en vampire. Cette opération peut être faîte en une fois ou sur plusieurs nuits.
@@ -563,6 +612,7 @@ atouts:
         ref: entry:baiser-des-tenebres
   - id: baiser-purificateur
     name: Baiser purificateur
+    status: active
     effect: En embrassant la personne qu’il aime, le personnage peut dissiper tous les sorts actifs sur celle-ci.
     value: 10000
     activation: ephemere
@@ -573,6 +623,7 @@ atouts:
         ref: entry:baiser-purificateur
   - id: baiser-salvateur
     name: Baiser salvateur
+    status: active
     effect: >-
       En embrassant la personne qu’il aime, le personnage peut rendre la vie à celle-ci. La mort du personnage ramené ne
       doit pas être plus ancienne qu’une minute par niveau du personnage la ramenant.
@@ -585,6 +636,7 @@ atouts:
         ref: entry:baiser-salvateur
   - id: baiser-vivifiant
     name: Baiser vivifiant
+    status: active
     effect: >-
       Le personnage peux rendre un nombre de point de vitalité égal à son niveau à la personne qu'il aime simplement en
       l'embrassant.
@@ -597,6 +649,7 @@ atouts:
         ref: entry:baiser-vivifiant
   - id: beaute-desarmante
     name: Beauté désarmante
+    status: active
     effect: >-
       Le personnage radie d’une telle beauté que si quelqu’un (qui pourrait être attiré par lui) désire lui nuire,
       celui-ci doit faire un jet de volonté en le voyant avec une difficulté supplémentaire égale à l’esthétique – 5 du
@@ -610,6 +663,7 @@ atouts:
         ref: entry:beaute-desarmante
   - id: bluff
     name: Bluff
+    status: active
     effect: Cet atout diminue la difficulté des jets de mensonge de 1.
     value: 2000
     activation: permanent
@@ -620,6 +674,7 @@ atouts:
         ref: entry:bluff
   - id: bonne-nuit
     name: Bonne nuit
+    status: active
     effect: >-
       Le personnage peut de son regard endormir celui ou ceux (une personne par niveau) qui le croiseront, sous un jet
       de volonté avec comme difficulté supplémentaire le niveau du personnage.
@@ -632,6 +687,7 @@ atouts:
         ref: entry:bonne-nuit
   - id: bouc-emissaire
     name: Bouc émissaire
+    status: active
     effect: >-
       En regardant quelqu’un dans les yeux, le personnage peut manipuler son mental de manière à ce qu’il soit persuadé
       d’avoir commis un crime effectué par le personnage. C’est effet dure 1 jour par niveau.
@@ -644,6 +700,7 @@ atouts:
         ref: entry:bouc-emissaire
   - id: bouclier-des-arcanes
     name: Bouclier des arcanes
+    status: active
     effect: >-
       Le magicien peut à tout moment expulser l’énergie magique de son corps sous la forme d’une bulle protectrice
       prenant la teinte de la magie du lanceur. Ce bouclier se développe en 1 DT et peut être dissipé à n’importe quel
@@ -659,6 +716,7 @@ atouts:
         ref: entry:bouclier-des-arcanes
   - id: boussole-interne
     name: Boussole interne
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un jet d’orientation.
     value: 2000
     activation: permanent
@@ -669,6 +727,7 @@ atouts:
         ref: entry:boussole-interne
   - id: brulure-de-l-argent
     name: Brûlure de l’argent
+    status: active
     effect: >-
       Annule l’autorégénération lorsque le personnage est blessé par de l’argent. Ce type de blessures guérit
       normalement.
@@ -681,6 +740,7 @@ atouts:
         ref: entry:brulure-de-l-argent
   - id: brumathropie
     name: Brumathropie
+    status: active
     effect: >-
       Permet au personnage de se changer en brume. La transformation prend 50 DT. Cette forme brumeuse prend
       grossièrement la forme du personnage et quelqu’un d’attentif pourra le détecter.
@@ -693,6 +753,7 @@ atouts:
         ref: entry:brumathropie
   - id: brume
     name: Brume
+    status: active
     effect: >-
       Le personnage peut embrumer autour de lui dans un rayon étant égal à son niveau. Celui-ci n’a aucune pénalité de
       vision dans sa propre brume.
@@ -705,6 +766,7 @@ atouts:
         ref: entry:brume
   - id: cachette-secrete
     name: Cachette secrète
+    status: active
     effect: >-
       Le personnage peut faire disparaître un objet (n’étant pas plus grand que lui) pendant une minute par niveau.
       Passé ce délai, l’objet tombe à terre des vêtements du personnage. Durant le laps de temps de disparition, l'objet
@@ -718,6 +780,7 @@ atouts:
         ref: entry:cachette-secrete
   - id: caresse-charnelle
     name: Caresse charnelle
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un jet de sexualité.
     value: 2000
     activation: permanent
@@ -728,6 +791,7 @@ atouts:
         ref: entry:caresse-charnelle
   - id: cerebralite
     name: Cérébralité
+    status: active
     effect: >-
       Le personnage peut décider de parler avec un langage cérébral et incompréhensible au commun des mortels en faisant
       maintes métaphores et autres jeux de langage à chacun de ses mots, si bien que seul ceux qui possèdent cet atout
@@ -741,6 +805,7 @@ atouts:
         ref: entry:cerebralite
   - id: chance
     name: Chance
+    status: active
     effect: Le joueur peut refaire (ou faire refaire), un jet directement lié à son personnage.
     value: 2000
     activation: ephemere
@@ -751,6 +816,7 @@ atouts:
         ref: entry:chance
   - id: chant-envoutant
     name: Chant envoûtant
+    status: active
     effect: >-
       Lorsque le personnage se met à chanter, les personnes autour de lui doivent faire un test de volonté pour ne pas
       être séduites (difficulté +1 par niveau du chanteur). Cet état se dissipe lentement après le chant (1 heure par
@@ -764,6 +830,7 @@ atouts:
         ref: entry:chant-envoutant
   - id: charme-tenebreux
     name: Charme ténébreux
+    status: active
     effect: "Le personnage possède de par son côté obscur un charme surnaturel. Les personnes (de races «\_compatibles\_») sont déstabilisées en sa présence et ajoute un malus égal au niveau du personnage à leur jet de volonté lorsque le personnage tente de les séduire."
     value: 4000
     activation: permanent
@@ -774,6 +841,7 @@ atouts:
         ref: entry:charme-tenebreux
   - id: chiropterothropie
     name: Chiroptèrothropie
+    status: active
     effect: >-
       Le personnage possède la capacité de se transformer en chauve-souris. La transformation prend 50 DT (soit 10
       secondes).
@@ -786,6 +854,7 @@ atouts:
         ref: entry:chiropterothropie
   - id: concentration
     name: Concentration
+    status: active
     effect: >-
       Le personnage peut décider de retarder son attaque, diminuant ainsi la difficulté de son jet pour toucher de 1
       pour chaque DT supplémentaire accordé.
@@ -798,6 +867,7 @@ atouts:
         ref: entry:concentration
   - id: conceptualisation
     name: Conceptualisation
+    status: active
     effect: >-
       Le personnage peut inventer de nouveaux sorts propre à sa magie. Le temps nécessaire à la création d’un nouveau
       sort est de 100 jours pour un sort de base moins le jet de conceptualisation. Ce nombre peut varier en fonction du
@@ -811,6 +881,7 @@ atouts:
         ref: entry:conceptualisation
   - id: conceptualisation-etendue
     name: Conceptualisation étendue
+    status: active
     effect: >-
       Le personnage peut inventer de nouveau sort de n’importe quel type de magie. Le temps nécessaire à la création
       d’un nouveau sort est de 100 jours pour un sort de basse (moins le jet de conceptualisation) (ce nombre varie en
@@ -824,6 +895,7 @@ atouts:
         ref: entry:conceptualisation-etendue
   - id: condition
     name: Condition
+    status: active
     effect: >-
       L'objet conçu avec une condition n'actionnera son effet magique que lorsque la condition imposée par celui qui l'a
       crée est remplie (par exemple une épée qui brille seulement en présence des orcs).
@@ -836,6 +908,7 @@ atouts:
         ref: entry:condition
   - id: connaissance-de-l-ennemi
     name: Connaissance de l’ennemi
+    status: active
     effect: "Le personnage n’oublie pas les ennemis qu’il a combattus et apprend de fois en fois un peu plus sur leurs techniques de combat respectives. Le personnage gagne un bonus de 1 sur les jets de dès qui entre en opposition avec ceux de son adversaire, pour chaque combat qu’il a déjà mené avec celui-ci. Ces points des bonus sont limités au score de connaissance de l’ennemi du personnage. Par exemple un personnage avec un score de 3 en connaissance de l’ennemi, qui a déjà combattu deux fois le même adversaire aura à présent une difficulté baissée de 2 lorsqu’il combattra à nouveau contre lui. Puis, cette difficulté sera baissée de 3 et ne montera pas plus haut tant que le niveau du personnage en «\_Connaissance de l’ennemi\_» ne dépasse pas 3."
     value: 5000
     activation: permanent
@@ -846,6 +919,7 @@ atouts:
         ref: entry:connaissance-de-l-ennemi
   - id: connaisseur
     name: Connaisseur
+    status: active
     effect: >-
       En goûtant, sentant, etc, le personnage est capable de citer les ingrédients d’une potion ou autre mixture. Il ne
       peut cependant déterminer que des ingrédients qu’il connaît et ne bénéficie pas d'information quant aux quantités.
@@ -858,6 +932,7 @@ atouts:
         ref: entry:connaisseur
   - id: contagion
     name: Contagion
+    status: active
     effect: >-
       Le personnage est contagieux de par ses morsures ou éventuellement griffure. La maladie transmise est au choix du
       joueur ou maître de jeu. Pour ne pas tomber malade, la cible diot faire un jet d'endurance avec pour difficilté
@@ -871,6 +946,7 @@ atouts:
         ref: entry:contagion
   - id: cordon-bleu
     name: Cordon-bleu
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage cuisine.
     value: 2000
     activation: permanent
@@ -881,6 +957,7 @@ atouts:
         ref: entry:cordon-bleu
   - id: corne-aux-mains
     name: Corne aux mains
+    status: active
     effect: Le personnage bénéficie d’une protection supplémentaire de 1 en P, E, C et T sur l'intérieure de ses mains.
     value: 3000
     activation: permanent
@@ -891,6 +968,7 @@ atouts:
         ref: entry:corne-aux-mains
   - id: coup-de-crayon
     name: Coup de crayon
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage dessine.
     value: 2000
     activation: permanent
@@ -901,6 +979,7 @@ atouts:
         ref: entry:coup-de-crayon
   - id: coup-de-pinceau
     name: Coup de pinceau
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage peint.
     value: 2000
     activation: permanent
@@ -911,6 +990,7 @@ atouts:
         ref: entry:coup-de-pinceau
   - id: coup-decisif
     name: Coup décisif
+    status: active
     effect: Additionne le niveau au nombre de dés pour toucher, lorsque le personnage utilise son arme de prédilection.
     value: 2000
     activation: permanent
@@ -921,6 +1001,7 @@ atouts:
         ref: entry:coup-decisif
   - id: coup-du-bucheron
     name: Coup du bûcheron
+    status: active
     effect: Additionne 1 dégât automatique, lorsque le personnage utilise une cognée.
     value: 2000
     activation: permanent
@@ -931,6 +1012,7 @@ atouts:
         ref: entry:coup-du-bucheron
   - id: coup-mortel
     name: Coup mortel
+    status: active
     effect: >-
       Additionne automatiquement le niveau du personnage, aux dégâts infligés par celui-ci. Un seul coup mortel peut
       être porté à la fois.
@@ -943,6 +1025,7 @@ atouts:
         ref: entry:coup-mortel
   - id: coupe-du-bois
     name: Coupe du bois
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage bûcheronne.
     value: 2000
     activation: permanent
@@ -953,6 +1036,7 @@ atouts:
         ref: entry:coupe-du-bois
   - id: coups-vicieux
     name: Coups vicieux
+    status: active
     effect: Le personnage peut déduire son niveau à l’endurance de sa cible pour 1 action.
     value: 2000
     activation: ephemere
@@ -963,6 +1047,7 @@ atouts:
         ref: entry:coups-vicieux
   - id: cours-toujours
     name: Cours toujours
+    status: active
     effect: Lorsque le personnage prend la fuite, il additionne automatiquement son niveau à son nombre de réussites.
     value: 4000
     activation: permanent
@@ -973,6 +1058,7 @@ atouts:
         ref: entry:cours-toujours
   - id: court-repit
     name: Court répit
+    status: active
     effect: Le personnage réduit son temps de sommeil nécéssaire de 2 heures.
     value: 2000
     activation: permanent
@@ -983,6 +1069,7 @@ atouts:
         ref: entry:court-repit
   - id: crane-dur
     name: Crâne dur
+    status: active
     effect: Les dégâts infligés dans la tête ne sont pas doublés.
     value: 3000
     activation: permanent
@@ -993,6 +1080,7 @@ atouts:
         ref: entry:crane-dur
   - id: cri-du-condamne
     name: Cri du condamné
+    status: active
     effect: >-
       Lorsque le personnage frappe sa cible et que celle-ci émet un son de souffrance, les personnages à proximité
       pouvant entendre ce son, doivent effectuer un test de volonté (difficulté + les dégâts qui ont été infligés) pour
@@ -1006,6 +1094,7 @@ atouts:
         ref: entry:cri-du-condamne
   - id: cris-de-guerre
     name: Cris de guerre
+    status: active
     effect: >-
       Le personnage pousse un tel cri de guerre que ses compagnons (capable de l’entendre) se sentent galvanisés par
       celui-ci et obtiennent 1 dès supplémentaire pour tous leurs jets guerriers du combat en court.
@@ -1018,6 +1107,7 @@ atouts:
         ref: entry:cris-de-guerre
   - id: culture-generale
     name: Culture générale
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un jet de connaissance.
     value: 2000
     activation: permanent
@@ -1028,6 +1118,7 @@ atouts:
         ref: entry:culture-generale
   - id: debordement-d-energie
     name: Débordement d’énergie
+    status: active
     effect: >-
       Cet atout permet au magicien de dépasser son propre quota d’énergie à l’aide de moyen auxiliaire tel que des
       potions d’énergie, des drains d’énergie, etc.
@@ -1040,6 +1131,7 @@ atouts:
         ref: entry:debordement-d-energie
   - id: defense
     name: Défense
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un combat défensif avec l’arme de prédilection.
     value: 2000
     activation: permanent
@@ -1050,6 +1142,7 @@ atouts:
         ref: entry:defense
   - id: dent-contre
     name: Dent contre
+    status: active
     effect: >-
       Cet atout est à choisir avec une race ou une classe. Il diminue la difficulté de 1, de tout jet pouvant nuire à la
       une cible appartenant au groupe choisi.
@@ -1062,6 +1155,7 @@ atouts:
         ref: entry:dent-contre
   - id: dents-de-sabres
     name: Dents de sabres
+    status: active
     effect: >-
       Le personnage possède des crocs plus acérées et une mâchoire plus puissante. Une morsure de sa part fera un dégât
       supplémentaire par point dans cet atout.
@@ -1074,6 +1168,7 @@ atouts:
         ref: entry:dents-de-sabres
   - id: depassement-de-soi
     name: Dépassement de soi
+    status: active
     effect: Le coût d’un point supplémentaire dans une aptitude, au delà de la limite physique est de NA x 15.
     value: 900
     activation: permanent
@@ -1084,6 +1179,7 @@ atouts:
         ref: entry:depassement-de-soi
   - id: deplacement-somnambule
     name: Déplacement somnambule
+    status: active
     effect: >-
       Le personnage peut continuer d'avancer tout en dormant. Un déplacement somnambule peu impliquer des notions fort
       simples tel que suivre quelque chose ou se diriger droit dans dans une direction donnée. Les opérations plus
@@ -1097,6 +1193,7 @@ atouts:
         ref: entry:deplacement-somnambule
   - id: desactivation
     name: Désactivation
+    status: active
     effect: Permet au magicien de désactiver à tout moment l'un de ces propre sort actif.
     value: 2000
     activation: permanent
@@ -1107,6 +1204,7 @@ atouts:
         ref: entry:desactivation
   - id: desamorcage-des-pieges-magiques
     name: Désamorçage des pièges magiques
+    status: active
     effect: Le personnage peut désamorcer des pièges tendus magiquement en faisant un jet de désamorçage traditionnel.
     value: 3000
     activation: permanent
@@ -1117,6 +1215,7 @@ atouts:
         ref: entry:desamorcage-des-pieges-magiques
   - id: detection-des-coups-portants
     name: Détection des coups portants
+    status: active
     effect: >-
       Le personnage a une telle habitude du combat que son instinct lui indique automatiquement si un coup donné dans sa
       direction en corps à corps le touchera ou non. Le joueur peut donc savoir si son adversaire le touche avant de
@@ -1131,6 +1230,7 @@ atouts:
         ref: entry:detection-des-coups-portants
   - id: detection-des-pieges-magiques
     name: Détection des pièges magiques
+    status: active
     effect: Le personnage peut détecter des pièges tendus magiquement en faisant un jet de détection traditionnel.
     value: 3000
     activation: permanent
@@ -1141,6 +1241,7 @@ atouts:
         ref: entry:detection-des-pieges-magiques
   - id: detection-des-projectiles-portants
     name: Détection des projectiles portants
+    status: active
     effect: >-
       Le personnage à une telle habitude d’être sous les feux balistiques qu’il a développé un instinct lui indiquant si
       le projectile lui est ou non, destiné. Le joueur peut donc savoir si le projectile le touche avant de décider de
@@ -1155,6 +1256,7 @@ atouts:
         ref: entry:detection-des-projectiles-portants
   - id: detection-du-defaut
     name: Détection du défaut
+    status: active
     effect: >-
       Le personnage peut savoir automatiquement le défaut d’un objet (ou son principal point faible) en observant
       celui-ci.
@@ -1167,6 +1269,7 @@ atouts:
         ref: entry:detection-du-defaut
   - id: developpement-avance
     name: Développement avancé
+    status: active
     effect: >-
       Le magicien peut développer et apprendre un sort qu’il possède en sort mineur, majeur, standard, de masse ou de
       distance. Le temps du développement dure le double du temps d’apprentissage du sort sur lequel travaille le
@@ -1180,6 +1283,7 @@ atouts:
         ref: entry:developpement-avance
   - id: developpement-magique
     name: Développement magique
+    status: active
     effect: >-
       Le magicien peut développer et apprendre un sort qu’il possède en sort mineur, majeur ou standard. Le temps du
       développement dure le double du temps d’apprentissage du sort sur lequel travaille le personnage (moins le jet de
@@ -1193,6 +1297,7 @@ atouts:
         ref: entry:developpement-magique
   - id: discretion
     name: Discrétion
+    status: active
     effect: Diminue la difficulté de 5 sur un jet de furtivité.
     value: 500
     activation: ephemere
@@ -1203,6 +1308,7 @@ atouts:
         ref: entry:discretion
   - id: disparition
     name: Disparition
+    status: active
     effect: >-
       Le personnage peut se cacher quelque part, non loin de l’endroit où il utilise cet atout. Cette action se fait en
       une fraction de seconde (1DT), cependant, personne ne doit le regarder s’il veut pouvoir disparaître.
@@ -1215,6 +1321,7 @@ atouts:
         ref: entry:disparition
   - id: dissimulation
     name: Dissimulation
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un jet basé sur le camouflage.
     value: 2000
     activation: permanent
@@ -1225,6 +1332,7 @@ atouts:
         ref: entry:dissimulation
   - id: doigts-de-fee
     name: Doigts de fée
+    status: active
     effect: Diminue la difficulté d’un jet basé sur le doigté de 1 par point dans l’atout.
     value: 4000
     activation: permanent
@@ -1235,6 +1343,7 @@ atouts:
         ref: entry:doigts-de-fee
   - id: domination-post-mortem
     name: Domination post-mortem
+    status: active
     effect: Le personnage ajoute 5 à la catégorie maximal de créature qu’il peut relever lors d’un appel des morts.
     value: 1
     activation: permanent
@@ -1245,6 +1354,7 @@ atouts:
         ref: entry:domination-post-mortem
   - id: don-pour-les-langues
     name: Don pour les langues
+    status: active
     effect: >-
       Le personnage divise ses jours d’apprentissage par son niveau, lors de l’apprentissage d’une langue (arrondi au
       supérieur).
@@ -1257,6 +1367,7 @@ atouts:
         ref: entry:don-pour-les-langues
   - id: douleur-aigue
     name: Douleur aigüe
+    status: active
     effect: >-
       Les blessures infligées par le personnage ne font pas plus de dégât, mais provoque le double de la douleur
       normale. Cet atout dure une minute par niveau.
@@ -1269,6 +1380,7 @@ atouts:
         ref: entry:douleur-aigue
   - id: droit-unique-de-revocation
     name: Droit unique de révocation
+    status: active
     effect: >-
       Le magicien est le seul à pouvoir révoquer une invocation qu’il a lui-même faite. Si celui-ci devait mourir,
       aucune révocation ne serait plus possible pour les objets ou créatures transporter par le magicien.
@@ -1281,6 +1393,7 @@ atouts:
         ref: entry:droit-unique-de-revocation
   - id: duel
     name: Duel
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un duel.
     value: 2000
     activation: permanent
@@ -1291,6 +1404,7 @@ atouts:
         ref: entry:duel
   - id: dulcinee
     name: Dulcinée
+    status: active
     effect: >-
       Cet atout est à choisir avec la dame des pensées du personnage. Lorsque celui-ci combat sous le regard de sa
       dulcinée, son niveau lui est accordé en dès supplémentaire pour toutes ses actions. Cet atout se lit au féminin
@@ -1304,6 +1418,7 @@ atouts:
         ref: entry:dulcinee
   - id: eau-benite
     name: Eau bénite
+    status: active
     effect: L’eau bénite par le personnage inflige 1 point de dégât (endurable) aux adorateurs opposés à sa foi.
     value: 2000
     activation: permanent
@@ -1314,6 +1429,7 @@ atouts:
         ref: entry:eau-benite
   - id: echappee-belle
     name: Echappée belle
+    status: active
     effect: >-
       Le personnage peut déduire son niveau au nombre de réussites obtenues par un autre personnage, lorsque ce dernier
       entreprend une action contre lui.
@@ -1326,6 +1442,7 @@ atouts:
         ref: entry:echappee-belle
   - id: effet-apeurant
     name: Effet apeurant
+    status: active
     effect: >-
       Le personnage a la capacité de  créer des œuvres ou objets étrangement malsains. Les personnages désirant s’en
       approcher doivent réussir un test de volonté.
@@ -1338,6 +1455,7 @@ atouts:
         ref: entry:effet-apeurant
   - id: effet-de-lumiere
     name: Effet de lumière
+    status: active
     effect: >-
       Permet de fabriquer des objets qui brillent plus ou moins en fonction du niveau de l’artisan au moment où il l’a
       conçu (la couleur, sera la plus approprier à l’objet).
@@ -1350,6 +1468,7 @@ atouts:
         ref: entry:effet-de-lumiere
   - id: effet-sonore
     name: Effet sonore
+    status: active
     effect: >-
       Permet de fabriquer des objet qui émettent un bruit plus ou moins fort en fonction du niveau de l’artisan, au
       moment ou il l’a conçu (le son, sera le plus approprier à l’objet).
@@ -1362,6 +1481,7 @@ atouts:
         ref: entry:effet-sonore
   - id: elaboration
     name: Elaboration
+    status: active
     effect: >-
       Permet d’élaborer une arme faisant 1 dégât supplémentaire à une race choisie. Celle-ci est sélectionnée par
       l’artisan lorsqu’il crée l’arme.
@@ -1374,6 +1494,7 @@ atouts:
         ref: entry:elaboration
   - id: elementaliste-de-l-element
     name: Elémentaliste de l’élément
+    status: active
     effect: >-
       L’élémentaliste possède un tel degré d’affinité avec l’élément dont il est enfant que tous les sorts de cet
       élément voient leur difficulté baisser de 1. Par exemple, un élémentaliste de feu lancera avec un bonus de 1 les
@@ -1387,6 +1508,7 @@ atouts:
         ref: entry:elementaliste-de-l-element
   - id: elevage
     name: Elevage
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage élève ses animaux de prédilections.
     value: 0
     activation: permanent
@@ -1397,6 +1519,7 @@ atouts:
         ref: entry:elevage
   - id: energie-a-l-honneur
     name: Energie à l’honneur
+    status: active
     effect: >-
       Le personnage teint l’air qui l’entoure, de la couleur de sa magie dans un rayon égal à son niveau en mètre. Dans
       cet environnement les sorts de la magie à l’honneur voient leurs difficultés baissées de 1 pendant 10
@@ -1410,6 +1533,7 @@ atouts:
         ref: entry:energie-a-l-honneur
   - id: energie-au-deshonneur
     name: Energie au déshonneur
+    status: active
     effect: >-
       Une vague jaune d’énergie s’extirpe du personnage en chassant une autre couleur dans un rayon égal au niveau du
       magicien en mètre. Dans cet environnement, tout sort lancé de la magie au déshonneur (choisie par le magicien
@@ -1424,6 +1548,7 @@ atouts:
         ref: entry:energie-au-deshonneur
   - id: energie-latente
     name: Energie latente
+    status: active
     effect: "Chaque fois que le personnage passe le niveau, son niveau en «\_Energie latente\_» multiplié par 3 est ajouté à ses points d'énergie."
     value: 2000
     activation: permanent
@@ -1434,6 +1559,7 @@ atouts:
         ref: entry:energie-latente
   - id: enfant-de-la-nature
     name: Enfant de la nature
+    status: active
     effect: >-
       La nature reconnaît dans le personnage un de ses enfants. Ainsi, les végétaux se tordent pour aider le personnage,
       les racines se retirent devant ses pieds, les branches des arbres le protègent de la pluie et du soleil, etc.
@@ -1446,6 +1572,7 @@ atouts:
         ref: entry:enfant-de-la-nature
   - id: enfant-de-l-element
     name: Enfant de l’élément
+    status: active
     effect: >-
       Cet atout est à choisir avec un élément (eau, feu, terre, pierre, glace, air, etc) Les éléments sont toujours
       matériels (pas d’ombre ou de lumière par exemple). L’élément reconnaît dans le personnage l'un des siens. Ainsi,
@@ -1462,6 +1589,7 @@ atouts:
         ref: entry:enfant-de-l-element
   - id: enseignement-efficace
     name: Enseignement efficace
+    status: active
     effect: >-
       Le personnage additionne automatiquement son niveau au nombre de réussites qu’il effectue lors d’un jet
       d’enseignement.
@@ -1474,6 +1602,7 @@ atouts:
         ref: entry:enseignement-efficace
   - id: epaules-solides
     name: Epaules solides
+    status: active
     effect: Le personnage peut porter 1kg supplémentaire par niveau sans être gêné par le poids.
     value: 2000
     activation: permanent
@@ -1484,6 +1613,7 @@ atouts:
         ref: entry:epaules-solides
   - id: epuration
     name: Epuration
+    status: active
     effect: Le personnage prend 1 dé supplémentaire pour toutes les actions visant à nuire à un sorcier.
     value: 10000
     activation: permanent
@@ -1494,6 +1624,7 @@ atouts:
         ref: entry:epuration
   - id: equilibre-controle
     name: Equilibre contrôlé
+    status: active
     effect: >-
       Le personnage possède un sens inné de l’équilibre et diminue la difficulté de touts les jets basés sur l’équilibre
       de 3.
@@ -1506,6 +1637,7 @@ atouts:
         ref: entry:equilibre-controle
   - id: erreur-de-la-nature
     name: Erreur de la nature
+    status: active
     effect: Diminue la difficulté de 1, de tout jet pouvant nuire à une cible de même race que celle du personnage.
     value: 2000
     activation: permanent
@@ -1516,6 +1648,7 @@ atouts:
         ref: entry:erreur-de-la-nature
   - id: escroquerie
     name: Escroquerie
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’une tentative d'escroquerie.
     value: 2000
     activation: permanent
@@ -1526,6 +1659,7 @@ atouts:
         ref: entry:escroquerie
   - id: espionnage
     name: Espionnage
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un jet d’espionnage.
     value: 2000
     activation: permanent
@@ -1536,6 +1670,7 @@ atouts:
         ref: entry:espionnage
   - id: esprit-logique
     name: Esprit logique
+    status: active
     effect: >-
       Le personnage divise ses jours d’apprentissage par son niveau, dans les sciences mathématique (arrondi au
       supérieur).
@@ -1548,6 +1683,7 @@ atouts:
         ref: entry:esprit-logique
   - id: esprit-mercatique
     name: Esprit mercatique
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un jet de marchandage.
     value: 2000
     activation: permanent
@@ -1558,6 +1694,7 @@ atouts:
         ref: entry:esprit-mercatique
   - id: estimation
     name: Estimation
+    status: active
     effect: >-
       Le personnage peut définir le nombre de réussites effectuées sur une réalisation (objet, concoction, danse, etc)
       dans son domaine de prédilection en utilisant ses sens (vue, odorat, goût, etc).
@@ -1570,6 +1707,7 @@ atouts:
         ref: entry:estimation
   - id: extermination
     name: Extermination
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un combat contre un ou plusieurs monstres.
     value: 2000
     activation: permanent
@@ -1580,6 +1718,7 @@ atouts:
         ref: entry:extermination
   - id: facture-d-arc
     name: Facture d'arc
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage construit un arc.
     value: 2000
     activation: permanent
@@ -1590,6 +1729,7 @@ atouts:
         ref: entry:facture-d-arc
   - id: familier
     name: Familier
+    status: active
     effect: >-
       Le personnage est aidé d’une créature qui peut prendre n’importe quelle forme. Ce suivant magique doit posséder
       une feuille de personnage dans laquelle son possesseurs pourra dépenser son niveau x 100 en points d’expérience
@@ -1614,6 +1754,7 @@ atouts:
         ref: entry:familier
   - id: familier-supplementaire
     name: Familier supplémentaire
+    status: active
     effect: >-
       Le personnage peut avoir un familier supplémentaire. Si le magicien avait placé des atouts en son familier, le
       nouveau hérite également de ceux-ci.
@@ -1626,6 +1767,7 @@ atouts:
         ref: entry:familier-supplementaire
   - id: familier-vigoureux
     name: Familier vigoureux
+    status: active
     effect: Le familier du magicien augmente ses points de vitalités par le niveau de son propriétaire.
     value: 8000
     activation: permanent
@@ -1636,6 +1778,7 @@ atouts:
         ref: entry:familier-vigoureux
   - id: feinte-du-bucheron
     name: Feinte du bûcheron
+    status: active
     effect: >-
       Le personnage peut frapper du dos de sa cognée et occasionné l’intégralité des dégâts de celle-ci sous la forme
       contendante.
@@ -1648,6 +1791,7 @@ atouts:
         ref: entry:feinte-du-bucheron
   - id: fidele-hombre
     name: Fidèle hombre
+    status: active
     effect: >-
       Le personnage peut se servir de son hombre pour effectuer 1 action matérielle (prendre des clefs, donner une
       baffe, etc).
@@ -1660,6 +1804,7 @@ atouts:
         ref: entry:fidele-hombre
   - id: flaire-infaillible
     name: Flaire infaillible
+    status: active
     effect: Le personnage possède un flaire hors norme et diminue la difficulté de tous ses jets basés sur l’odorat de 3.
     value: 500
     activation: permanent
@@ -1670,6 +1815,7 @@ atouts:
         ref: entry:flaire-infaillible
   - id: foi
     name: Foi
+    status: active
     effect: Diminue la difficulté d’un jet de volonté de 5.
     value: 500
     activation: ephemere
@@ -1680,6 +1826,7 @@ atouts:
         ref: entry:foi
   - id: folie-furieuse
     name: Folie furieuse
+    status: active
     effect: >-
       Additionne le niveau au nombre de dés lors d’un jet de force et endurance, lorsque le personnage est fou furieux
       (c’est à lui de décider d’activer ou non cet état) mais il réduit alors l’empathie, l’intelligence et la
@@ -1693,6 +1840,7 @@ atouts:
         ref: entry:folie-furieuse
   - id: force-de-geant
     name: Force de géant
+    status: active
     effect: >-
       Une fois atteint sa limite physique, les points supplémentaires pour la force ne coûtent que NA x 10 (à la place
       de NA x 20).
@@ -1705,6 +1853,7 @@ atouts:
         ref: entry:force-de-geant
   - id: force-de-l-ours
     name: Force de l’ours
+    status: active
     effect: Diminue la difficulté des jets de force de 1.
     value: 3000
     activation: permanent
@@ -1715,6 +1864,7 @@ atouts:
         ref: entry:force-de-l-ours
   - id: force-d-esprit
     name: Force d’esprit
+    status: active
     effect: Permet d'effectuer un test de volonté pour échapper aux effets d’un sort d’illusion.
     value: 3000
     activation: permanent
@@ -1725,6 +1875,7 @@ atouts:
         ref: entry:force-d-esprit
   - id: forteresse-mentale
     name: Forteresse mentale
+    status: active
     effect: "Le personnage possède un lourd passé qu’il a décidé d’enfermer à double tour dans sa mémoire. Lorsqu’un sort ou atout de pénétration mental est lancé sur le personnage (par exemple contrôle mental, vision de rêve, vol de secret, …), celui-ci se fait avec une difficulté supplémentaire égal au niveau du personnage. Si aucun jet n’est demandé (comme pour l’atout «\_Vol de secret\_») un jet d’intelligence de l’intrus se fait avec une difficulté supplémentaire égal au niveau du personnage comme pour les sorts."
     value: 3000
     activation: permanent
@@ -1735,6 +1886,7 @@ atouts:
         ref: entry:forteresse-mentale
   - id: frappe-affaiblissante
     name: Frappe affaiblissante
+    status: active
     effect: >-
       Augmente le facteur de vitesse d’un personnage ou d’une créature blessée par le personnage. L’augmentation est
       égale au nombre de points de dégât infligé. Cet état se prolonge un tour (50 DT) par niveau.
@@ -1747,6 +1899,7 @@ atouts:
         ref: entry:frappe-affaiblissante
   - id: frenesie-collective
     name: Frénésie collective
+    status: active
     effect: >-
       Lors d’un jet de peur, le personnage peut déduire 1 à son facteur de volonté pour chaque personnage de la même
       race que lui l’accompagnant.
@@ -1759,6 +1912,7 @@ atouts:
         ref: entry:frenesie-collective
   - id: fureur-guerriere
     name: Fureur guerrière
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un jet de force, pendant un combat.
     value: 2000
     activation: permanent
@@ -1769,6 +1923,7 @@ atouts:
         ref: entry:fureur-guerriere
   - id: garde-rapprochee
     name: Garde rapprochée
+    status: active
     effect: Additionne le niveau pour toute action visant la sauvegarde de son employeur.
     value: 2000
     activation: permanent
@@ -1779,6 +1934,7 @@ atouts:
         ref: entry:garde-rapprochee
   - id: generalisation
     name: Généralisation
+    status: active
     effect: "Permet au personnage d’utiliser l’atout «\_Répondre à l’insulte\_» non plus sur une personne, mais sur une race (nation pour les humains) ou sur une classe."
     value: 4000
     activation: permanent
@@ -1789,6 +1945,7 @@ atouts:
         ref: entry:generalisation
   - id: grace
     name: Grâce
+    status: active
     effect: >-
       Le personnage peut accorder sa grâce à n'importe qui sauf lui-même. Celui-ci implique une difficulté de +1 pour
       tout jet destiné à nuire au porteur de la grâce. Un même personnage peut scinder ses grâces sur plusieurs personne
@@ -1803,6 +1960,7 @@ atouts:
         ref: entry:grace
   - id: grand-amour
     name: Grand amour
+    status: active
     effect: >-
       Additionne le niveau aux points d’aptitudes physiques du personnage, son niveau, lorsque son grand amour se voit
       menacé directement.
@@ -1815,6 +1973,7 @@ atouts:
         ref: entry:grand-amour
   - id: grele-de-fleches
     name: Grêle de flèches
+    status: active
     effect: >-
       Le personnage peut ajouter une flèche à son tir par point en "Grêle de flèches". S'il possède plusieurs points
       dans cet atout, il pourra diviser ses flèche additionnelles comme bon lui semble (ex: un archer ayant Grêle de
@@ -1829,6 +1988,7 @@ atouts:
         ref: entry:grele-de-fleches
   - id: griffes-acerees
     name: Griffes acérées
+    status: active
     effect: >-
       Le personnage possède des griffes plus acérées et plus dures que la moyenne. Une griffure de sa part fera 1 dégât
       supplémentaire.
@@ -1841,6 +2001,7 @@ atouts:
         ref: entry:griffes-acerees
   - id: guerison
     name: Guérison
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’une intervention médicale.
     value: 2000
     activation: permanent
@@ -1851,6 +2012,7 @@ atouts:
         ref: entry:guerison
   - id: humanothropie
     name: Humanothropie
+    status: active
     effect: Le personnage possède la capacité de se transformer en humain. La transformation prend 50 DT (soit 10 secondes).
     value: 1700
     activation: permanent
@@ -1861,6 +2023,7 @@ atouts:
         ref: entry:humanothropie
   - id: hybridation-du-familier
     name: Hybridation du familier
+    status: active
     effect: >-
       Lors de l'acquisition de cet atout, le magicien doit choisir une partie du corps de son familier (ex. un bras, les
       yeux, la peau, ...). Une fois le familier rappeler dans son magicien, ce dernier pourra modifier sa propre forme
@@ -1878,6 +2041,7 @@ atouts:
         ref: entry:hybridation-du-familier
   - id: hypersensibilite
     name: Hypersensibilité
+    status: active
     effect: Le personnage peut ressentir les émotions d’une autre personne en la touchant.
     value: 3000
     activation: permanent
@@ -1888,6 +2052,7 @@ atouts:
         ref: entry:hypersensibilite
   - id: hypnotisme-artistique
     name: Hypnotisme artistique
+    status: active
     effect: >-
       Le personnage peut hypnotiser (sous jet de volonté) en exerçant son art. Cet effet dure un tour (soit 50 DT) par
       niveau.
@@ -1900,6 +2065,7 @@ atouts:
         ref: entry:hypnotisme-artistique
   - id: immaterialite
     name: Immatérialité
+    status: active
     effect: >-
       Le personnage est absent du monde physique. Ce qui signifie que toute interaction physique avec son environnement
       lui est impossible.
@@ -1912,6 +2078,7 @@ atouts:
         ref: entry:immaterialite
   - id: immobilisme
     name: Immobilisme
+    status: active
     effect: >-
       Le personnage peut se rendre parfaitement immobile sans effectuer aucun jet de dés pendant un temps maximum de 10
       minutes par niveau.
@@ -1924,6 +2091,7 @@ atouts:
         ref: entry:immobilisme
   - id: imparable
     name: Imparable
+    status: active
     effect: >-
       Toutes personnes essayant de parer le personnage, augmente leurs difficultés de 1 et ceci pendant 1 tours (50DT)
       par niveau.
@@ -1936,6 +2104,7 @@ atouts:
         ref: entry:imparable
   - id: incantation-silencieuse
     name: Incantation silencieuse
+    status: active
     effect: >-
       Le personnage à la capacité de réciter ses formules magiques dans sa tête lorsqu’il jette un sort et donc de
       rester silencieux en lançant un sort.
@@ -1948,6 +2117,7 @@ atouts:
         ref: entry:incantation-silencieuse
   - id: incantation-stoique
     name: Incantation stoïque
+    status: active
     effect: Le personnage a la capacité de lancer ses sorts uniquement de par la force de sa parole sans besoin de gestuelle.
     value: 3000
     activation: permanent
@@ -1958,6 +2128,7 @@ atouts:
         ref: entry:incantation-stoique
   - id: indestructible
     name: Indestructible
+    status: active
     effect: >-
       Le personnage peut construire des objets (dans son domaine de prédilection) pratiquement indestructible. Le seul
       moyen de les détruire est de le faire sur le lieux où celui-ci à été construit. Cet atout demande 30 réussites de
@@ -1971,6 +2142,7 @@ atouts:
         ref: entry:indestructible
   - id: inesquivable
     name: Inesquivable
+    status: active
     effect: >-
       Toutes personnes essayant d’esquiver le personnage, augmente leurs difficultés de 1 et ceci pendant 1 tours (50DT)
       par niveau.
@@ -1983,6 +2155,7 @@ atouts:
         ref: entry:inesquivable
   - id: infiltration-arcanique
     name: Infiltration arcanique
+    status: active
     effect: >-
       Le magicien est un tel spécialiste des flux arcaniques utilisés dans la magie qu'il est capable d'injecter un sort
       dans l'énergie drainée par un autre magicien qui lance lui-même un sort. A la fin du TI du sort infecté, les deux
@@ -1997,6 +2170,7 @@ atouts:
         ref: entry:infiltration-arcanique
   - id: inquisition
     name: Inquisition
+    status: active
     effect: Ajoute son niveau en dès lors d'un jet d'investigation religieuse.
     value: 2000
     activation: permanent
@@ -2007,6 +2181,7 @@ atouts:
         ref: entry:inquisition
   - id: inversion-des-energies
     name: Inversion des énergies
+    status: active
     effect: >-
       Le personnage possède un tel niveau de maîtrise en magie qu’il peut inverser sens dans lequel l’énergie le
       traverse lorsqu’il incante un sort. Cette pratique très risquée à but de lancer des sorts sans utiliser d’énergie.
@@ -2021,6 +2196,7 @@ atouts:
         ref: entry:inversion-des-energies
   - id: invisibilite
     name: Invisibilité
+    status: active
     effect: Le personnage peut se rendre invisible. Cet état peut durer jusqu’à 1 minute par niveau.
     value: 5000
     activation: ephemere
@@ -2031,6 +2207,7 @@ atouts:
         ref: entry:invisibilite
   - id: jamais-sans-mon-arme
     name: Jamais sans mon arme
+    status: active
     effect: Le personnage ne lâche jamais son arme sans son consentement (sauf s’il est mort ou inconscient).
     value: 4000
     activation: permanent
@@ -2041,6 +2218,7 @@ atouts:
         ref: entry:jamais-sans-mon-arme
   - id: jusqu-a-la-mort
     name: Jusqu'à la mort
+    status: active
     effect: Le personnage ne mourra que lorsque sa vitalité sera réduite à 0.
     value: 1200
     activation: permanent
@@ -2051,6 +2229,7 @@ atouts:
         ref: entry:jusqu-a-la-mort
   - id: juste-cause
     name: Juste cause
+    status: active
     effect: >-
       Additionne le niveau au nombre de dés lorsque le personnage défend les faibles (directement). Par exemple sauver
       une jeune dame en détresse comptera comme directe, alors que sauver le monde en détruisant un objet magique sera
@@ -2064,6 +2243,7 @@ atouts:
         ref: entry:juste-cause
   - id: langage-aquatique
     name: Langage aquatique
+    status: active
     effect: Cet atout permet au personnage de parfaitement comprendre et d’être compris de toutes les créatures aquatiques.
     value: 2000
     activation: permanent
@@ -2074,6 +2254,7 @@ atouts:
         ref: entry:langage-aquatique
   - id: langage-canin
     name: Langage canin
+    status: active
     effect: Cet atout permet au personnage de parfaitement comprendre et d’être compris de tous les canidés.
     value: 2000
     activation: permanent
@@ -2084,6 +2265,7 @@ atouts:
         ref: entry:langage-canin
   - id: langage-de-la-vermine
     name: Langage de la vermine
+    status: active
     effect: >-
       Cet atout permet au personnage de parfaitement comprendre et d’être compris de tous les insectes, vers et
       arachnides.
@@ -2096,6 +2278,7 @@ atouts:
         ref: entry:langage-de-la-vermine
   - id: langage-felin
     name: Langage félin
+    status: active
     effect: Cet atout permet au personnage de parfaitement comprendre et d’être compris de tous les félins.
     value: 2000
     activation: permanent
@@ -2106,6 +2289,7 @@ atouts:
         ref: entry:langage-felin
   - id: langage-reptilien
     name: Langage reptilien
+    status: active
     effect: Cet atout permet au personnage de parfaitement comprendre et d’être compris de tous les reptiles.
     value: 2000
     activation: permanent
@@ -2116,6 +2300,7 @@ atouts:
         ref: entry:langage-reptilien
   - id: langage-rongeur
     name: Langage rongeur
+    status: active
     effect: Cet atout permet au personnage de parfaitement comprendre et d’être compris de tous les rongeurs.
     value: 2000
     activation: permanent
@@ -2126,6 +2311,7 @@ atouts:
         ref: entry:langage-rongeur
   - id: langue-de-bois
     name: Langue de bois
+    status: active
     effect: >-
       Cet atout renforce la crédibilité du personnage et la fluidité de son discours, lorsque celui-ci tente d’échapper
       à une question. Le questionneur doit faire un jet d’intelligence (difficulté = 7 + niveau du parleur), pour se
@@ -2139,6 +2325,7 @@ atouts:
         ref: entry:langue-de-bois
   - id: leurre
     name: Leurre
+    status: active
     effect: >-
       Le personnage peut changer l’apparence d’un objet en un autre (les objets doivent être de tailles similaires) pour
       une durée de 1 minute par niveau.
@@ -2151,6 +2338,7 @@ atouts:
         ref: entry:leurre
   - id: levee-d-atout
     name: Levée d'atout
+    status: active
     effect: >-
       Cet atout est à prendre en choisissant en autre atout. Le personnage pourra dès lors, quand il le désirera,
       annuler les effets de cet atout choisit pendant la période de temps qu’il lui conviendra.
@@ -2163,6 +2351,7 @@ atouts:
         ref: entry:levee-d-atout
   - id: levitation
     name: Lévitation
+    status: active
     effect: >-
       Le personnage peut élever son corps dans les airs et se déplacer en hauteur grâce à la force de son esprit. La
       vitesse d’un tel déplacement se joue avec un jet d’intelligence. La hauteur maximale que le personnage peut
@@ -2176,6 +2365,7 @@ atouts:
         ref: entry:levitation
   - id: liberation-d-energie
     name: Libération d’énergie
+    status: active
     effect: "Le personnage peut libérer son énergie qui le quitte sous la forme d’une déflagration teintée de sa couleur. Toutes personnes prisent dans celle-ci doivent faire un jet de force pour ne pas être éjectées. La difficulté  du jet de force est de 1 par point d’énergie dépensé. Donc si un magicien dépense 7 point d’énergie, la difficulté du jet sera de 7. La zone de déflagration possède un rayon de 1m/niveau. (Permanent) (Atout de niveau 3 de l’orientation\_: Magicien)\""
     value: 3000
     activation: permanent
@@ -2186,6 +2376,7 @@ atouts:
         ref: entry:liberation-d-energie
   - id: liens-d-amities
     name: Liens d’amitiés
+    status: active
     effect: Le personnage peut défaire un nœud par le simple touché.
     value: 3000
     activation: ephemere
@@ -2196,6 +2387,7 @@ atouts:
         ref: entry:liens-d-amities
   - id: liens-spirituels
     name: Liens spirituels
+    status: active
     effect: >-
       Permet de connaître l’état de santé des créatures liées (invocables) en temps réel. Si une créature souffre,
       l’invocateur sentira que quelque chose ne va pas avec la créature en question.
@@ -2208,6 +2400,7 @@ atouts:
         ref: entry:liens-spirituels
   - id: lingua-vegetalis
     name: Lingua végétalis
+    status: active
     effect: Le personnage peut communiquer avec les végétaux.
     value: 500
     activation: permanent
@@ -2218,6 +2411,7 @@ atouts:
         ref: entry:lingua-vegetalis
   - id: loup-de-mer
     name: Loup de mer
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage dirige un bateau.
     value: 2000
     activation: permanent
@@ -2228,6 +2422,7 @@ atouts:
         ref: entry:loup-de-mer
   - id: lycanthropie
     name: Lycanthropie
+    status: active
     effect: Permet au personnage de se transformer en loup. La transformation prend 50 DT (10 secondes).
     value: 1565
     activation: permanent
@@ -2238,6 +2433,7 @@ atouts:
         ref: entry:lycanthropie
   - id: magie-banche
     name: Magie banche
+    status: active
     effect: Diminue la difficulté de tous les sorts de magie blanche 1.
     value: 2000
     activation: permanent
@@ -2248,6 +2444,7 @@ atouts:
         ref: entry:magie-banche
   - id: magie-bleue
     name: Magie bleue
+    status: active
     effect: Diminue la difficulté de tous les sorts élémentaux de 1.
     value: 2000
     activation: permanent
@@ -2258,6 +2455,7 @@ atouts:
         ref: entry:magie-bleue
   - id: magie-brune
     name: Magie brune
+    status: active
     effect: Diminue la difficulté de tous les sorts divinatoire de 1.
     value: 2000
     activation: permanent
@@ -2268,6 +2466,7 @@ atouts:
         ref: entry:magie-brune
   - id: magie-grise
     name: Magie grise
+    status: active
     effect: Diminue la difficulté de tous les sorts nécromancienne de 1.
     value: 0
     activation: permanent
@@ -2278,6 +2477,7 @@ atouts:
         ref: entry:magie-grise
   - id: magie-jaune
     name: Magie jaune
+    status: active
     effect: Diminue la difficulté de tous les sorts d'abjuration de 1.
     value: 2000
     activation: permanent
@@ -2288,6 +2488,7 @@ atouts:
         ref: entry:magie-jaune
   - id: magie-noire
     name: Magie noire
+    status: active
     effect: Diminue la difficulté de tous les sorts de magie noire de 1.
     value: 0
     activation: permanent
@@ -2298,6 +2499,7 @@ atouts:
         ref: entry:magie-noire
   - id: magie-orange
     name: Magie orange
+    status: active
     effect: Diminue la difficulté de tous les sorts oranges de 1.
     value: 2000
     activation: permanent
@@ -2308,6 +2510,7 @@ atouts:
         ref: entry:magie-orange
   - id: magie-rouge
     name: Magie rouge
+    status: active
     effect: Diminue la difficulté de tous les sorts d'altération de 1.
     value: 2000
     activation: permanent
@@ -2318,6 +2521,7 @@ atouts:
         ref: entry:magie-rouge
   - id: magie-turquoise
     name: Magie turquoise
+    status: active
     effect: Diminue la difficulté de tous les sorts d'enchantement de 1.
     value: 2000
     activation: permanent
@@ -2328,6 +2532,7 @@ atouts:
         ref: entry:magie-turquoise
   - id: magie-verte
     name: Magie verte
+    status: active
     effect: Diminue la difficulté de tous les sorts de magie verte de 1.
     value: 2000
     activation: permanent
@@ -2338,6 +2543,7 @@ atouts:
         ref: entry:magie-verte
   - id: magie-violette
     name: Magie violette
+    status: active
     effect: Diminue la difficulté de tous les sorts d'illusion de 1.
     value: 2000
     activation: permanent
@@ -2348,6 +2554,7 @@ atouts:
         ref: entry:magie-violette
   - id: magnetisme
     name: Magnétisme
+    status: active
     effect: Diminue la difficulté pour plaire, dans le domaine de prédilection, de 5.
     value: 500
     activation: ephemere
@@ -2358,6 +2565,7 @@ atouts:
         ref: entry:magnetisme
   - id: main-du-magicien
     name: Main du magicien
+    status: active
     effect: Permet au magicien de lancer 1 sorts depuis son familier.
     value: 4000
     activation: ephemere
@@ -2368,6 +2576,7 @@ atouts:
         ref: entry:main-du-magicien
   - id: main-verte
     name: Main verte
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage entretien des végétaux.
     value: 2000
     activation: permanent
@@ -2378,6 +2587,7 @@ atouts:
         ref: entry:main-verte
   - id: maitre-du-mensonge
     name: Maître du mensonge
+    status: active
     effect: Le personnage peut ajouter son niveau à son nombre de dès lors d'un jet de mensonge.
     value: 5000
     activation: permanent
@@ -2388,6 +2598,7 @@ atouts:
         ref: entry:maitre-du-mensonge
   - id: maitre-en-choc
     name: Maître en choc
+    status: active
     effect: Le personnage inflige un dégât supplémentaire automatique, lorsque celui-ci inflige des dégâts contondants.
     value: 10000
     activation: permanent
@@ -2398,6 +2609,7 @@ atouts:
         ref: entry:maitre-en-choc
   - id: maitre-en-guerison
     name: Maître en guérison
+    status: active
     effect: Tous les sorts de guérison du personnage voient leur difficulté réduite de 1 par point dans cet atout.
     value: 10000
     activation: permanent
@@ -2408,6 +2620,7 @@ atouts:
         ref: entry:maitre-en-guerison
   - id: maitre-en-lame
     name: Maître en lame
+    status: active
     effect: Le personnage inflige un dégât supplémentaire automatique, lorsque celui-ci inflige des dégâts tranchants.
     value: 10000
     activation: permanent
@@ -2418,6 +2631,7 @@ atouts:
         ref: entry:maitre-en-lame
   - id: maitre-en-perforation
     name: Maître en perforation
+    status: active
     effect: Le personnage inflige 1 dégât supplémentaire automatique, lorsque celui-ci inflige des dégâts perforants.
     value: 10000
     activation: permanent
@@ -2428,6 +2642,7 @@ atouts:
         ref: entry:maitre-en-perforation
   - id: maitre-en-sort-de-masse
     name: Maître en sort de masse
+    status: active
     effect: Tous les sorts de masse du personnage voient leur difficulté réduite de 1.
     value: 11000
     activation: permanent
@@ -2438,6 +2653,7 @@ atouts:
         ref: entry:maitre-en-sort-de-masse
   - id: maitre-en-sort-majeur
     name: Maître en sort majeur
+    status: active
     effect: Tous les sorts majeurs du personnage voient leur difficulté réduite de 1.
     value: 10000
     activation: permanent
@@ -2448,6 +2664,7 @@ atouts:
         ref: entry:maitre-en-sort-majeur
   - id: maitre-en-sort-mineur
     name: Maître en sort mineur
+    status: active
     effect: Tous les sorts mineurs du personnage voient leur difficulté réduite de 1.
     value: 10000
     activation: permanent
@@ -2458,6 +2675,7 @@ atouts:
         ref: entry:maitre-en-sort-mineur
   - id: maitrise-de-la-bete
     name: Maîtrise de la bête
+    status: active
     effect: >-
       Le personnage peut maîtriser ses actions lorsqu’il est transformé en Loup-Garou. Son agressivité reste toutefois
       énorme.
@@ -2470,6 +2688,7 @@ atouts:
         ref: entry:maitrise-de-la-bete
   - id: maitrise-de-la-hache
     name: Maîtrise de la hache
+    status: active
     effect: Diminue la difficulté d’un jet de hache de 1.
     value: 2000
     activation: permanent
@@ -2480,6 +2699,7 @@ atouts:
         ref: entry:maitrise-de-la-hache
   - id: maitrise-de-l-armure
     name: Maîtrise de l’armure
+    status: active
     effect: >-
       Permet d’augmenter les caractéristiques (PECT) d’une armure lors de sa fabrication. Le nombre de points
       supplémentaire à allouer est égal au nombre de point dans cet atout. La disposition des points additionnels peut
@@ -2493,6 +2713,7 @@ atouts:
         ref: entry:maitrise-de-l-armure
   - id: maitrise-de-l-energie
     name: Maîtrise de l’énergie
+    status: active
     effect: "Cet atout modifie l’atout «\_Energie à l’honneur\_» de la manière suivante\_: Le personnage teint l’air qui l’entoure de la couleur de sa magie dans un rayon égal à son niveau en mètre. Cette couleur est nettement plus intense que dans le simple «\_Energie à l’honneur\_». Dans cet environnement les sorts de la couleur maîtrisées voient leurs difficultés baissées de 1 pendant 10 minutes/niveau. Ce bonus ne s’applique pas au magicien qui lui bénéficie d’un bonus égal à son niveau. Maîtriser une énergie prend 10DT non réductible. Cet atout modifie de manière permanente l’\_«\_Energie à l’honneur\_» qui lui reste éphémère, ce qui signifie que passer d’un atout à l’autre n’amène pas de point supplémentaire dans l’atout."
     value: 15000
     activation: ephemere
@@ -2503,6 +2724,7 @@ atouts:
         ref: entry:maitrise-de-l-energie
   - id: maitrise-de-soi
     name: Maîtrise de soi
+    status: active
     effect: >-
       Cet atout permet au personnage de diminuer son nombre de réussites lors d’un jet. Cette diminution est au choix du
       joueur.
@@ -2515,6 +2737,7 @@ atouts:
         ref: entry:maitrise-de-soi
   - id: maitrise-des-fragrances
     name: Maîtrise des fragrances
+    status: active
     effect: Additionne le niveau au nombre de dés lors sur un jet de création de parfum.
     value: 2000
     activation: permanent
@@ -2525,6 +2748,7 @@ atouts:
         ref: entry:maitrise-des-fragrances
   - id: maitrise-equestre
     name: Maîtrise équestre
+    status: active
     effect: Additionne le niveau au nombre de dés pour une manœuvre équestre.
     value: 2000
     activation: permanent
@@ -2535,6 +2759,7 @@ atouts:
         ref: entry:maitrise-equestre
   - id: maitrise-martiale
     name: Maîtrise martiale
+    status: active
     effect: Diminue de 5 la difficulté d’un jet de combat dans le domaine de prédilection.
     value: 500
     activation: ephemere
@@ -2545,6 +2770,7 @@ atouts:
         ref: entry:maitrise-martiale
   - id: martyrisation
     name: Martyrisation
+    status: active
     effect: >-
       Cet atout est à choisir avec une personne. Il additionne le niveau du personnage en dés à tous les jets pouvant
       nuire à la cible choisie. Si la cible vient à mourir ou à disparaître depuis trop longtemps, l’atout peut être
@@ -2558,6 +2784,7 @@ atouts:
         ref: entry:martyrisation
   - id: mecanisme-d-autodefense
     name: Mécanisme d’autodéfense
+    status: active
     effect: >-
       Le personnage a vécut une expérience si traumatisante qu’il génère un mécanisme d’autodéfense lorsque les
       circonstances font que ses mauvais souvenirs resurgissent. Dès lors, le personnage gagne son niveau en dès
@@ -2572,6 +2799,7 @@ atouts:
         ref: entry:mecanisme-d-autodefense
   - id: mefait
     name: Méfait
+    status: active
     effect: Diminue la difficulté de 5 lorsque le personnage nuit à un autre.
     value: 500
     activation: ephemere
@@ -2582,6 +2810,7 @@ atouts:
         ref: entry:mefait
   - id: memoire-photographique
     name: Mémoire photographique
+    status: active
     effect: >-
       Le personnage peut enregistrer parfaitement une scène qu’il a vu. Il peut à tout moment échanger cette image pour
       celle qu’il a devant les yeux. Cet atout peut être cumulé pour augmenter le nombre d’image en mémoire du
@@ -2595,6 +2824,7 @@ atouts:
         ref: entry:memoire-photographique
   - id: mimetisme
     name: Mimétisme
+    status: active
     effect: >-
       La peau du personnage prend la couleur de son environnement. Cet état peut durer autant de temps que désirer. Par
       contre, si l’environnement vient à changer de couleur, la peau elle, ne peut changer de teinte (ou revenir à la
@@ -2608,6 +2838,7 @@ atouts:
         ref: entry:mimetisme
   - id: mobilisation-post-mortem
     name: Mobilisation post-mortem
+    status: active
     effect: "Lorsque le personnage fait un appel des morts, le nombre de revenant peut être au maximum de\_: son niveau X (mobilisation post-mortem + 1). Autrement dit, si un magicien ne possède pas cet atout, il relèvera son niveau au maximum de morts, s’il possède un points en mobilisation post-mortem, il relèvera 2X fois son niveau, puis trois fois s’il reprend à nouveau cet atout, et ainsi de suite."
     value: 2000
     activation: permanent
@@ -2618,6 +2849,7 @@ atouts:
         ref: entry:mobilisation-post-mortem
   - id: modele
     name: Modèle
+    status: active
     effect: >-
       Cet atout est à choisir avec une personne. Le personnage peut dès lors ajouter son niveau en dés pour représenter
       son modèle.
@@ -2630,6 +2862,7 @@ atouts:
         ref: entry:modele
   - id: modulation-de-souvenir
     name: Modulation de souvenir
+    status: active
     effect: >-
       Le personnage peut moduler le souvenir d’une personne en changeant un détail, et ce de manière permanente même si
       on essaye de lui rendre la mémoire.
@@ -2642,6 +2875,7 @@ atouts:
         ref: entry:modulation-de-souvenir
   - id: mon-precieux
     name: Mon précieux
+    status: active
     effect: >-
       Le personnage peut choisir 1 objet (qu’il voit) et saura dès lors en permanence dans quelle direction aller pour
       retrouver celui-ci. Il peut décider de changer d’objet quand il le souhaite.
@@ -2654,6 +2888,7 @@ atouts:
         ref: entry:mon-precieux
   - id: morsure-lupine
     name: Morsure lupine
+    status: active
     effect: Si le personnage mord un autre personnage humain, celui-ci devient un Loup-garou.
     value: 2300
     activation: permanent
@@ -2664,6 +2899,7 @@ atouts:
         ref: entry:morsure-lupine
   - id: mort-dans-le-sillage
     name: Mort dans le sillage
+    status: active
     effect: >-
       Le personnage est si profondément mauvais que sous ses pas l’herbe meurt et ne repousse qu’à grand peine. La
       végétation ne peut repousser qu’après une durée égale au niveau du personnage en année.
@@ -2676,6 +2912,7 @@ atouts:
         ref: entry:mort-dans-le-sillage
   - id: mort-vivant
     name: Mort-vivant
+    status: active
     effect: >-
       En tant que mort, le personnage ne respire plus, son cœur ne bat plus, son teint s’éclaircit et sa peau se
       refroidit.
@@ -2688,6 +2925,7 @@ atouts:
         ref: entry:mort-vivant
   - id: motivation-macabre
     name: Motivation macabre
+    status: active
     effect: "Lors d’un combat, le personnage peut ajouter un dès à chacune de ses actions pour chaque ennemi qu’il aura tué. Le nombre de dès ainsi additionnés ne peut dépasser le score du personnage en «\_Motivation macabre\_»."
     value: 6000
     activation: permanent
@@ -2698,6 +2936,7 @@ atouts:
         ref: entry:motivation-macabre
   - id: muet
     name: Muet
+    status: active
     effect: Le personnage est incapable de parler.
     value: -2500
     activation: permanent
@@ -2708,6 +2947,7 @@ atouts:
         ref: entry:muet
   - id: musique-stimulante
     name: Musique stimulante
+    status: active
     effect: >-
       Lorsque le personnage joue de la musique, il stimule une émotion (choisie de part le style musical) chez les
       personnes l’entendant.
@@ -2720,6 +2960,7 @@ atouts:
         ref: entry:musique-stimulante
   - id: narration-palpitante
     name: Narration palpitante
+    status: active
     effect: Additionne le niveau au nombre de dés pour raconter une histoire.
     value: 2000
     activation: permanent
@@ -2730,6 +2971,7 @@ atouts:
         ref: entry:narration-palpitante
   - id: ne-pour-tuer
     name: Né pour tuer
+    status: active
     effect: >-
       Le personnage apprend de nouvelle technique de combat ou utilisation d’arme, avec une aisance déconcertante. Le
       nombre de jours de son apprentissage sont divisés par son niveau.
@@ -2742,6 +2984,7 @@ atouts:
         ref: entry:ne-pour-tuer
   - id: nuit-blanche
     name: Nuit blanche
+    status: active
     effect: Permet au personnage de ne pas dormir pendant 1 nuit, sans pour autant avoir des malus.
     value: 2000
     activation: ephemere
@@ -2752,6 +2995,7 @@ atouts:
         ref: entry:nuit-blanche
   - id: odeur-du-sang
     name: Odeur du sang
+    status: active
     effect: >-
       Le personnage peut pister à l’instinct un autre personnage ou une créature qu’il aurait blessé au préalable. Cet
       atout possède un rayon d’action de 1 km par niveau. Si la proie récupère de ses plaies ou, si le personnage
@@ -2765,6 +3009,7 @@ atouts:
         ref: entry:odeur-du-sang
   - id: oeil-du-margoulin
     name: Oeil du margoulin
+    status: active
     effect: Le personnage voit naturellement scintiller les objets ayant de la valeur.
     value: 3000
     activation: permanent
@@ -2775,6 +3020,7 @@ atouts:
         ref: entry:oeil-du-margoulin
   - id: orateur-ideal
     name: Orateur idéal
+    status: active
     effect: Ajoute le niveau du personnage à ses dès lors d'un jet de discours.
     value: 5000
     activation: permanent
@@ -2785,6 +3031,7 @@ atouts:
         ref: entry:orateur-ideal
   - id: orfevrerie
     name: Orfèvrerie
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage fait des travaux d’orfèvre.
     value: 2000
     activation: permanent
@@ -2795,6 +3042,7 @@ atouts:
         ref: entry:orfevrerie
   - id: organisme-fragile
     name: Organisme fragile
+    status: active
     effect: L’organisme du personnage est particulièrement sensible aux maladies (deux fois plus).
     value: -500
     activation: permanent
@@ -2805,6 +3053,7 @@ atouts:
         ref: entry:organisme-fragile
   - id: osmose-avec-la-nature
     name: Osmose avec la nature
+    status: active
     effect: >-
       Permet au personnage d’ajouter son niveau en nombre de dés supplémentaires lorsqu’il effectue un jet basé sur son
       affinité avec la nature (comme par exemple dresser un animal).
@@ -2817,6 +3066,7 @@ atouts:
         ref: entry:osmose-avec-la-nature
   - id: osteoderme
     name: Ostéoderme
+    status: active
     effect: >-
       Le personnage est couvert d’écailles lui conférant une armure de 1 dans un type de dégât au choix (P, E, C ou T).
       Cette protection est valable sur l’ensemble du corps à l’exeption du ventre, cou, des yeux, etc.
@@ -2829,6 +3079,7 @@ atouts:
         ref: entry:osteoderme
   - id: outre-l-armure
     name: Outre l’armure
+    status: active
     effect: >-
       Le personnage frappe de telle manière que les armures sont de moindre efficacité face à ses coups. Les armures
       (ceci comprend également les armures naturelles telles que les écailles) sont diminuées de un point dans chaque
@@ -2842,6 +3093,7 @@ atouts:
         ref: entry:outre-l-armure
   - id: ouvrage
     name: Ouvrage
+    status: active
     effect: Diminue de 5 la difficulté pour un ouvrage dans le domaine de prédilection.
     value: 500
     activation: ephemere
@@ -2852,6 +3104,7 @@ atouts:
         ref: entry:ouvrage
   - id: paluche
     name: Paluche
+    status: active
     effect: Les dégâts occasionner par un coup de poing ou une claque font 1 dégât supplémentaire automatique.
     value: 2000
     activation: permanent
@@ -2862,6 +3115,7 @@ atouts:
         ref: entry:paluche
   - id: par-dela-les-forets
     name: Par-delà les forets
+    status: active
     effect: Lorsque le personnage se déplace dans les forets, tous ses jets de déplacement ont une difficulté réduite de 1.
     value: 3000
     activation: permanent
@@ -2872,6 +3126,7 @@ atouts:
         ref: entry:par-dela-les-forets
   - id: par-dela-les-marais
     name: Par-delà les marais
+    status: active
     effect: Lorsque le personnage se déplace dans les marais, tous ses jets de déplacement ont une difficulté réduite de 1.
     value: 3000
     activation: permanent
@@ -2882,6 +3137,7 @@ atouts:
         ref: entry:par-dela-les-marais
   - id: par-dela-les-montagnes
     name: Par-delà les montagnes
+    status: active
     effect: Lorsque le personnage se déplace dans les montagnes, tous ses jets de déplacement ont une difficulté réduite de 1.
     value: 3000
     activation: permanent
@@ -2892,6 +3148,7 @@ atouts:
         ref: entry:par-dela-les-montagnes
   - id: parfum-de-l-ombre
     name: Parfum de l’ombre
+    status: active
     effect: Le personnage ne dégage plus aucune odeur corporelle pendant 10 minutes par niveau.
     value: 4000
     activation: ephemere
@@ -2902,6 +3159,7 @@ atouts:
         ref: entry:parfum-de-l-ombre
   - id: parole-divine
     name: Parole divine
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage prêche la bonne parole.
     value: 2000
     activation: permanent
@@ -2912,6 +3170,7 @@ atouts:
         ref: entry:parole-divine
   - id: partenaire-ideal
     name: Partenaire idéal
+    status: active
     effect: "Lorsque le personnage danse avec quelqu’un, celui-ci peut décider de lui transférer un ou plusieurs dés pris dans sa compétence\_de danse. Cet effet prend fin à la fin de la danse."
     value: 2000
     activation: permanent
@@ -2922,6 +3181,7 @@ atouts:
         ref: entry:partenaire-ideal
   - id: pas-d-araignee
     name: Pas d’araignée
+    status: active
     effect: >-
       Avec de l’élan, le personnage peut courrir contre un mur et faire un nombre de pas égal a son niveau, tout en
       étant jusqu'à perpendiculaire au sol.
@@ -2934,6 +3194,7 @@ atouts:
         ref: entry:pas-d-araignee
   - id: pas-leger
     name: Pas léger
+    status: active
     effect: >-
       Permet au personnage de ne plus faire aucune trace de pas en marchant, et ce, sur n’importe quelle surface. Cet
       effet dure 10 minutes par niveau.
@@ -2946,6 +3207,7 @@ atouts:
         ref: entry:pas-leger
   - id: pasage-celeste
     name: Pasage céleste
+    status: active
     effect: NA
     value: 3000
     activation: permanent
@@ -2956,6 +3218,7 @@ atouts:
         ref: entry:pasage-celeste
   - id: passage-a-l-ombre
     name: Passage à l’ombre
+    status: active
     effect: >-
       Permet au personnage d’entrer intégralement dans sa propre hombre et de se déplacer ainsi ou bon lui semble. C’est
       état peut durer jusqu’à 1 minute par niveau au maximum.
@@ -2968,6 +3231,7 @@ atouts:
         ref: entry:passage-a-l-ombre
   - id: passage-au-familier
     name: Passage au familier
+    status: active
     effect: >-
       Cet atout permet au personnage d’entrer intégralement dans son familier et d’en sortir quand et ou bon lui semble.
       Ce passage prend un facteur de vitesse.
@@ -2980,6 +3244,7 @@ atouts:
         ref: entry:passage-au-familier
   - id: passe-muraille
     name: Passe muraille
+    status: active
     effect: >-
       Le corps du personnage devient immatériel et peut donc passer à travers les murs, les gens et tous ce qui est
       matériel. Cet état peut durer jusqu’à une minute par niveau.
@@ -2992,6 +3257,7 @@ atouts:
         ref: entry:passe-muraille
   - id: paysannerie
     name: Paysannerie
+    status: active
     effect: Diminue la difficulté de 5 lors d’un jet de paysannerie (dans le domaine de prédilection).
     value: 500
     activation: ephemere
@@ -3002,6 +3268,7 @@ atouts:
         ref: entry:paysannerie
   - id: pensee-profonde
     name: Pensée profonde
+    status: active
     effect: Additionne le niveau aux dés lors d’un jet de philosophie.
     value: 2000
     activation: permanent
@@ -3012,6 +3279,7 @@ atouts:
         ref: entry:pensee-profonde
   - id: perception-des-energies
     name: Perception des énergies
+    status: active
     effect: "Le personnage peut à tout moment «\_enclenché\_» sa perception des énergies. La couleur de ses iris peut alors changer. Le magicien percevra alors le monde de façon différente. Cet atout lui donne le don de percevoir l'énergie pure. Le magicien qui en est doté voit des brumes colorées scintillantes teintées de la couleur de la magie en question, un peu comme des aurores boréales. Il pourra estimer les stocks d'énergie dans un lieu, percevoir les fortes concentrations d'une énergie, mais il a aura aussi la capacité de voir les mouvements, les variations d'énergie. Si un sort est lancé, il pourra estimer la quantité d'énergie nécessaire pour le lancer, la localisation du lanceur et la nature de l'énergie utilisée (la couleur)."
     value: 7000
     activation: permanent
@@ -3022,6 +3290,7 @@ atouts:
         ref: entry:perception-des-energies
   - id: perfectionnisme
     name: Perfectionnisme
+    status: active
     effect: >-
       Permet de retravailler un objet déjà crée de manière à y additionner les réussites de qualité du nouveau jet. Un
       personnage peut retravailler autant de fois un objet qu’il possède de points de perfectionnisme.
@@ -3034,6 +3303,7 @@ atouts:
         ref: entry:perfectionnisme
   - id: periple
     name: Périple
+    status: active
     effect: Diminue la difficulté de 5 pour un jet de déplacement (avec le moyen de locomotion de prédilection).
     value: 500
     activation: ephemere
@@ -3044,6 +3314,7 @@ atouts:
         ref: entry:periple
   - id: persecution
     name: Persécution
+    status: active
     effect: >-
       Cet atout est à choisir avec une race, voir une classe. Il additionne 1 dé à tous les jets pouvant nuire à la
       cible choisie.
@@ -3056,6 +3327,7 @@ atouts:
         ref: entry:persecution
   - id: persistance-magique
     name: Persistance magique
+    status: active
     effect: >-
       Le magicien peut, en 1 DT, renouveler un sort actif sans faire d’incantation. Ce qui signifie qu’un sort à 3
       réussites qui durait 10 minutes sera renouvelé dès le moment ou le magicien utilisera son atout, et repartira pour
@@ -3069,6 +3341,7 @@ atouts:
         ref: entry:persistance-magique
   - id: peur
     name: Peur
+    status: active
     effect: >-
       Le personnage provoque la peur chez les autres. Ceux-ci doivent en sa présence faire un test de volonté pour
       maîtriser leur peur. Un personnage possédant cet atout s’y voit automatiquement immunisé.
@@ -3081,6 +3354,7 @@ atouts:
         ref: entry:peur
   - id: peur-du-noir
     name: Peur du noir
+    status: active
     effect: >-
       Le personnage peut lancer une peur du noir sur une personne par niveau. Celles-ci effectuent alors un test de
       volonté pour ne pas être apeurées. Celui qui échouera à ce test se sentira mal à l’aise et essayera (au possible)
@@ -3094,6 +3368,7 @@ atouts:
         ref: entry:peur-du-noir
   - id: pied-marin
     name: Pied marin
+    status: active
     effect: >-
       Avec de l’élan, le personnage peut se déplacer sur de l’eau (ou toute surfaces liquide), d’un nombre de pas égal à
       son niveau.
@@ -3106,6 +3381,7 @@ atouts:
         ref: entry:pied-marin
   - id: pieds-poilus
     name: Pieds poilus
+    status: active
     effect: Diminue de 3 la difficulté d’un jet pour se mouvoir silencieusement.
     value: 500
     activation: permanent
@@ -3116,6 +3392,7 @@ atouts:
         ref: entry:pieds-poilus
   - id: pisteur-ne
     name: Pisteur né
+    status: active
     effect: >-
       Le personnage possède un sens du pistage aiguisé et diminue la difficulté de tous les jets basés sur le pistage de
       3.
@@ -3128,6 +3405,7 @@ atouts:
         ref: entry:pisteur-ne
   - id: place-a-l-ombre
     name: Place à l’ombre
+    status: active
     effect: >-
       Le personnage peut à distance (1m/niveau) éteindre d’un geste de la main une flamme de bougie ou de torche. Cet
       atout est utilisable une fois par niveau.
@@ -3140,6 +3418,7 @@ atouts:
         ref: entry:place-a-l-ombre
   - id: polyvalence
     name: Polyvalence
+    status: active
     effect: "Le personnage peut désormais choisir ses les atouts de niveaux dans toutes les orientations (les classes et les conditions demeurent restrictives) jusqu’à un niveau égal à son nombre de point en «\_Polyvalence\_» + 1. Cet atout compte comme atout à part entière et ne permet de choisir un autre atout lorsqu’on l'acquière. Par exemple, si un guerrier niveau 5 choisit cet atout. Il pourra donc, quand il passera niveau 6, prendre un atout d’artiste niveau 2 (Polyvalence\_: 1 + 1). Il devra reprendre l’atout «\_Polyvalence\_» s’il désire accéder aux atouts de niveau 3 des orientations qui ne sont pas la sienne. Néanmoins, il ne pourra pas choisir l’atout «\_Musique stimulante\_» qui est réservé aux bardes car la polyvalence permet juste d’annuler la barrière des orientations."
     value: 5000
     activation: permanent
@@ -3150,6 +3429,7 @@ atouts:
         ref: entry:polyvalence
   - id: possession
     name: Possession
+    status: active
     effect: >-
       Le personnage peut entrer dans un le corps d’un autre personnage vivant. Celui-ci peut tenter de résister en
       effectuant un jet de volonté avec une difficulté supplémentaire égale au score détenu par le personnage entrant,
@@ -3165,6 +3445,7 @@ atouts:
         ref: entry:possession
   - id: potion-d-energie
     name: Potion d'énergie
+    status: active
     effect: >-
       Le personnage est capable de confectionner des potions de d'énergie arcanique. Les points restaurés sont égaux au
       nombre de réussites du jet d'alchimie (diff. 7).
@@ -3177,6 +3458,7 @@ atouts:
         ref: entry:potion-d-energie
   - id: potion-de-vitalite
     name: Potion de vitalité
+    status: active
     effect: >-
       Le personnage est capable de confectionner des potions de vitalité. Les points restaurés sont égaux au nombre de
       réussites du jet d'alchimie (diff. 9).
@@ -3189,6 +3471,7 @@ atouts:
         ref: entry:potion-de-vitalite
   - id: pour-la-prime
     name: Pour la prime
+    status: active
     effect: >-
       Additionne le niveau au nombre de dés pour permettant d'obtenir une prime directement. Arrêter un voleur pour une
       récompense sera considérer comme directe. Se sauver d'un traquenard pour survire (et arrêter un voleur par la
@@ -3202,6 +3485,7 @@ atouts:
         ref: entry:pour-la-prime
   - id: pouvoir-symbolique
     name: Pouvoir symbolique
+    status: active
     effect: >-
       Lorsque le personnage prend en main un symbole lié à son culte, celui-ci agit sur une distance égale au niveau du
       personnage. Par exemple un crucifix brûlera un vampire en entrant au contact avec sa peau. Mais si le personnage
@@ -3215,6 +3499,7 @@ atouts:
         ref: entry:pouvoir-symbolique
   - id: precision
     name: Précision
+    status: active
     effect: Additionne le niveau aux dés lors d’un jet de tir avec l’arme de prédilection.
     value: 2000
     activation: permanent
@@ -3225,6 +3510,7 @@ atouts:
         ref: entry:precision
   - id: pressentiment-de-la-cible
     name: Pressentiment de la cible
+    status: active
     effect: >-
       Le personnage à une telle habitude d’être la cible d’attaque qu’il en a développé un sens tout particulier de
       défense. Sons instinct lui indiquent infailliblement lorsque qu’un projectile, coup, ou autre forme d’agression en
@@ -3239,6 +3525,7 @@ atouts:
         ref: entry:pressentiment-de-la-cible
   - id: production
     name: Production
+    status: active
     effect: Diminue la difficulté de 5 pour la construction d’un objet.
     value: 500
     activation: ephemere
@@ -3249,6 +3536,7 @@ atouts:
         ref: entry:production
   - id: projections-cauchemardesques
     name: Projections cauchemardesques
+    status: active
     effect: >-
       En touchant un être, le personnage peut lui faire voir (sous la forme d’un flash) tout le mal que le personnage
       serait prêt à lui faire. Ces visions durent 1 DT par niveaux.
@@ -3261,6 +3549,7 @@ atouts:
         ref: entry:projections-cauchemardesques
   - id: protection-divine
     name: Protection divine
+    status: active
     effect: >-
       Dévie automatiquement un coup porté. L’utilisation de cet atout doit être décidé juste avant le jet de force de
       l’adversaire.
@@ -3273,6 +3562,7 @@ atouts:
         ref: entry:protection-divine
   - id: purification-celeste
     name: Purification céleste
+    status: active
     effect: NA
     value: 525
     activation: permanent
@@ -3283,6 +3573,7 @@ atouts:
         ref: entry:purification-celeste
   - id: race-aquatique
     name: Race aquatique
+    status: active
     effect: Le personnage peut respirer normalement sous l’eau. Ses jets de nage se ont une difficulté diminuée de 3.
     value: 1485
     activation: permanent
@@ -3293,6 +3584,7 @@ atouts:
         ref: entry:race-aquatique
   - id: rage
     name: Rage
+    status: active
     effect: >-
       Cet atout permet au personnage d’ignorer tous les malus dus aux coups encaisser, cet état dure un tour (50 DT) par
       niveau.
@@ -3305,6 +3597,7 @@ atouts:
         ref: entry:rage
   - id: rage-lunaire
     name: Rage lunaire
+    status: active
     effect: >-
       Les nuits de pleine lune, le personnage se transforme en Loup-Garou. Il ne contrôle plus ses actions et est pris
       d’une furie meurtrière. Le lendemain, le personnage, revenu sous sa forme de base (humain ou loup), ne se souvient
@@ -3319,6 +3612,7 @@ atouts:
         ref: entry:rage-lunaire
   - id: rancune
     name: Rancune
+    status: active
     effect: >-
       Pendant un combat chaque point de dégât subit est additionné et compte comme dégât automatique lorsque le
       personnage parvient à toucher celui qu’il l’a blessé.
@@ -3331,6 +3625,7 @@ atouts:
         ref: entry:rancune
   - id: rappel-de-l-arme
     name: Rappel de l’arme
+    status: active
     effect: >-
       L’arme revient automatiquement dans les mains de son possesseur au bon vouloir de celui-ci. Ceci compte pour une
       action (et dure donc un facteur de vitesse).
@@ -3343,6 +3638,7 @@ atouts:
         ref: entry:rappel-de-l-arme
   - id: rappel-du-familier
     name: Rappel du familier
+    status: active
     effect: >-
       Permet au magicien de rappeler son/ses familier(s) en lui à tout moment. Celui-ci disparaît pour une période
       choisie par le magicien. Faire entrer ou sortir un familier de soi-même prend un facteur de vitesse.
@@ -3355,6 +3651,7 @@ atouts:
         ref: entry:rappel-du-familier
   - id: recharge-rapide
     name: Recharge rapide
+    status: active
     effect: Diminue de 1  DT le temps nécessaire au chargement d’une arme de distance. Ce temps ne peut être inférieur à 1.
     value: 2000
     activation: permanent
@@ -3365,6 +3662,7 @@ atouts:
         ref: entry:recharge-rapide
   - id: recherche-personnelle
     name: Recherche personnelle
+    status: active
     effect: >-
       Permet au personnage d’apprendre des connaissances par lui-même, si celui-ci à la possibilité de faire ses propres
       expériences.
@@ -3377,6 +3675,7 @@ atouts:
         ref: entry:recherche-personnelle
   - id: reconnaissance-du-guerrier
     name: Reconnaissance du guerrier
+    status: active
     effect: >-
       Lorsque les yeux du personnage croisent ceux d’un autre guerrier, le niveau de celui-ci peut alors lui être
       révélé.
@@ -3389,6 +3688,7 @@ atouts:
         ref: entry:reconnaissance-du-guerrier
   - id: reflexes-fulgurants
     name: Réflexes fulgurants
+    status: active
     effect: >-
       Supprime la difficulté supplémentaire (de +1) lors d’un jet de réflexe. Cet atout peut être choisit à condition de
       posséder un score en réflexes minimum de 4.
@@ -3401,6 +3701,7 @@ atouts:
         ref: entry:reflexes-fulgurants
   - id: reflexion
     name: Réflexion
+    status: active
     effect: Diminue la difficulté d’un d’intelligence de 5.
     value: 500
     activation: ephemere
@@ -3411,6 +3712,7 @@ atouts:
         ref: entry:reflexion
   - id: regard-de-braise
     name: Regard de braise
+    status: active
     effect: Annule les pénalités dues à une luminosité trop intense ou même au soleil dans les yeux.
     value: 3000
     activation: permanent
@@ -3421,6 +3723,7 @@ atouts:
         ref: entry:regard-de-braise
   - id: regard-du-guerrier
     name: Regard du guerrier
+    status: active
     effect: >-
       Le personnage possède un regard de combattant aguerrit et les gens le ressentent, même s’ils ne comprennent pas
       toujours pourquoi. Les personnages peuvent faire un jet de volonté avec le niveau du guerrier comme difficulté
@@ -3434,6 +3737,7 @@ atouts:
         ref: entry:regard-du-guerrier
   - id: regeneration-des-membres
     name: Régénération des membres
+    status: active
     effect: >-
       Le personnage peut régénérer un membre coupé. Le temps de la repousse est de 30 jours moins le niveau du
       personnage.
@@ -3446,6 +3750,7 @@ atouts:
         ref: entry:regeneration-des-membres
   - id: renaissance-celeste
     name: Renaissance céleste
+    status: active
     effect: NA
     value: 6000
     activation: permanent
@@ -3456,6 +3761,7 @@ atouts:
         ref: entry:renaissance-celeste
   - id: repondre-a-l-insulte
     name: Répondre à l’insulte
+    status: active
     effect: >-
       Le personnage peut s’ajouter son niveau en nombre de dés lorsqu’il frappe sur quelqu’un l’aillant insulté. Les dés
       gagnés de la sorte peuvent êtres répartis au gré du joueur dans ses aptitudes physiques. Cet état dure jusqu'à ce
@@ -3469,6 +3775,7 @@ atouts:
         ref: entry:repondre-a-l-insulte
   - id: repos-du-guerrier
     name: Repos du guerrier
+    status: active
     effect: Le personnage récupère le double de points de vitalité lors d’une nuit de sommeil.
     value: 2000
     activation: permanent
@@ -3479,6 +3786,7 @@ atouts:
         ref: entry:repos-du-guerrier
   - id: repulsion
     name: Répulsion
+    status: active
     effect: >-
       Le personnage arrive à canaliser son énergie pour la libérer dans une direction bien précise. Généralement c’est
       de la paume de la main que sors cette force invisible qui repousse les corps. La portée de cette force (comparable
@@ -3494,6 +3802,7 @@ atouts:
         ref: entry:repulsion
   - id: resistance-a-la-chaleur
     name: Résistance à la chaleur
+    status: active
     effect: Le personnage résiste plus aisément à la chaleur. Jet en dessous de la résistance sur D100 pour résister.
     value: 2
     activation: permanent
@@ -3504,6 +3813,7 @@ atouts:
         ref: entry:resistance-a-la-chaleur
   - id: resistance-a-la-fatigue
     name: Résistance à la fatigue
+    status: active
     effect: Le personnage résiste plus aisément à la fatigue. Jet en dessous de la résistance sur D100 pour résister.
     value: 2
     activation: permanent
@@ -3514,6 +3824,7 @@ atouts:
         ref: entry:resistance-a-la-fatigue
   - id: resistance-a-la-fumee
     name: Résistance à la fumée
+    status: active
     effect: Le personnage résiste plus aisément à la fumée. Jet en dessous de la résistance sur D100 pour résister.
     value: 2
     activation: permanent
@@ -3524,6 +3835,7 @@ atouts:
         ref: entry:resistance-a-la-fumee
   - id: resistance-a-la-magie
     name: Résistance à la magie
+    status: active
     effect: Le personnage résiste plus aisément à la magie. Jet en dessous de la résistance sur D100 pour résister.
     value: 2
     activation: permanent
@@ -3534,6 +3846,7 @@ atouts:
         ref: entry:resistance-a-la-magie
   - id: resistance-a-l-alcool
     name: Résistance à l’alcool
+    status: active
     effect: Le personnage résiste plus aisément à l'alcool. Jet en dessous de la résistance sur D100 pour résister.
     value: 2
     activation: permanent
@@ -3544,6 +3857,7 @@ atouts:
         ref: entry:resistance-a-l-alcool
   - id: resistance-au-feu
     name: Résistance au feu
+    status: active
     effect: Le personnage résiste plus aisément au feu. Jet en dessous de la résistance sur D100 pour résister.
     value: 2
     activation: permanent
@@ -3554,6 +3868,7 @@ atouts:
         ref: entry:resistance-au-feu
   - id: resistance-au-froid
     name: Résistance au froid
+    status: active
     effect: Le personnage résiste plus aisément au froid. Jet en dessous de la résistance sur un D100 pour résister.
     value: 2000
     activation: permanent
@@ -3564,6 +3879,7 @@ atouts:
         ref: entry:resistance-au-froid
   - id: resistance-aux-drogues
     name: Résistance aux drogues
+    status: active
     effect: Le personnage résiste plus aisément aux drogues. Jet en dessous de la résistance sur D100 pour résister.
     value: 2
     activation: permanent
@@ -3574,6 +3890,7 @@ atouts:
         ref: entry:resistance-aux-drogues
   - id: resistance-aux-maladies
     name: Résistance aux maladies
+    status: active
     effect: Le personnage résiste plus aisément aux maladies. Jet en dessous de la résistance sur D100 pour résister.
     value: 2
     activation: permanent
@@ -3584,6 +3901,7 @@ atouts:
         ref: entry:resistance-aux-maladies
   - id: resistance-aux-poisons
     name: Résistance aux poisons
+    status: active
     effect: Le personnage résiste plus aisément aux poisons. Jet en dessous de la résistance sur D100 pour résister.
     value: 2
     activation: permanent
@@ -3594,6 +3912,7 @@ atouts:
         ref: entry:resistance-aux-poisons
   - id: resistance-selective
     name: Résistance sélective
+    status: active
     effect: >-
       Cet atout permet au personnage de choisir s'il souhaite ou non utiliser sa résistance. Pour choisir cet atout, le
       personnage doit posséder au minimum une résistance.
@@ -3606,6 +3925,7 @@ atouts:
         ref: entry:resistance-selective
   - id: resonance
     name: Résonance
+    status: active
     effect: >-
       Le magicien peut utiliser son énergie pour entrer en résonance avec l'un de ses sorts et augmenter la puissance de
       celui-ci. Moyennant 10 points d'énergie, le personnage peut, en un facteur de vitesse, ajouter une réussite à l'un
@@ -3620,6 +3940,7 @@ atouts:
         ref: entry:resonance
   - id: resonance-avancee
     name: Résonance avancée
+    status: active
     effect: >-
       En plus de pouvoir utiliser son atout de résonance sur ses propres sorts, le magicien peut l'utiliser sur
       n'importe quel sort de sa couleur magique peu importe le lanceur dudit sort.
@@ -3632,6 +3953,7 @@ atouts:
         ref: entry:resonance-avancee
   - id: ressentir-la-magie
     name: Ressentir la magie
+    status: active
     effect: Permet au personnage de ressentir le rayonnement de la magie sur un rayon d’un mètre par niveau.
     value: 2000
     activation: permanent
@@ -3642,6 +3964,7 @@ atouts:
         ref: entry:ressentir-la-magie
   - id: ressentir-la-trace-du-mal
     name: Ressentir la trace du mal
+    status: active
     effect: >-
       Permet au personnage de ressentir la présence du mal que se soit une personne, un acte ou autre. Plus le mal est
       grand, et plus le personnage le  ressentira fort au fond de lui. De plus, le personnage peut ressentir la trace
@@ -3657,6 +3980,7 @@ atouts:
         ref: entry:ressentir-la-trace-du-mal
   - id: ressentir-le-bien
     name: Ressentir le bien
+    status: active
     effect: >-
       Permet au personnage de ressentir la présence du bien, que se soit une personne, un acte ou autre. Plus le bien
       est grand, et plus le personnage le ressentira fort au fond de lui.
@@ -3669,6 +3993,7 @@ atouts:
         ref: entry:ressentir-le-bien
   - id: ressentir-le-magicien
     name: Ressentir le magicien
+    status: active
     effect: Permet au magicien de ressentir la présence d’autres magiciens sur une distance d’un mètre par niveau.
     value: 3000
     activation: permanent
@@ -3679,6 +4004,7 @@ atouts:
         ref: entry:ressentir-le-magicien
   - id: ressentir-le-mal
     name: Ressentir le mal
+    status: active
     effect: >-
       Permet au personnage de ressentir la présence du mal, que se soit une personne, un acte ou autre. Plus le mal est
       grand, et plus le personnage le  ressentira fort au fond de lui.
@@ -3691,6 +4017,7 @@ atouts:
         ref: entry:ressentir-le-mal
   - id: ressentir-l-arme
     name: Ressentir l’arme
+    status: active
     effect: >-
       Le personnage peut d’instinct ressentir une arme à proximité de lui. Par exemple, si un personnage cache un
       couteau dans sa botte, il ne saura pas qu’il s’agit d’un couteaux, mais son instinct lui soufflera de se méfier de
@@ -3704,6 +4031,7 @@ atouts:
         ref: entry:ressentir-l-arme
   - id: resurrection
     name: Résurrection
+    status: active
     effect: >-
       Le personnage peut ramener un mort à la vie (comme avec le sort de magie blanche). La mort du sujet, ne doit pas
       remonter à plus du niveau en minutes de celui qui le ramène.
@@ -3716,6 +4044,7 @@ atouts:
         ref: entry:resurrection
   - id: retombe-sur-ses-pattes
     name: Retombe sur ses pattes
+    status: active
     effect: Permet de retomber automatiquement sur ses pattes ou pieds.
     value: 350
     activation: permanent
@@ -3726,6 +4055,7 @@ atouts:
         ref: entry:retombe-sur-ses-pattes
   - id: retraite-strategique
     name: Retraite stratégique
+    status: active
     effect: Permet à un personnage de diminuer la difficulté d’un jet de fuite de 1.
     value: 2000
     activation: permanent
@@ -3736,6 +4066,7 @@ atouts:
         ref: entry:retraite-strategique
   - id: rien-a-perdre
     name: Rien à perdre
+    status: active
     effect: >-
       Le personnage déduit automatiquement son niveau aux malus distribuer lors d’un jet de volonté dans une situation
       dangereuse.
@@ -3748,6 +4079,7 @@ atouts:
         ref: entry:rien-a-perdre
   - id: robustesse
     name: Robustesse
+    status: active
     effect: Donne une résistance de +1C au corps du personnage.
     value: 2000
     activation: permanent
@@ -3758,6 +4090,7 @@ atouts:
         ref: entry:robustesse
   - id: ruee
     name: Ruée
+    status: active
     effect: La charge du personnage inflige un dégât supplémentaire par point dans cet atout.
     value: 2000
     activation: permanent
@@ -3768,6 +4101,7 @@ atouts:
         ref: entry:ruee
   - id: sacrifice
     name: Sacrifice
+    status: active
     effect: >-
       Le personnage peut décider de se sacrifier pour ramener quelqu’un à la vie. Ce personnage ne doit pas être mort
       depuis plus que d’heure par niveau du personnage qui se sacrifie.
@@ -3780,6 +4114,7 @@ atouts:
         ref: entry:sacrifice
   - id: sacrifice-d-energie
     name: Sacrifice d’énergie
+    status: active
     effect: >-
       Le magicien peut sacrifier autant de point d’énergie qu’il le souhaite en faisant perdre à un autre magicien (à
       une distance maximum de 1m/niveau) ce même nombre de points d’énergie.
@@ -3792,6 +4127,7 @@ atouts:
         ref: entry:sacrifice-d-energie
   - id: sang-froid
     name: Sang-froid
+    status: active
     effect: Le personnage ne tient compte d'aucun malus d'augmentation de son facteur de volonté.
     value: 550
     activation: permanent
@@ -3802,6 +4138,7 @@ atouts:
         ref: entry:sang-froid
   - id: sans-forme
     name: Sans forme
+    status: active
     effect: >-
       Le personnage peut d’un regard dans les yeux de sa victime effacer sa forme de la mémoire de celle-ci. La cible
       doit faire un test d’intelligence de difficulté égal au niveau du lanceur pour ne pas oublier. Une personne ayant
@@ -3815,6 +4152,7 @@ atouts:
         ref: entry:sans-forme
   - id: sans-hombre
     name: Sans hombre
+    status: active
     effect: Le personnage peut faire disparaître son hombre pendant une minute par niveau.
     value: 3000
     activation: ephemere
@@ -3825,6 +4163,7 @@ atouts:
         ref: entry:sans-hombre
   - id: sans-nom
     name: Sans nom
+    status: active
     effect: >-
       Le personnage peut d’un regard dans les yeux de sa victime effacer son nom de la mémoire de celle-ci. La cible
       doit faire un test d’intelligence de difficulté égal au niveau du lanceur pour ne pas oublier. Une personne ayant
@@ -3838,6 +4177,7 @@ atouts:
         ref: entry:sans-nom
   - id: sans-reflet
     name: Sans reflet
+    status: active
     effect: Le personnage n’a aucun reflet, que ce soit dans l’eau, dans un miroir, ou toute surface réfléchissante.
     value: -200
     activation: permanent
@@ -3848,6 +4188,7 @@ atouts:
         ref: entry:sans-reflet
   - id: sans-visage
     name: Sans visage
+    status: active
     effect: >-
       Le personnage peut d’un regard dans les yeux de sa victime effacer son visage de la mémoire de celle-ci. La cible
       doit faire un test d’intelligence de difficulté égal au niveau du lanceur pour ne pas oublier. Une personne ayant
@@ -3861,6 +4202,7 @@ atouts:
         ref: entry:sans-visage
   - id: sante-de-fer
     name: Santé de fer
+    status: active
     effect: "Chaque fois que le personnage passe un niveau, il ajoute alors son nouveau niveau en «\_Santé de fer\_» à ses points de vitalité."
     value: 2000
     activation: permanent
@@ -3871,6 +4213,7 @@ atouts:
         ref: entry:sante-de-fer
   - id: saut-de-l-ange
     name: Saut de l’ange
+    status: active
     effect: Le personnage peut effectuer un saut d’une hauteur égale à son niveau en mètre.
     value: 3000
     activation: ephemere
@@ -3881,6 +4224,7 @@ atouts:
         ref: entry:saut-de-l-ange
   - id: savoir-la-magie
     name: Savoir la magie
+    status: active
     effect: Permet au magicien d’identifier le type de magie qu’il ressent sur 1 mètre par niveau autour de lui.
     value: 4000
     activation: permanent
@@ -3891,6 +4235,7 @@ atouts:
         ref: entry:savoir-la-magie
   - id: savoir-l-arme
     name: Savoir l’arme
+    status: active
     effect: Permet au personnage d’identifier le type d’arme qu’il ressent sur 1 mètre par niveau autour de lui.
     value: 4000
     activation: permanent
@@ -3901,6 +4246,7 @@ atouts:
         ref: entry:savoir-l-arme
   - id: science-de-la-vie
     name: Science de la vie
+    status: active
     effect: Additionne le niveau du personnage au nombre de dès lancés lors d’un jet d’alchimie.
     value: 2000
     activation: permanent
@@ -3911,6 +4257,7 @@ atouts:
         ref: entry:science-de-la-vie
   - id: science-des-plantes
     name: Science des plantes
+    status: active
     effect: Additionne le niveau du personnage au nombre de dès lancés lors d’un jet d’herboristerie.
     value: 0
     activation: permanent
@@ -3921,6 +4268,7 @@ atouts:
         ref: entry:science-des-plantes
   - id: secret-des-poignards-volants
     name: Secret des poignards volants
+    status: active
     effect: Le personnage peut faire effectuer une courbe par niveau à un couteau de jet qu’il a lui-même lancé.
     value: 2000
     activation: ephemere
@@ -3931,6 +4279,7 @@ atouts:
         ref: entry:secret-des-poignards-volants
   - id: self-controle
     name: Self-contrôle
+    status: active
     effect: >-
       Le personnage possède la totale maîtrise de ses propres faits et gestes. Lors d’un jet, il peut définir un nombre
       de réussites maximum qu’il ne dépassera pas.
@@ -3943,6 +4292,7 @@ atouts:
         ref: entry:self-controle
   - id: sens-de-la-scene
     name: Sens de la scène
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un jet de comédie.
     value: 2000
     activation: permanent
@@ -3953,6 +4303,7 @@ atouts:
         ref: entry:sens-de-la-scene
   - id: sens-des-affaires
     name: Sens des affaires
+    status: active
     effect: Diminue la difficulté de 5 lors d’un jet de commerce.
     value: 500
     activation: ephemere
@@ -3963,6 +4314,7 @@ atouts:
         ref: entry:sens-des-affaires
   - id: sens-du-danger
     name: Sens du danger
+    status: active
     effect: >-
       Le personnage a l’habitude du danger dans son quotidien. Tant et si bien qu’il arrive à le flairer. Il ajoute donc
       son niveau en dés lors de jets de perceptions qui pourraient le prévenir d’un danger.
@@ -3975,6 +4327,7 @@ atouts:
         ref: entry:sens-du-danger
   - id: sens-du-familier
     name: Sens du familier
+    status: active
     effect: >-
       Le personnage peut choisir un sens par lequel il sera lié à son familier. Par exemple s’il choisit la vue, il
       verra tout ce que voie son familier.
@@ -3987,6 +4340,7 @@ atouts:
         ref: entry:sens-du-familier
   - id: sens-en-eveil
     name: Sens en éveil
+    status: active
     effect: Ajoute le niveau du personnage à ses dès lors d'un jet de perception.
     value: 5000
     activation: permanent
@@ -3997,6 +4351,7 @@ atouts:
         ref: entry:sens-en-eveil
   - id: sens-politique
     name: Sens politique
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un jet de politique.
     value: 2000
     activation: permanent
@@ -4007,6 +4362,7 @@ atouts:
         ref: entry:sens-politique
   - id: sentir-la-mort
     name: Sentir la mort
+    status: active
     effect: "Le personnage à développé la capacité de sentir l’odeur de la mort. Il détecte donc automatiquement la présence de cadavre ainsi que les Mort-Vivants sur un rayon de 3 mètres par niveaux. Il est aussi capable d’indiquer la direction d’où lui viens cette «\_odeur\_»."
     value: 4000
     activation: permanent
@@ -4017,6 +4373,7 @@ atouts:
         ref: entry:sentir-la-mort
   - id: sequelles
     name: Séquelles
+    status: active
     effect: Les coups portés par le personnage ne peuvent êtres soignés par l'atout "Régénération".
     value: 4000
     activation: permanent
@@ -4027,6 +4384,7 @@ atouts:
         ref: entry:sequelles
   - id: serrer-les-dents
     name: Serrer les dents
+    status: active
     effect: >-
       Le personnage peut, une fois par niveau, annuler un jet de force lors d’une frappe qu’il reçoit, ne subissant
       ainsi que les dégâts automatiques.
@@ -4039,6 +4397,7 @@ atouts:
         ref: entry:serrer-les-dents
   - id: service
     name: Service
+    status: active
     effect: Diminue la difficulté de 5 pour un jet de tâches domestiques (dans le domaine de prédilection).
     value: 500
     activation: ephemere
@@ -4049,6 +4408,7 @@ atouts:
         ref: entry:service
   - id: servitude
     name: Servitude
+    status: active
     effect: >-
       Additionne le niveau au nombre de dés lorsque le personnage sert son maître. La tâche que le personnage effectue
       doit être en rapport avec sa condition de domestique.
@@ -4061,6 +4421,7 @@ atouts:
         ref: entry:servitude
   - id: seul-contre-tous
     name: Seul contre tous
+    status: active
     effect: Le personnage additionne à ses jets de dés, un dé supplémentaire par ennemi qu’il combat en plus du premier.
     value: 5000
     activation: permanent
@@ -4071,6 +4432,7 @@ atouts:
         ref: entry:seul-contre-tous
   - id: silence-de-mort
     name: Silence de mort
+    status: active
     effect: >-
       Le personnage crée un silence anormal d’ou aucun son ne pourra s’échapper. Celui-ci s’étend sur un rayon d’un
       mètre par niveau autour du personnage et dure une minute par niveau. Cet espace insonorisé ne se déplace pas avec
@@ -4084,6 +4446,7 @@ atouts:
         ref: entry:silence-de-mort
   - id: soif-de-sang
     name: Soif de sang
+    status: active
     effect: Le personnage ne peut se nourrir que de sang.
     value: -1000
     activation: permanent
@@ -4094,6 +4457,7 @@ atouts:
         ref: entry:soif-de-sang
   - id: soleil-petrificateur
     name: Soleil pétrificateur
+    status: active
     effect: >-
       Les rayons du soleil change le personnage en pierre. Un personnage ainsi statufié ne reviens pas à son état normal
       une fois la nuit venue.
@@ -4106,6 +4470,7 @@ atouts:
         ref: entry:soleil-petrificateur
   - id: sommeil-leger
     name: Sommeil léger
+    status: active
     effect: Annule les malus dus au sommeil d’un personnage, pour les jets de perception.
     value: 2000
     activation: permanent
@@ -4116,6 +4481,7 @@ atouts:
         ref: entry:sommeil-leger
   - id: son-envoutant
     name: Son envoûtant
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage joue de son instrument de prédilection.
     value: 2000
     activation: permanent
@@ -4126,6 +4492,7 @@ atouts:
         ref: entry:son-envoutant
   - id: sonar
     name: Sonar
+    status: active
     effect: >-
       Le personnage est doté d'un sonar lui permettant de se repérer dans l'espace par retour d'ultrasons qu'il émet.
       Ses jets de reconnaissance lié à son environnement passent par l'ouïe lorsqu'il utilise cet atout.
@@ -4138,6 +4505,7 @@ atouts:
         ref: entry:sonar
   - id: sourd
     name: Sourd
+    status: active
     effect: Le personnage est incapable d'entendre.
     value: -2500
     activation: permanent
@@ -4148,6 +4516,7 @@ atouts:
         ref: entry:sourd
   - id: souvenir-de-la-bete
     name: Souvenir de la bête
+    status: active
     effect: >-
       Le personnage arrive à se souvenir de se qu’il a fait les soirs de pleine lune lorsqu’il était changé en
       Loup-Garou.
@@ -4160,6 +4529,7 @@ atouts:
         ref: entry:souvenir-de-la-bete
   - id: sublimation
     name: Sublimation
+    status: active
     effect: >-
       Les objet créés par le personnage (dans son domaine de prédilection) octroient un bonus de +1 en esthétisme à son
       porteur par points en Sublimation. Un objet offrant un bonus de X doit avoir un minimum de X * 5 réussites lors de
@@ -4174,6 +4544,7 @@ atouts:
         ref: entry:sublimation
   - id: subtilisation
     name: Subtilisation
+    status: active
     effect: Additionne son niveau au nombre de dès lorsque le personnage effectue un vol.
     value: 2000
     activation: permanent
@@ -4184,6 +4555,7 @@ atouts:
         ref: entry:subtilisation
   - id: survie
     name: Survie
+    status: active
     effect: Le personnage n’accumule des malus de blessure qu’à partir du quart (et non de la moitié) de sa vitalité.
     value: 3000
     activation: permanent
@@ -4194,6 +4566,7 @@ atouts:
         ref: entry:survie
   - id: sus-aux-magiciens
     name: Sus aux magiciens
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage nui à un magicien.
     value: 2000
     activation: permanent
@@ -4204,6 +4577,7 @@ atouts:
         ref: entry:sus-aux-magiciens
   - id: telekinesie
     name: Télékinésie
+    status: active
     effect: >-
       Le personnage peut soulever et déplacer de la matière solide dans les airs (les liquides et gazeux ne sont donc
       pas inclus). Pour se faire, le personnage doit s'aider au moins une de ses main et se concentrer sur la cible
@@ -4221,6 +4595,7 @@ atouts:
         ref: entry:telekinesie
   - id: telekinesie-avancee
     name: Télékinésie avancée
+    status: active
     effect: >-
       Le personnage peut maintenant utiliser sa télékinésie sans forcément devoir utiliser ses mains. Il peut également
       déplacer la matière quelle qu’elle soit (solide, liquide, gazeux, etc) ce qui signifie que l'atout permet
@@ -4235,6 +4610,7 @@ atouts:
         ref: entry:telekinesie-avancee
   - id: telekinesie-lourde
     name: Télékinésie lourde
+    status: active
     effect: >-
       Le poids maximal déplacé par le personnage grace à sa télékinésie est maintenant égale à son niveau en
       "Télékinésie lourde" + 1 kg/niveaux.
@@ -4247,6 +4623,7 @@ atouts:
         ref: entry:telekinesie-lourde
   - id: telepathie
     name: Télépathie
+    status: active
     effect: Le personnage peut entrer en contact avec une personne de par la pensée, il doit pour cela voir cette personne.
     value: 600
     activation: permanent
@@ -4257,6 +4634,7 @@ atouts:
         ref: entry:telepathie
   - id: teleportation
     name: Téléportation
+    status: active
     effect: Le personnage peut se téléporter dans un lieu à portée de vue et à 1m de distance par niveau maximum.
     value: 6000
     activation: ephemere
@@ -4267,6 +4645,7 @@ atouts:
         ref: entry:teleportation
   - id: temps-d-arret
     name: Temps d’arrêt
+    status: active
     effect: >-
       Le personnage peut se stopper net ou et quand bon lui semble pendant 1 DT/niveau. Pendant se temps il peut
       entreprendre des action (comme par exemple se rattraper lors d’une chute qu’il peut stopper).
@@ -4279,6 +4658,7 @@ atouts:
         ref: entry:temps-d-arret
   - id: tenacite
     name: Ténacité
+    status: active
     effect: Donne une résistance de +1E au corps du personnage.
     value: 2000
     activation: permanent
@@ -4289,6 +4669,7 @@ atouts:
         ref: entry:tenacite
   - id: terreur
     name: Terreur
+    status: active
     effect: >-
       Le personnage provoque la terreur chez les autres. Ceux-ci doivent, en sa présence, faire un test de volonté avec
       une difficulté supplémentaire égale au niveau du personnage terrifiant pour maîtriser leur peur. Un personnage
@@ -4302,6 +4683,7 @@ atouts:
         ref: entry:terreur
   - id: tornade-de-coups
     name: Tornade de coups
+    status: active
     effect: Additionne un coup porté par le personnage lorsque celui-ci utilise cet atout (les coups sont tous identiques).
     value: 5000
     activation: ephemere
@@ -4312,6 +4694,7 @@ atouts:
         ref: entry:tornade-de-coups
   - id: totem
     name: Totem
+    status: active
     effect: "Cet atout est à choisir avec une race animale se rapprochant du personnage. Les animaux de cette race reconnaissent le personnage comme l’un des leurs et ne lui feront aucun mal. Au contraire, s’ils ont la possibilité de l’aider, ils le feront dans la mesure de leurs moyens. Cet atout ne peut être choisit qu’une seule fois et ne peut être combiné avec l’atout «\_Enfant de l’élément\_»."
     value: 4000
     activation: permanent
@@ -4322,6 +4705,7 @@ atouts:
         ref: entry:totem
   - id: touche-leger
     name: Touché léger
+    status: active
     effect: Additionne le niveau au nombre de dés pour toucher quelqu’un sans que celui-ci ne le remarque.
     value: 2000
     activation: permanent
@@ -4332,6 +4716,7 @@ atouts:
         ref: entry:touche-leger
   - id: toujours-sur-soi
     name: Toujours sur soi
+    status: active
     effect: >-
       Le personnage peut choisir 1 objet qu’il peut faire disparaître et réapparaître à volonté dans sa main. Le poids
       de cet objet est toujours comptabilisé.
@@ -4344,6 +4729,7 @@ atouts:
         ref: entry:toujours-sur-soi
   - id: tour-de-passe-passe
     name: Tour de passe-passe
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un tour de passe-passe.
     value: 2000
     activation: permanent
@@ -4354,6 +4740,7 @@ atouts:
         ref: entry:tour-de-passe-passe
   - id: tranchant
     name: Tranchant
+    status: active
     effect: >-
       Les armes tranchantes créés par le personnage inflige un dégât de +1 T. Un objet ayant un bonus de X Tranchant
       supplémentaire doit avoir un minimum de X * 5 réussites lors de sa création (ceci représente une qualité
@@ -4367,6 +4754,7 @@ atouts:
         ref: entry:tranchant
   - id: transfert-de-vision
     name: Transfert de vision
+    status: active
     effect: NA
     value: 100
     activation: permanent
@@ -4377,6 +4765,7 @@ atouts:
         ref: entry:transfert-de-vision
   - id: transfert-spatial
     name: Transfert spatial
+    status: active
     effect: >-
       Cet atout est à choisir avec un lieu. Dès lors, le magicien peut, en faisant une invocation standard, décider de
       transférer sa cible dans ce lieu choisit. Le lieu peut être changé par le magicien à tout moment pour autant que
@@ -4390,6 +4779,7 @@ atouts:
         ref: entry:transfert-spatial
   - id: transformation-hybride
     name: Transformation hybride
+    status: active
     effect: >-
       Le personnage peut se transformer en Loup-Garou quand il le désire. Il ne peut toutefois pas décider de ne pas se
       transformer les nuits de pleine lune.
@@ -4402,6 +4792,7 @@ atouts:
         ref: entry:transformation-hybride
   - id: traque
     name: Traque
+    status: active
     effect: Additionne le niveau au nombre de dés, lors d’un jet de pistage ou autre investigation forestière.
     value: 2000
     activation: permanent
@@ -4412,6 +4803,7 @@ atouts:
         ref: entry:traque
   - id: travail-de-la-peau
     name: Travail de la peau
+    status: active
     effect: Additionne le niveau au nombre de dès lorsque le personnage effectue un travail de tannerie.
     value: 2000
     activation: permanent
@@ -4422,6 +4814,7 @@ atouts:
         ref: entry:travail-de-la-peau
   - id: travail-du-bois
     name: Travail du bois
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage fait des travaux de menuiserie.
     value: 2000
     activation: permanent
@@ -4432,6 +4825,7 @@ atouts:
         ref: entry:travail-du-bois
   - id: travail-du-metal
     name: Travail du métal
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage forge.
     value: 2000
     activation: permanent
@@ -4442,6 +4836,7 @@ atouts:
         ref: entry:travail-du-metal
   - id: travail-du-recipient
     name: Travail du récipient
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage fait des travaux de poterie.
     value: 2000
     activation: permanent
@@ -4452,6 +4847,7 @@ atouts:
         ref: entry:travail-du-recipient
   - id: travail-du-textile
     name: Travail du textile
+    status: active
     effect: Additionne le niveau au nombre de dés lors d’un jet de couture.
     value: 2000
     activation: permanent
@@ -4462,6 +4858,7 @@ atouts:
         ref: entry:travail-du-textile
   - id: trompe-la-mort
     name: Trompe la mort
+    status: active
     effect: >-
       Permet au personnage de simuler un mort. La peau se blanchit, le cœur ralentit et n’est presque plus perceptible,
       il en va de même pour la respiration. Cet état peut être conservé 10 minutes par niveau.
@@ -4474,6 +4871,7 @@ atouts:
         ref: entry:trompe-la-mort
   - id: trop-facile
     name: Trop facile
+    status: active
     effect: >-
       Diminue la difficulté d’un sort choisi de 1. Le sort est à définir avec la prise de l'atout et ne peut être
       changer par la suite.
@@ -4486,6 +4884,7 @@ atouts:
         ref: entry:trop-facile
   - id: tuons-la-bete
     name: Tuons la bête
+    status: active
     effect: >-
       Le personnage choisit un monstre sur lequel, il infligera automatiquement son niveau en dégât supplémentaire
       lorsqu’il touchera celui-ci.
@@ -4498,6 +4897,7 @@ atouts:
         ref: entry:tuons-la-bete
   - id: unicite
     name: Unicité
+    status: active
     effect: >-
       Les ouvrages du personnage (dans son domaine) ne peuvent êtres recopiés. Son travail lui est si propre que
       quelqu’un ayant les connaissances suffisantes pourra déterminer la personne qui à fabriquer l’objet en question.
@@ -4510,6 +4910,7 @@ atouts:
         ref: entry:unicite
   - id: vade-retro
     name: Vade rétro
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage effectue un exorcisme.
     value: 2000
     activation: permanent
@@ -4520,6 +4921,7 @@ atouts:
         ref: entry:vade-retro
   - id: vegothropie
     name: Vegothropie
+    status: active
     effect: >-
       Le personnage peut se transformer en plante. La durée de la transformation est de 10 minutes. La plante en
       question est relative au personnage.
@@ -4532,6 +4934,7 @@ atouts:
         ref: entry:vegothropie
   - id: velocite
     name: Vélocité
+    status: active
     effect: Diminue de 3 la difficulté de course.
     value: 600
     activation: permanent
@@ -4542,6 +4945,7 @@ atouts:
         ref: entry:velocite
   - id: ventre-du-magicien
     name: Ventre du magicien
+    status: active
     effect: Le familier peut, en se nourrissant, sustenter son magicien.
     value: 4000
     activation: permanent
@@ -4552,6 +4956,7 @@ atouts:
         ref: entry:ventre-du-magicien
   - id: ventre-vide
     name: Ventre vide
+    status: active
     effect: >-
       Lorsque le personnage tente d’obtenir de la nourriture, ses actions ont une difficulté diminuée de 1 par point
       dans cet attout.
@@ -4564,6 +4969,7 @@ atouts:
         ref: entry:ventre-vide
   - id: verrouillage-de-souvenir
     name: Verrouillage de souvenir
+    status: active
     effect: >-
       Le personnage peut mettre un verrou sur un souvenir d’une personne, de manière à ce que elle-ci n’y ait plus
       accès, même si on essaye de le lui rendre la mémoire.
@@ -4576,6 +4982,7 @@ atouts:
         ref: entry:verrouillage-de-souvenir
   - id: victime
     name: Victime
+    status: active
     effect: >-
       Le personnage peut choisir 1 être vivant (qu’il voit) et saura en permanence dans quelle direction aller pour
       retrouver celui-ci. Il peut décider de changer d’être quand il le souhaite.
@@ -4588,6 +4995,7 @@ atouts:
         ref: entry:victime
   - id: vision
     name: Vision
+    status: active
     effect: >-
       La vision est représentée en pourcentage, ce qui signifie qu’un homme en bonne forme possède une vision de 100%.
       Un personnage ayant 200% en vision verra donc deux fois plus loin et plus précisément.
@@ -4600,6 +5008,7 @@ atouts:
         ref: entry:vision
   - id: vision-nocturne
     name: Vision nocturne
+    status: active
     effect: Le personnage est nyctalope.
     value: 1000
     activation: permanent
@@ -4610,6 +5019,7 @@ atouts:
         ref: entry:vision-nocturne
   - id: vision-thermique
     name: Vision thermique
+    status: active
     effect: >-
       Permet au personnage de voir toutes sources de chaleur. Celles-ci brillent, ce qui les rend donc visibles même
       dans le noir total.
@@ -4622,6 +5032,7 @@ atouts:
         ref: entry:vision-thermique
   - id: visions-cauchemardesques
     name: Visions cauchemardesques
+    status: active
     effect: >-
       En touchant un être, le personnage peut lui faire voir (sous forme d’un flash) des visions du mal qu’à fait le
       personnage. Ces visions durent 1 DT par niveau.
@@ -4634,6 +5045,7 @@ atouts:
         ref: entry:visions-cauchemardesques
   - id: voix-intense
     name: Voix intense
+    status: active
     effect: Additionne le niveau au nombre de dés lorsque le personnage chante.
     value: 2000
     activation: permanent
@@ -4644,6 +5056,7 @@ atouts:
         ref: entry:voix-intense
   - id: voix-surnaturelle
     name: Voix surnaturelle
+    status: active
     effect: >-
       Le personnage peut, quand il le désire, moduler sa voix qui devient alors plus impressionnante mais d’aspect non
       naturel. Quand le personnage utilise sa voix surnaturelle, il additionne son niveau au nombre de dès lors d’un jet
@@ -4657,6 +5070,7 @@ atouts:
         ref: entry:voix-surnaturelle
   - id: vol
     name: Vol
+    status: active
     effect: >-
       Le personnage peut voler. Que ce soit grâce à des ailes, une faculté mentale ou autres, celui-ci peut se déplacer
       librement dans les airs.
@@ -4669,6 +5083,7 @@ atouts:
         ref: entry:vol
   - id: vol-de-familier
     name: Vol de familier
+    status: active
     effect: >-
       Le magicien peut détourner le lien qui relie un autre magicien à son familier et rediriger ce lien vers lui-même.
       De la sorte, le personnage peut avoir un familier supplémentaire. Ce nouveau familier reste lié et au service du
@@ -4683,6 +5098,7 @@ atouts:
         ref: entry:vol-de-familier
   - id: vol-de-secret
     name: Vol de secret
+    status: active
     effect: >-
       Le personnage peut entendre pendant 1 minute par niveau ce qu’un autre personnage se dit mentalement. Il peut
       également voir les images que celui-ci s’imagine. Toutefois, pour pénétrer le mental de quelqu'un, le personnage

--- a/data/catalogs/bestiaire.yaml
+++ b/data/catalogs/bestiaire.yaml
@@ -6,8 +6,8 @@
 version: 1
 metadata:
   source: web
-  imported_at: "2026-04-25"
-  updated_at: "2026-04-30"
+  imported_at: '2026-04-25'
+  updated_at: '2026-04-30'
   total_entries: 31
   total_playable_races: 25
   source_files:
@@ -30,11 +30,11 @@ metadata:
 #   lore (descriptif narratif)
 
 creatures:
-
   # === HUMAINS ET PROCHES ===
 
   - id: humain
-    name: "Humain, -e"
+    name: 'Humain, -e'
+    status: active
     category: humanoid
     size_m: 1.75
     life_expectancy: 75
@@ -52,24 +52,37 @@ creatures:
       intelligence: 5
       reflexes: 5
       perception: 5
-    innate_atouts: ["Anti-limites physiques"]
+    innate_atouts: ['Anti-limites physiques']
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Empire", "Enorie", "Aderand", "Terres du Nord", "Alteria", "Cortega", "Dundoria", "Yonkado", "Irtanie", "Dêtre"]
+    habitat:
+      [
+        'Empire',
+        'Enorie',
+        'Aderand',
+        'Terres du Nord',
+        'Alteria',
+        'Cortega',
+        'Dundoria',
+        'Yonkado',
+        'Irtanie',
+        'Dêtre'
+      ]
     social_structure: civilized
     playable: true
-    lore: "Race-pivot polyvalente. Capable du meilleur comme du pire."
+    lore: 'Race-pivot polyvalente. Capable du meilleur comme du pire.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:humain"
+        ref: 'entry:humain'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:humain"
+        ref: 'entry:humain'
     metadata: { source: paper, version: 1 }
 
   - id: demi_elfe
-    name: "Demi-elfe"
+    name: 'Demi-elfe'
+    status: active
     category: humanoid
     size_m: 1.80
     life_expectancy: 2000
@@ -87,29 +100,30 @@ creatures:
       intelligence: 5
       reflexes: 5
       perception: 5
-    innate_atouts: ["Dépassement de soi", "Vision nocturne"]
+    innate_atouts: ['Dépassement de soi', 'Vision nocturne']
     intelligence_level: sentient
     language_capable: true
-    habitat: ["parmi les Elfes ou les Humains"]
+    habitat: ['parmi les Elfes ou les Humains']
     social_structure: civilized
     playable: true
     lore: "Issu d'une union humain × elfe. Mentalité variable selon enfance."
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:demi_elfe"
+        ref: 'entry:demi_elfe'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:demi_elfe"
+        ref: 'entry:demi_elfe'
     metadata: { source: paper, version: 1 }
 
   # === ELFES ===
 
   - id: haut_elfe
-    name: "Haut-elfe, -"
+    name: 'Haut-elfe, -'
+    status: active
     category: humanoid
     size_m: 1.90
-    life_expectancy: -1  # immortel
+    life_expectancy: -1 # immortel
     xp_category: 20
     vitality_base: 15
     speed_factor_base: 7
@@ -124,28 +138,29 @@ creatures:
       intelligence: 7
       reflexes: 5
       perception: 5
-    innate_atouts: ["Vision nocturne"]
+    innate_atouts: ['Vision nocturne']
     resistances:
-      - { type: alcool, value: 30, source: "race:haut_elfe" }
-      - { type: maladies, value: 30, source: "race:haut_elfe" }
-      - { type: vision, value: 110, source: "race:haut_elfe" }
+      - { type: alcool, value: 30, source: 'race:haut_elfe' }
+      - { type: maladies, value: 30, source: 'race:haut_elfe' }
+      - { type: vision, value: 110, source: 'race:haut_elfe' }
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Haut Royaume"]
+    habitat: ['Haut Royaume']
     social_structure: civilized
     playable: true
-    lore: "Cités blanches utopiques, sagesse, calme."
+    lore: 'Cités blanches utopiques, sagesse, calme.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:haut_elfe"
+        ref: 'entry:haut_elfe'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:haut_elfe"
+        ref: 'entry:haut_elfe'
     metadata: { source: paper, version: 1 }
 
   - id: elfe_des_bois
-    name: "Elfe des Bois"
+    name: 'Elfe des Bois'
+    status: active
     category: humanoid
     size_m: 1.85
     life_expectancy: -1
@@ -163,28 +178,29 @@ creatures:
       intelligence: 6
       reflexes: 6
       perception: 6
-    innate_atouts: ["Vision nocturne"]
+    innate_atouts: ['Vision nocturne']
     resistances:
       - { type: alcool, value: 24 }
       - { type: maladies, value: 30 }
       - { type: vision, value: 110 }
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Forêt de Tyrkan"]
+    habitat: ['Forêt de Tyrkan']
     social_structure: civilized
     playable: true
     lore: "Philosophie de l'équilibre, archers réputés."
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:elfe_des_bois"
+        ref: 'entry:elfe_des_bois'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:elfe_des_bois"
+        ref: 'entry:elfe_des_bois'
     metadata: { source: paper, version: 1 }
 
   - id: elfe_sombre
-    name: "Elfe Sombre"
+    name: 'Elfe Sombre'
+    status: active
     category: humanoid
     size_m: 1.90
     life_expectancy: -1
@@ -202,28 +218,29 @@ creatures:
       intelligence: 6
       reflexes: 5
       perception: 5
-    innate_atouts: ["Vision nocturne"]
+    innate_atouts: ['Vision nocturne']
     resistances:
       - { type: alcool, value: 30 }
       - { type: maladies, value: 30 }
       - { type: vision, value: 110 }
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Monde Sombre"]
+    habitat: ['Monde Sombre']
     social_structure: civilized
     playable: true
-    lore: "Sans larmes, sans sentiments envers les étrangers. Présage funeste."
+    lore: 'Sans larmes, sans sentiments envers les étrangers. Présage funeste.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:elfe_sombre"
+        ref: 'entry:elfe_sombre'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:elfe_sombre"
+        ref: 'entry:elfe_sombre'
     metadata: { source: paper, version: 1 }
 
   - id: elfe_de_nacre
-    name: "Elfe de Nacre"
+    name: 'Elfe de Nacre'
+    status: active
     category: humanoid
     size_m: 1.85
     life_expectancy: -1
@@ -241,7 +258,7 @@ creatures:
       intelligence: 6
       reflexes: 5
       perception: 5
-    innate_atouts: ["Vision nocturne"]
+    innate_atouts: ['Vision nocturne']
     resistances:
       - { type: alcool, value: 30 }
       - { type: drogues, value: 12 }
@@ -249,24 +266,25 @@ creatures:
       - { type: vision, value: 110 }
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Blanc Royaume"]
+    habitat: ['Blanc Royaume']
     social_structure: civilized
     playable: true
-    lore: "Le plus cruel des peuples. Drogues, piercings, prisonniers."
+    lore: 'Le plus cruel des peuples. Drogues, piercings, prisonniers.'
     notes_kw_invention: true
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:elfe_de_nacre"
+        ref: 'entry:elfe_de_nacre'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:elfe_de_nacre"
+        ref: 'entry:elfe_de_nacre'
     metadata: { source: paper, version: 1 }
 
   # === PETITES RACES ===
 
   - id: nain
-    name: "Nain, -e"
+    name: 'Nain, -e'
+    status: active
     category: humanoid
     size_m: 1.30
     life_expectancy: 500
@@ -284,7 +302,7 @@ creatures:
       intelligence: 5
       reflexes: 4
       perception: 4
-    innate_atouts: ["Force de géant"]
+    innate_atouts: ['Force de géant']
     resistances:
       - { type: alcool, value: 30 }
       - { type: drogues, value: 21 }
@@ -296,18 +314,19 @@ creatures:
     habitat: ["Portes d'Azrak"]
     social_structure: civilized
     playable: true
-    lore: "Entêtés, déterminés. Meilleurs artisans (architecture, joaillerie, forge, brasseurs de bières)."
+    lore: 'Entêtés, déterminés. Meilleurs artisans (architecture, joaillerie, forge, brasseurs de bières).'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:nain"
+        ref: 'entry:nain'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:nain"
+        ref: 'entry:nain'
     metadata: { source: paper, version: 1 }
 
   - id: hobbit
-    name: "Hobbit"
+    name: 'Hobbit'
+    status: active
     category: humanoid
     size_m: 1.10
     life_expectancy: 95
@@ -325,27 +344,28 @@ creatures:
       intelligence: 5
       reflexes: 5
       perception: 5
-    innate_atouts: ["Pieds poilus"]
+    innate_atouts: ['Pieds poilus']
     resistances:
       - { type: fumee, value: 60 }
       - { type: magie, value: 60 }
     intelligence_level: sentient
     language_capable: true
-    habitat: ["paysans, vallées"]
+    habitat: ['paysans, vallées']
     social_structure: civilized
     playable: true
-    lore: "Paisibles paysans. Tabac, agriculture. Déplacement silencieux."
+    lore: 'Paisibles paysans. Tabac, agriculture. Déplacement silencieux.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:hobbit"
+        ref: 'entry:hobbit'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:hobbit"
+        ref: 'entry:hobbit'
     metadata: { source: paper, version: 1 }
 
   - id: gnome
-    name: "Gnome"
+    name: 'Gnome'
+    status: active
     category: humanoid
     size_m: 0.6
     life_expectancy: 200
@@ -363,7 +383,7 @@ creatures:
       intelligence: 5
       reflexes: 5
       perception: 6
-    innate_atouts: ["Affinité avec les illusions", "Vision nocturne"]
+    innate_atouts: ['Affinité avec les illusions', 'Vision nocturne']
     resistances:
       - { type: magie, value: 20 }
     intelligence_level: sentient
@@ -371,18 +391,19 @@ creatures:
     habitat: ["Collines d'Ico"]
     social_structure: civilized
     playable: true
-    lore: "Mystérieux, joyeux. Plus grands illusionnistes."
+    lore: 'Mystérieux, joyeux. Plus grands illusionnistes.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:gnome"
+        ref: 'entry:gnome'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:gnome"
+        ref: 'entry:gnome'
     metadata: { source: paper, version: 1 }
 
   - id: gobelin
-    name: "Gobelin, -e"
+    name: 'Gobelin, -e'
+    status: active
     category: humanoid
     size_m: 0.5
     life_expectancy: 15
@@ -400,28 +421,29 @@ creatures:
       intelligence: 4
       reflexes: 5
       perception: 5
-    innate_atouts: ["Frénésie collective", "Vision nocturne"]
+    innate_atouts: ['Frénésie collective', 'Vision nocturne']
     resistances:
       - { type: maladies, value: 16 }
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Terres Sauvages"]
+    habitat: ['Terres Sauvages']
     social_structure: tribal
     playable: true
-    lore: "Sale, vert, sournois. Pillent en nombre. Nocturne."
+    lore: 'Sale, vert, sournois. Pillent en nombre. Nocturne.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:gobelin"
+        ref: 'entry:gobelin'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:gobelin"
+        ref: 'entry:gobelin'
     metadata: { source: paper, version: 1 }
 
   # === RACES MASSIVES ===
 
   - id: orc
-    name: "Orc"
+    name: 'Orc'
+    status: active
     category: humanoid
     size_m: 1.60
     life_expectancy: 35
@@ -439,26 +461,27 @@ creatures:
       intelligence: 4
       reflexes: 5
       perception: 5
-    innate_atouts: ["Peur", "Vision nocturne"]
+    innate_atouts: ['Peur', 'Vision nocturne']
     resistances:
       - { type: maladies, value: 4 }
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Terres Sauvages"]
+    habitat: ['Terres Sauvages']
     social_structure: tribal
     playable: true
-    lore: "Brutalité, violence, pillage. Soldats parfaits sous bon chef."
+    lore: 'Brutalité, violence, pillage. Soldats parfaits sous bon chef.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:orc"
+        ref: 'entry:orc'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:orc"
+        ref: 'entry:orc'
     metadata: { source: paper, version: 1 }
 
   - id: ogre
-    name: "Ogre, -sse"
+    name: 'Ogre, -sse'
+    status: active
     category: humanoid
     size_m: 3.0
     life_expectancy: 300
@@ -476,29 +499,30 @@ creatures:
       intelligence: 4
       reflexes: 3
       perception: 4
-    innate_atouts: ["Terreur"]
+    innate_atouts: ['Terreur']
     resistances:
       - { type: feu, value: 54 }
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Terres Sauvages"]
+    habitat: ['Terres Sauvages']
     social_structure: tribal
     playable: true
-    lore: "Énormes créatures grasses. Carnivores, friands de chair humaine, surtout enfants."
+    lore: 'Énormes créatures grasses. Carnivores, friands de chair humaine, surtout enfants.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:ogre"
+        ref: 'entry:ogre'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:ogre"
+        ref: 'entry:ogre'
     metadata: { source: paper, version: 1 }
 
   - id: troll
-    name: "Troll, -ope"
+    name: 'Troll, -ope'
+    status: active
     category: humanoid
     size_m: 3.60
-    life_expectancy: -1  # immortel
+    life_expectancy: -1 # immortel
     xp_category: 48
     vitality_base: 120
     speed_factor_base: 10
@@ -513,30 +537,31 @@ creatures:
       intelligence: 2
       reflexes: 4
       perception: 4
-    innate_atouts: ["Auto régénération", "Terreur", "Vision nocturne"]
-    innate_handicaps: ["Aube pétrificatrice"]
+    innate_atouts: ['Auto régénération', 'Terreur', 'Vision nocturne']
+    innate_handicaps: ['Aube pétrificatrice']
     resistances:
       - { type: maladies, value: 20 }
       - { type: poisons, value: 11 }
     intelligence_level: semi_sentient
-    language_capable: true  # rarement
-    habitat: ["Terres Sauvages"]
+    language_capable: true # rarement
+    habitat: ['Terres Sauvages']
     social_structure: solitary
     playable: true
     lore: "Force brute. Régénération, mais pétrifié à l'aube."
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:troll"
+        ref: 'entry:troll'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:troll"
+        ref: 'entry:troll'
     metadata: { source: paper, version: 1 }
 
   # === CRÉATURES MYTHOLOGIQUES ===
 
   - id: centaure
-    name: "Centaure, -sse"
+    name: 'Centaure, -sse'
+    status: active
     category: humanoid
     size_m: 2.40
     life_expectancy: 100
@@ -554,7 +579,7 @@ creatures:
       intelligence: 5
       reflexes: 5
       perception: 5
-    innate_atouts: ["Vélocité"]
+    innate_atouts: ['Vélocité']
     resistances:
       - { type: alcool, value: 11 }
     intelligence_level: sentient
@@ -562,18 +587,19 @@ creatures:
     habitat: []
     social_structure: tribal
     playable: true
-    lore: "Forces de la nature. Esprits violents, attirance pour le bon vin."
+    lore: 'Forces de la nature. Esprits violents, attirance pour le bon vin.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:centaure"
+        ref: 'entry:centaure'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:centaure"
+        ref: 'entry:centaure'
     metadata: { source: paper, version: 1 }
 
   - id: dryade
-    name: "Dryade"
+    name: 'Dryade'
+    status: active
     category: spirit
     size_m: 1.70
     life_expectancy: -1
@@ -591,24 +617,25 @@ creatures:
       intelligence: 5
       reflexes: 5
       perception: 5
-    innate_atouts: ["Lingua vegetalis", "Vegothropie"]
+    innate_atouts: ['Lingua vegetalis', 'Vegothropie']
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Forêt de Tyrkan", "Collines d'Ico"]
+    habitat: ['Forêt de Tyrkan', "Collines d'Ico"]
     social_structure: solitary
     playable: true
-    lore: "Nymphes des arbres. Toujours féminines. Transformation en arbre possible."
+    lore: 'Nymphes des arbres. Toujours féminines. Transformation en arbre possible.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:dryade"
+        ref: 'entry:dryade'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:dryade"
+        ref: 'entry:dryade'
     metadata: { source: paper, version: 1 }
 
   - id: ondine
-    name: "Ondine"
+    name: 'Ondine'
+    status: active
     category: spirit
     size_m: 1.75
     life_expectancy: -1
@@ -626,26 +653,27 @@ creatures:
       intelligence: 5
       reflexes: 5
       perception: 5
-    innate_atouts: ["Chant envoûtant", "Race aquatique"]
+    innate_atouts: ['Chant envoûtant', 'Race aquatique']
     intelligence_level: sentient
     language_capable: true
     habitat: ["points d'eaux vives"]
     social_structure: solitary
     playable: true
-    lore: "Nymphes des eaux. Charme surnaturel. Acquièrent une âme par mariage."
+    lore: 'Nymphes des eaux. Charme surnaturel. Acquièrent une âme par mariage.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:ondine"
+        ref: 'entry:ondine'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:ondine"
+        ref: 'entry:ondine'
     metadata: { source: paper, version: 1 }
 
   # === FÉLIDÉS ===
 
   - id: chigr
-    name: "Chigr"
+    name: 'Chigr'
+    status: active
     category: humanoid
     size_m: 1.70
     life_expectancy: 50
@@ -663,26 +691,27 @@ creatures:
       intelligence: 4
       reflexes: 6
       perception: 6
-    innate_atouts: ["Équilibre contrôlé", "Retombe sur ses pattes", "Vision nocturne"]
+    innate_atouts: ['Équilibre contrôlé', 'Retombe sur ses pattes', 'Vision nocturne']
     resistances:
       - { type: chaleur, value: 3 }
     intelligence_level: sentient
     language_capable: true
     social_structure: tribal
     playable: true
-    lore: "Le plus petit des félidés. Mélange humain × petit félin (chat, lynx, ocelot)."
+    lore: 'Le plus petit des félidés. Mélange humain × petit félin (chat, lynx, ocelot).'
     notes_kw_invention: true
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:chigr"
+        ref: 'entry:chigr'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:chigr"
+        ref: 'entry:chigr'
     metadata: { source: paper, version: 1 }
 
   - id: khochigr
-    name: "Khochigr"
+    name: 'Khochigr'
+    status: active
     category: humanoid
     size_m: 1.90
     life_expectancy: 55
@@ -700,26 +729,27 @@ creatures:
       intelligence: 4
       reflexes: 6
       perception: 6
-    innate_atouts: ["Équilibre contrôlé", "Retombe sur ses pattes", "Vision nocturne"]
+    innate_atouts: ['Équilibre contrôlé', 'Retombe sur ses pattes', 'Vision nocturne']
     resistances:
       - { type: chaleur, value: 6 }
     intelligence_level: sentient
     language_capable: true
     social_structure: tribal
     playable: true
-    lore: "Mélange équilibré humain × félin moyen (léopard, panthère, puma, jaguar, guépard)."
+    lore: 'Mélange équilibré humain × félin moyen (léopard, panthère, puma, jaguar, guépard).'
     notes_kw_invention: true
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:khochigr"
+        ref: 'entry:khochigr'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:khochigr"
+        ref: 'entry:khochigr'
     metadata: { source: paper, version: 1 }
 
   - id: khogr
-    name: "Khogr"
+    name: 'Khogr'
+    status: active
     category: humanoid
     size_m: 1.95
     life_expectancy: 60
@@ -737,28 +767,29 @@ creatures:
       intelligence: 4
       reflexes: 6
       perception: 6
-    innate_atouts: ["Équilibre contrôlé", "Retombe sur ses pattes", "Vision nocturne"]
+    innate_atouts: ['Équilibre contrôlé', 'Retombe sur ses pattes', 'Vision nocturne']
     resistances:
       - { type: chaleur, value: 9 }
     intelligence_level: sentient
     language_capable: true
     social_structure: tribal
     playable: true
-    lore: "Plus grand des félidés (lion, tigre). Force de la nature, prédateur."
+    lore: 'Plus grand des félidés (lion, tigre). Force de la nature, prédateur.'
     notes_kw_invention: true
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:khogr"
+        ref: 'entry:khogr'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:khogr"
+        ref: 'entry:khogr'
     metadata: { source: paper, version: 1 }
 
   # === HOMMES-X (anthropomorphes) ===
 
   - id: canidae
-    name: "Canidae"
+    name: 'Canidae'
+    status: active
     category: humanoid
     size_m: 2.10
     life_expectancy: 65
@@ -776,27 +807,28 @@ creatures:
       intelligence: 5
       reflexes: 5
       perception: 7
-    innate_atouts: ["Flaire infaillible", "Pisteur né"]
+    innate_atouts: ['Flaire infaillible', 'Pisteur né']
     resistances:
       - { type: fatigue, value: 25 }
     intelligence_level: sentient
     language_capable: true
-    habitat: ["orées de forêts, plaines karstiques, grottes"]
-    social_structure: pack  # meutes
+    habitat: ['orées de forêts, plaines karstiques, grottes']
+    social_structure: pack # meutes
     playable: true
-    lore: "Hommes-loup / Hommes-chien. Endurance et flaire. Sous-espèce : Gnolls (mélange humain + hyène)."
-    sub_species: ["gnolls"]
+    lore: 'Hommes-loup / Hommes-chien. Endurance et flaire. Sous-espèce : Gnolls (mélange humain + hyène).'
+    sub_species: ['gnolls']
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:canidae"
+        ref: 'entry:canidae'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:canidae"
+        ref: 'entry:canidae'
     metadata: { source: paper, version: 1 }
 
   - id: homme_lezard
-    name: "Homme Lézard / Femme Lézard"
+    name: 'Homme Lézard / Femme Lézard'
+    status: active
     category: humanoid
     size_m: 1.80
     life_expectancy: 70
@@ -814,28 +846,29 @@ creatures:
       intelligence: 5
       reflexes: 8
       perception: 6
-    innate_atouts: ["Sang-froid", "Vision nocturne"]
-    innate_handicaps: ["Organisme fragile"]
+    innate_atouts: ['Sang-froid', 'Vision nocturne']
+    innate_handicaps: ['Organisme fragile']
     resistances:
       - { type: chaleur, value: 36 }
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Stazyliss"]
+    habitat: ['Stazyliss']
     social_structure: tribal
     playable: true
-    lore: "Imperturbables, escarmouches ciblées. Pacifiques, isolationnistes."
+    lore: 'Imperturbables, escarmouches ciblées. Pacifiques, isolationnistes.'
     notes_kw_invention: true
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:homme_lezard"
+        ref: 'entry:homme_lezard'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:homme_lezard"
+        ref: 'entry:homme_lezard'
     metadata: { source: paper, version: 1 }
 
   - id: homme_oiseau
-    name: "Homme Oiseau / Femme Oiselle"
+    name: 'Homme Oiseau / Femme Oiselle'
+    status: active
     category: humanoid
     size_m: 1.85
     life_expectancy: 90
@@ -853,27 +886,28 @@ creatures:
       intelligence: 5
       reflexes: 5
       perception: 7
-    innate_atouts: ["Vol"]
+    innate_atouts: ['Vol']
     resistances:
       - { type: vision, value: 235 }
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Grande Cité Haute (palais flottant)"]
+    habitat: ['Grande Cité Haute (palais flottant)']
     social_structure: civilized
     playable: true
-    lore: "Pacifique, discret, légendaire."
+    lore: 'Pacifique, discret, légendaire.'
     notes_kw_invention: true
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:homme_oiseau"
+        ref: 'entry:homme_oiseau'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:homme_oiseau"
+        ref: 'entry:homme_oiseau'
     metadata: { source: paper, version: 1 }
 
   - id: homme_rat
-    name: "Homme Rat / Femme Ratte"
+    name: 'Homme Rat / Femme Ratte'
+    status: active
     category: humanoid
     size_m: 1.50
     life_expectancy: 45
@@ -891,31 +925,32 @@ creatures:
       intelligence: 5
       reflexes: 6
       perception: 6
-    innate_atouts: ["Frénésie collective", "Vision nocturne"]
+    innate_atouts: ['Frénésie collective', 'Vision nocturne']
     resistances:
       - { type: maladies, value: 49 }
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Souterrain"]
-    social_structure: civilized  # Empire
+    habitat: ['Souterrain']
+    social_structure: civilized # Empire
     playable: true
-    lore: "Sociaux, imprévisibles, adaptatifs. Empereur héréditaire par joutes."
+    lore: 'Sociaux, imprévisibles, adaptatifs. Empereur héréditaire par joutes.'
     notes_kw_invention: true
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:homme_rat"
+        ref: 'entry:homme_rat'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:homme_rat"
+        ref: 'entry:homme_rat'
     metadata: { source: paper, version: 1 }
 
   # === MORT-VIVANTS ===
 
   - id: fantome
-    name: "Fantôme"
+    name: 'Fantôme'
+    status: active
     category: undead
-    size_m: 0  # dépend de la race de base
+    size_m: 0 # dépend de la race de base
     life_expectancy: -1
     xp_category: 31
     vitality_base: 13
@@ -931,26 +966,27 @@ creatures:
       intelligence: 5
       reflexes: 3
       perception: 4
-    innate_atouts: ["Immatérialité", "Mort-vivant", "Possession", "Vision nocturne", "Vol"]
+    innate_atouts: ['Immatérialité', 'Mort-vivant', 'Possession', 'Vision nocturne', 'Vol']
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Landes Désertiques"]
+    habitat: ['Landes Désertiques']
     social_structure: solitary
     playable: false
-    lore: "Âmes errantes avec mission. Possession = 1 par défaut."
+    lore: 'Âmes errantes avec mission. Possession = 1 par défaut.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:fantome"
+        ref: 'entry:fantome'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:fantome"
+        ref: 'entry:fantome'
     metadata: { source: paper, version: 1 }
 
   - id: squelette
-    name: "Squelette"
+    name: 'Squelette'
+    status: active
     category: undead
-    size_m: 0  # celle de l'ancienne race
+    size_m: 0 # celle de l'ancienne race
     life_expectancy: -1
     xp_category: 16
     vitality_base: 15
@@ -966,24 +1002,25 @@ creatures:
       intelligence: 4
       reflexes: 4
       perception: 3
-    innate_atouts: ["Jusqu'à la mort", "Mort-vivant", "Peur"]
-    intelligence_level: instinctive  # parfois plus selon l'individu
-    language_capable: false  # généralement
-    habitat: ["Landes Désertiques", "nécropoles"]
+    innate_atouts: ["Jusqu'à la mort", 'Mort-vivant', 'Peur']
+    intelligence_level: instinctive # parfois plus selon l'individu
+    language_capable: false # généralement
+    habitat: ['Landes Désertiques', 'nécropoles']
     social_structure: pack
     playable: false
-    lore: "Relevés par nécromancie. Sans peur, sans tentation, sans remords."
+    lore: 'Relevés par nécromancie. Sans peur, sans tentation, sans remords.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:squelette"
+        ref: 'entry:squelette'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:squelette"
+        ref: 'entry:squelette'
     metadata: { source: paper, version: 1 }
 
   - id: vampire
-    name: "Vampire, sse"
+    name: 'Vampire, sse'
+    status: active
     category: undead
     size_m: 1.75
     life_expectancy: -1
@@ -1001,26 +1038,36 @@ creatures:
       intelligence: 5
       reflexes: 5
       perception: 5
-    innate_atouts: ["Baiser de la nuit", "Baiser des ténèbres", "Brumathropie", "Chiroptèrothropie", "Lycanthropie", "Mort-vivant", "Vision nocturne"]
-    innate_handicaps: ["Aube meurtrière", "Sans reflet", "Soif de sang"]
+    innate_atouts:
+      [
+        'Baiser de la nuit',
+        'Baiser des ténèbres',
+        'Brumathropie',
+        'Chiroptèrothropie',
+        'Lycanthropie',
+        'Mort-vivant',
+        'Vision nocturne'
+      ]
+    innate_handicaps: ['Aube meurtrière', 'Sans reflet', 'Soif de sang']
     intelligence_level: sentient
     language_capable: true
-    habitat: ["Partout"]
+    habitat: ['Partout']
     social_structure: solitary
-    playable: true  # via transformation D3 Q-D3.5
-    lore: "Humains qui ont embrassé la mort. Beauté ténébreuse, canines, peau froide."
+    playable: true # via transformation D3 Q-D3.5
+    lore: 'Humains qui ont embrassé la mort. Beauté ténébreuse, canines, peau froide.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:vampire"
+        ref: 'entry:vampire'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:vampire"
+        ref: 'entry:vampire'
     metadata: { source: paper, version: 1 }
 
   - id: loup_garou
-    name: "Loup-garou, Louve-garou"
-    category: humanoid  # forme hybride
+    name: 'Loup-garou, Louve-garou'
+    status: active
+    category: humanoid # forme hybride
     size_m: 2.50
     life_expectancy: 50
     xp_category: 45
@@ -1037,27 +1084,36 @@ creatures:
       intelligence: 4
       reflexes: 7
       perception: 7
-    innate_atouts: ["Auto régénération", "Humanothropie", "Lycanthropie", "Morsure lupine", "Terreur", "Vision nocturne"]
-    innate_handicaps: ["Brûlure de l'argent", "Rage lunaire"]
-    intelligence_level: sentient  # forme humaine ; instinctive en forme bestiale
-    language_capable: true  # en forme humaine
+    innate_atouts:
+      [
+        'Auto régénération',
+        'Humanothropie',
+        'Lycanthropie',
+        'Morsure lupine',
+        'Terreur',
+        'Vision nocturne'
+      ]
+    innate_handicaps: ["Brûlure de l'argent", 'Rage lunaire']
+    intelligence_level: sentient # forme humaine ; instinctive en forme bestiale
+    language_capable: true # en forme humaine
     habitat: ["régions peuplées d'humains"]
-    social_structure: pack  # parmi les loups
-    playable: true  # via Morsure lupine D3 Q-D3.5
-    lore: "Vit parmi les hommes, transformation pleine lune. Société secrète parmi les meutes de loups."
+    social_structure: pack # parmi les loups
+    playable: true # via Morsure lupine D3 Q-D3.5
+    lore: 'Vit parmi les hommes, transformation pleine lune. Société secrète parmi les meutes de loups.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:loup_garou"
+        ref: 'entry:loup_garou'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:loup_garou"
+        ref: 'entry:loup_garou'
     metadata: { source: paper, version: 1 }
 
   # === ANIMAUX ===
 
   - id: cheval
-    name: "Cheval, Jument"
+    name: 'Cheval, Jument'
+    status: active
     category: beast
     size_m: 1.80
     life_expectancy: 25
@@ -1075,23 +1131,24 @@ creatures:
       intelligence: 2
       reflexes: 3
       perception: 4
-    innate_atouts: ["Vélocité"]
+    innate_atouts: ['Vélocité']
     intelligence_level: instinctive
     language_capable: false
-    social_structure: pack  # troupeau
+    social_structure: pack # troupeau
     playable: false
     lore: "Plus belle conquête de l'homme. Transport, symbole de richesse."
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:cheval"
+        ref: 'entry:cheval'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:cheval"
+        ref: 'entry:cheval'
     metadata: { source: paper, version: 1, default_mount: true }
 
   - id: chat
-    name: "Chat, -te"
+    name: 'Chat, -te'
+    status: active
     category: beast
     size_m: 0.25
     life_expectancy: 15
@@ -1109,23 +1166,24 @@ creatures:
       intelligence: 2
       reflexes: 6
       perception: 7
-    innate_atouts: ["Équilibre contrôlé", "Retombe sur ses pattes", "Vision nocturne"]
+    innate_atouts: ['Équilibre contrôlé', 'Retombe sur ses pattes', 'Vision nocturne']
     intelligence_level: instinctive
     language_capable: false
     social_structure: solitary
     playable: false
-    lore: "Lien occulte. Familier de sorcière par excellence. Neuf vies."
+    lore: 'Lien occulte. Familier de sorcière par excellence. Neuf vies.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:chat"
+        ref: 'entry:chat'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:chat"
+        ref: 'entry:chat'
     metadata: { source: paper, version: 1, common_familiar: true }
 
   - id: loup
-    name: "Loup, Louve"
+    name: 'Loup, Louve'
+    status: active
     category: beast
     size_m: 0.8
     life_expectancy: 50
@@ -1143,26 +1201,27 @@ creatures:
       intelligence: 3
       reflexes: 6
       perception: 7
-    innate_atouts: ["Frénésie collective", "Vision nocturne"]
+    innate_atouts: ['Frénésie collective', 'Vision nocturne']
     intelligence_level: instinctive
     language_capable: false
-    habitat: ["forêts"]
-    social_structure: pack  # 3-15 individus
+    habitat: ['forêts']
+    social_structure: pack # 3-15 individus
     playable: false
-    lore: "Prédateur des forêts. En meute (3-15). Origine du mythe loup-garou."
+    lore: 'Prédateur des forêts. En meute (3-15). Origine du mythe loup-garou.'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:loup"
+        ref: 'entry:loup'
       - path: data/legacy/paper/regles-papier/extracted/listes/bestiaire.md
         sha256: 42bb96214a287182f5b009bf8c2a0019c0f339cb19bf84d477abdc18f9a159cd
-        ref: "entry:loup"
+        ref: 'entry:loup'
     metadata: { source: paper, version: 1 }
 
   # === MORTS-VIVANTS (web only) ===
 
   - id: zombie
-    name: "Zombie"
+    name: 'Zombie'
+    status: active
     category: undead
     size_m: 1.75
     life_expectancy: 0
@@ -1185,9 +1244,9 @@ creatures:
     language_capable: false
     social_structure: horde
     playable: false
-    lore: "Cadavre animé par nécromancie. Présent web-canonique uniquement (absent du paper)."
+    lore: 'Cadavre animé par nécromancie. Présent web-canonique uniquement (absent du paper).'
     source_refs:
       - path: data/legacy/web-scraped/documents/bestiaire/index.md
         sha256: 3c6089bf92473e5022e22064678fe2004bc64399c4f205b9d9b5e90c145f2da9
-        ref: "entry:zombie"
+        ref: 'entry:zombie'
     metadata: { source: web, version: 1, web_only: true }

--- a/data/catalogs/classes.yaml
+++ b/data/catalogs/classes.yaml
@@ -13,6 +13,7 @@ metadata:
 classes:
   - id: bijoutier
     name: Bijoutier
+    status: active
     orientation_id: artisan
     primary_skill_id: bijouterie
     primary_skill_choice: fixed
@@ -22,6 +23,7 @@ classes:
         ref: line:9
   - id: charpentier
     name: Charpentier
+    status: active
     orientation_id: artisan
     primary_skill_id: charpenterie
     primary_skill_choice: fixed
@@ -31,6 +33,7 @@ classes:
         ref: line:10
   - id: couturier
     name: Couturier
+    status: active
     orientation_id: artisan
     primary_skill_id: couture
     primary_skill_choice: fixed
@@ -40,6 +43,7 @@ classes:
         ref: line:11
   - id: facteur-d-arc
     name: Facteur d’arc
+    status: active
     orientation_id: artisan
     primary_skill_id: facture-d-arc
     primary_skill_choice: fixed
@@ -49,6 +53,7 @@ classes:
         ref: line:12
   - id: forgeron
     name: Forgeron
+    status: active
     orientation_id: artisan
     primary_skill_id: forge
     primary_skill_choice: fixed
@@ -58,6 +63,7 @@ classes:
         ref: line:13
   - id: menuisier
     name: Menuisier
+    status: active
     orientation_id: artisan
     primary_skill_id: menuiserie
     primary_skill_choice: fixed
@@ -67,6 +73,7 @@ classes:
         ref: line:14
   - id: parfumeur
     name: Parfumeur
+    status: active
     orientation_id: artisan
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -76,6 +83,7 @@ classes:
         ref: line:15
   - id: potier
     name: Potier
+    status: active
     orientation_id: artisan
     primary_skill_id: poterie
     primary_skill_choice: fixed
@@ -85,6 +93,7 @@ classes:
         ref: line:16
   - id: tanneur
     name: Tanneur
+    status: active
     orientation_id: artisan
     primary_skill_id: tannage
     primary_skill_choice: fixed
@@ -94,6 +103,7 @@ classes:
         ref: line:17
   - id: tonnelier
     name: Tonnelier
+    status: active
     orientation_id: artisan
     primary_skill_id: facture-de-tonneau
     primary_skill_choice: fixed
@@ -103,6 +113,7 @@ classes:
         ref: line:18
   - id: vannier
     name: Vannier
+    status: active
     orientation_id: artisan
     primary_skill_id: vannerie
     primary_skill_choice: fixed
@@ -112,6 +123,7 @@ classes:
         ref: line:19
   - id: barde
     name: Barde
+    status: active
     orientation_id: artiste
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -121,6 +133,7 @@ classes:
         ref: line:21
   - id: chanteur
     name: Chanteur
+    status: active
     orientation_id: artiste
     primary_skill_id: chant
     primary_skill_choice: fixed
@@ -130,6 +143,7 @@ classes:
         ref: line:22
   - id: comedien
     name: Comédien
+    status: active
     orientation_id: artiste
     primary_skill_id: comedie
     primary_skill_choice: fixed
@@ -139,6 +153,7 @@ classes:
         ref: line:23
   - id: conteur
     name: Conteur
+    status: active
     orientation_id: artiste
     primary_skill_id: conte
     primary_skill_choice: fixed
@@ -148,6 +163,7 @@ classes:
         ref: line:24
   - id: danseur
     name: Danseur
+    status: active
     orientation_id: artiste
     primary_skill_id: danse
     primary_skill_choice: fixed
@@ -157,6 +173,7 @@ classes:
         ref: line:25
   - id: dessinateur
     name: Dessinateur
+    status: active
     orientation_id: artiste
     primary_skill_id: dessin
     primary_skill_choice: fixed
@@ -166,6 +183,7 @@ classes:
         ref: line:26
   - id: ecrivain
     name: Écrivain
+    status: active
     orientation_id: artiste
     primary_skill_id: redaction
     primary_skill_choice: fixed
@@ -175,6 +193,7 @@ classes:
         ref: line:27
   - id: peintre
     name: Peintre
+    status: active
     orientation_id: artiste
     primary_skill_id: peinture
     primary_skill_choice: fixed
@@ -184,6 +203,7 @@ classes:
         ref: line:28
   - id: prestidigitateur
     name: Prestidigitateur
+    status: active
     orientation_id: artiste
     primary_skill_id: prestidigitation
     primary_skill_choice: fixed
@@ -193,6 +213,7 @@ classes:
         ref: line:29
   - id: aubergiste
     name: Aubergiste
+    status: active
     orientation_id: commercant
     primary_skill_id: hotellerie
     primary_skill_choice: fixed
@@ -202,6 +223,7 @@ classes:
         ref: line:31
   - id: chasseur
     name: Chasseur
+    status: active
     orientation_id: commercant
     primary_skill_id: chasse
     primary_skill_choice: fixed
@@ -211,6 +233,7 @@ classes:
         ref: line:32
   - id: marchand
     name: Marchand
+    status: active
     orientation_id: commercant
     primary_skill_id: marchandage
     primary_skill_choice: fixed
@@ -220,6 +243,7 @@ classes:
         ref: line:33
   - id: pecheur
     name: Pêcheur
+    status: active
     orientation_id: commercant
     primary_skill_id: peche
     primary_skill_choice: fixed
@@ -229,6 +253,7 @@ classes:
         ref: line:34
   - id: prostitue
     name: Prostitué
+    status: active
     orientation_id: commercant
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -238,6 +263,7 @@ classes:
         ref: line:35
   - id: tavernier
     name: Tavernier
+    status: active
     orientation_id: commercant
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -247,6 +273,7 @@ classes:
         ref: line:36
   - id: chasseur-dommestique
     name: Chasseur
+    status: active
     orientation_id: dommestique
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -256,6 +283,7 @@ classes:
         ref: line:38
   - id: cuisinier
     name: Cuisinier
+    status: active
     orientation_id: dommestique
     primary_skill_id: cuisine
     primary_skill_choice: fixed
@@ -265,6 +293,7 @@ classes:
         ref: line:39
   - id: jardinier
     name: Jardinier
+    status: active
     orientation_id: dommestique
     primary_skill_id: jardinage
     primary_skill_choice: fixed
@@ -274,6 +303,7 @@ classes:
         ref: line:40
   - id: serf
     name: Serf
+    status: active
     orientation_id: dommestique
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -283,6 +313,7 @@ classes:
         ref: line:41
   - id: soubrette
     name: Soubrette
+    status: active
     orientation_id: dommestique
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -292,6 +323,7 @@ classes:
         ref: line:42
   - id: arbaletrier
     name: Arbalétrier
+    status: active
     orientation_id: guerrier
     primary_skill_id: arbalete
     primary_skill_choice: fixed
@@ -301,6 +333,7 @@ classes:
         ref: line:44
   - id: archer
     name: Archer
+    status: active
     orientation_id: guerrier
     primary_skill_id: archerie
     primary_skill_choice: fixed
@@ -310,6 +343,7 @@ classes:
         ref: line:45
   - id: barbare
     name: Barbare
+    status: active
     orientation_id: guerrier
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -319,6 +353,7 @@ classes:
         ref: line:46
   - id: berzerker
     name: Berzerker
+    status: active
     orientation_id: guerrier
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -328,6 +363,7 @@ classes:
         ref: line:47
   - id: cavalier
     name: Cavalier
+    status: active
     orientation_id: guerrier
     primary_skill_id: equitation
     primary_skill_choice: fixed
@@ -337,6 +373,7 @@ classes:
         ref: line:48
   - id: chasseur-de-magicien
     name: Chasseur de magicien
+    status: active
     orientation_id: guerrier
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -346,6 +383,7 @@ classes:
         ref: line:49
   - id: duelliste
     name: Duelliste
+    status: active
     orientation_id: guerrier
     primary_skill_id: epee-a-une-main
     primary_skill_choice: fixed
@@ -355,6 +393,7 @@ classes:
         ref: line:50
   - id: fantassin
     name: Fantassin
+    status: active
     orientation_id: guerrier
     primary_skill_id: lance
     primary_skill_choice: fixed
@@ -364,6 +403,7 @@ classes:
         ref: line:51
   - id: fantassin-leger
     name: Fantassin léger
+    status: active
     orientation_id: guerrier
     primary_skill_id: lance
     primary_skill_choice: fixed
@@ -373,6 +413,7 @@ classes:
         ref: line:52
   - id: fantassin-lourd
     name: Fantassin lourd
+    status: active
     orientation_id: guerrier
     primary_skill_id: hallebarde
     primary_skill_choice: fixed
@@ -382,6 +423,7 @@ classes:
         ref: line:53
   - id: garde
     name: Garde
+    status: active
     orientation_id: guerrier
     primary_skill_id: epee-a-une-main
     primary_skill_choice: fixed
@@ -391,6 +433,7 @@ classes:
         ref: line:54
   - id: garde-du-corps
     name: Garde du corps
+    status: active
     orientation_id: guerrier
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -400,6 +443,7 @@ classes:
         ref: line:55
   - id: justicier
     name: Justicier
+    status: active
     orientation_id: guerrier
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -409,6 +453,7 @@ classes:
         ref: line:56
   - id: mercenaires
     name: Mercenaires
+    status: active
     orientation_id: guerrier
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -418,6 +463,7 @@ classes:
         ref: line:57
   - id: samourai
     name: Samouraï
+    status: active
     orientation_id: guerrier
     primary_skill_id: katana
     primary_skill_choice: fixed
@@ -427,6 +473,7 @@ classes:
         ref: line:58
   - id: tueur-de-monstres
     name: Tueur de monstres
+    status: active
     orientation_id: guerrier
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -436,6 +483,7 @@ classes:
         ref: line:59
   - id: assassin
     name: Assassin
+    status: active
     orientation_id: hors-la-loi
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -445,6 +493,7 @@ classes:
         ref: line:61
   - id: braconnier
     name: Braconnier
+    status: active
     orientation_id: hors-la-loi
     primary_skill_id: chasse
     primary_skill_choice: fixed
@@ -454,6 +503,7 @@ classes:
         ref: line:62
   - id: escroc
     name: Escroc
+    status: active
     orientation_id: hors-la-loi
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -463,6 +513,7 @@ classes:
         ref: line:63
   - id: espion
     name: Espion
+    status: active
     orientation_id: hors-la-loi
     primary_skill_id: furtivite
     primary_skill_choice: fixed
@@ -472,6 +523,7 @@ classes:
         ref: line:64
   - id: ninja
     name: Ninja
+    status: active
     orientation_id: hors-la-loi
     primary_skill_id: furtivite
     primary_skill_choice: fixed
@@ -481,6 +533,7 @@ classes:
         ref: line:65
   - id: voleur
     name: Voleur
+    status: active
     orientation_id: hors-la-loi
     primary_skill_id: vol-a-la-tire
     primary_skill_choice: fixed
@@ -490,6 +543,7 @@ classes:
         ref: line:66
   - id: voleur-a-la-tire
     name: Voleur à la tire
+    status: active
     orientation_id: hors-la-loi
     primary_skill_id: vol-a-la-tire
     primary_skill_choice: fixed
@@ -499,6 +553,7 @@ classes:
         ref: line:67
   - id: alchimiste
     name: Alchimiste
+    status: active
     orientation_id: intellectuel
     primary_skill_id: alchimie
     primary_skill_choice: fixed
@@ -508,6 +563,7 @@ classes:
         ref: line:69
   - id: herboriste
     name: Herboriste
+    status: active
     orientation_id: intellectuel
     primary_skill_id: herbologie
     primary_skill_choice: fixed
@@ -517,6 +573,7 @@ classes:
         ref: line:70
   - id: joueur-de-poker
     name: Joueur de poker
+    status: active
     orientation_id: intellectuel
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -526,6 +583,7 @@ classes:
         ref: line:71
   - id: medecin
     name: Médecin
+    status: active
     orientation_id: intellectuel
     primary_skill_id: medecine
     primary_skill_choice: fixed
@@ -535,6 +593,7 @@ classes:
         ref: line:72
   - id: philosophe
     name: Philosophe
+    status: active
     orientation_id: intellectuel
     primary_skill_id: philosophie
     primary_skill_choice: fixed
@@ -544,6 +603,7 @@ classes:
         ref: line:73
   - id: politicien
     name: Politicien
+    status: active
     orientation_id: intellectuel
     primary_skill_id: politique
     primary_skill_choice: fixed
@@ -553,6 +613,7 @@ classes:
         ref: line:74
   - id: precepteur
     name: Précepteur
+    status: active
     orientation_id: intellectuel
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -562,6 +623,7 @@ classes:
         ref: line:75
   - id: scribe
     name: Scribe
+    status: active
     orientation_id: intellectuel
     primary_skill_id: redaction
     primary_skill_choice: fixed
@@ -571,6 +633,7 @@ classes:
         ref: line:76
   - id: abjurateur
     name: Abjurateur
+    status: active
     orientation_id: magicien
     primary_skill_id: null
     primary_skill_choice: magician_no_primary
@@ -580,6 +643,7 @@ classes:
         ref: line:78
   - id: alterateur
     name: Altérateur
+    status: active
     orientation_id: magicien
     primary_skill_id: null
     primary_skill_choice: magician_no_primary
@@ -589,6 +653,7 @@ classes:
         ref: line:79
   - id: chaman
     name: Chaman
+    status: active
     orientation_id: magicien
     primary_skill_id: null
     primary_skill_choice: magician_no_primary
@@ -598,6 +663,7 @@ classes:
         ref: line:80
   - id: clerc
     name: Clerc
+    status: active
     orientation_id: magicien
     primary_skill_id: null
     primary_skill_choice: magician_no_primary
@@ -607,6 +673,7 @@ classes:
         ref: line:81
   - id: devin
     name: Devin
+    status: active
     orientation_id: magicien
     primary_skill_id: null
     primary_skill_choice: magician_no_primary
@@ -616,6 +683,7 @@ classes:
         ref: line:82
   - id: druide
     name: Druide
+    status: active
     orientation_id: magicien
     primary_skill_id: null
     primary_skill_choice: magician_no_primary
@@ -625,6 +693,7 @@ classes:
         ref: line:83
   - id: elementaliste
     name: Elémentaliste
+    status: active
     orientation_id: magicien
     primary_skill_id: null
     primary_skill_choice: magician_no_primary
@@ -634,6 +703,7 @@ classes:
         ref: line:84
   - id: enchanteur
     name: Enchanteur
+    status: active
     orientation_id: magicien
     primary_skill_id: null
     primary_skill_choice: magician_no_primary
@@ -643,6 +713,7 @@ classes:
         ref: line:85
   - id: illusionniste
     name: Illusionniste
+    status: active
     orientation_id: magicien
     primary_skill_id: null
     primary_skill_choice: magician_no_primary
@@ -652,6 +723,7 @@ classes:
         ref: line:86
   - id: invocateur
     name: Invocateur
+    status: active
     orientation_id: magicien
     primary_skill_id: null
     primary_skill_choice: magician_no_primary
@@ -661,6 +733,7 @@ classes:
         ref: line:87
   - id: necromancien
     name: Nécromancien
+    status: active
     orientation_id: magicien
     primary_skill_id: null
     primary_skill_choice: magician_no_primary
@@ -670,6 +743,7 @@ classes:
         ref: line:88
   - id: sorcier
     name: Sorcier
+    status: active
     orientation_id: magicien
     primary_skill_id: null
     primary_skill_choice: magician_no_primary
@@ -679,6 +753,7 @@ classes:
         ref: line:89
   - id: bucheron
     name: Bûcheron
+    status: active
     orientation_id: ouvrier
     primary_skill_id: bucheronnage
     primary_skill_choice: fixed
@@ -688,6 +763,7 @@ classes:
         ref: line:91
   - id: agriculteur
     name: Agriculteur
+    status: active
     orientation_id: paysan
     primary_skill_id: agriculture
     primary_skill_choice: fixed
@@ -697,6 +773,7 @@ classes:
         ref: line:93
   - id: apiculteur
     name: Apiculteur
+    status: active
     orientation_id: paysan
     primary_skill_id: apiculture
     primary_skill_choice: fixed
@@ -706,6 +783,7 @@ classes:
         ref: line:94
   - id: berger
     name: Berger
+    status: active
     orientation_id: paysan
     primary_skill_id: elevage-de-moutons
     primary_skill_choice: fixed
@@ -715,6 +793,7 @@ classes:
         ref: line:95
   - id: chevrier
     name: Chevrier
+    status: active
     orientation_id: paysan
     primary_skill_id: elevage-de-chevres
     primary_skill_choice: fixed
@@ -724,6 +803,7 @@ classes:
         ref: line:96
   - id: eleveur-de-bovides
     name: Eleveur de bovidés
+    status: active
     orientation_id: paysan
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -733,6 +813,7 @@ classes:
         ref: line:97
   - id: eleveur-de-volailles
     name: Eleveur de volailles
+    status: active
     orientation_id: paysan
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -742,6 +823,7 @@ classes:
         ref: line:98
   - id: porcher
     name: Porcher
+    status: active
     orientation_id: paysan
     primary_skill_id: elevage-de-porcs
     primary_skill_choice: fixed
@@ -751,6 +833,7 @@ classes:
         ref: line:99
   - id: exorciste
     name: Exorciste
+    status: active
     orientation_id: religieux
     primary_skill_id: exorcisme
     primary_skill_choice: fixed
@@ -760,6 +843,7 @@ classes:
         ref: line:101
   - id: inquisiteur
     name: Inquisiteur
+    status: active
     orientation_id: religieux
     primary_skill_id: theologie
     primary_skill_choice: fixed
@@ -769,6 +853,7 @@ classes:
         ref: line:102
   - id: pretre
     name: Prêtre
+    status: active
     orientation_id: religieux
     primary_skill_id: theologie
     primary_skill_choice: fixed
@@ -778,6 +863,7 @@ classes:
         ref: line:103
   - id: eclaireur
     name: Eclaireur
+    status: active
     orientation_id: voyageur
     primary_skill_id: observation-du-terrain
     primary_skill_choice: fixed
@@ -787,6 +873,7 @@ classes:
         ref: line:105
   - id: navigateur
     name: Navigateur
+    status: active
     orientation_id: voyageur
     primary_skill_id: navigation
     primary_skill_choice: fixed
@@ -796,6 +883,7 @@ classes:
         ref: line:106
   - id: pirate
     name: Pirate
+    status: active
     orientation_id: voyageur
     primary_skill_id: null
     primary_skill_choice: player_choice
@@ -805,6 +893,7 @@ classes:
         ref: line:107
   - id: ranger
     name: Ranger
+    status: active
     orientation_id: voyageur
     primary_skill_id: chasse
     primary_skill_choice: fixed
@@ -814,6 +903,7 @@ classes:
         ref: line:108
   - id: rodeur
     name: Rôdeur
+    status: active
     orientation_id: voyageur
     primary_skill_id: chasse
     primary_skill_choice: fixed

--- a/data/catalogs/competences.yaml
+++ b/data/catalogs/competences.yaml
@@ -14,6 +14,7 @@ metadata:
 skills:
   - id: calligraphie
     name: Calligraphie
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -25,6 +26,7 @@ skills:
       source: web-canonical
   - id: chant
     name: Chant
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -36,6 +38,7 @@ skills:
       source: web-canonical
   - id: berceuse
     name: Berceuse
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -47,6 +50,7 @@ skills:
       source: web-canonical
   - id: opera
     name: Opéra
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -58,6 +62,7 @@ skills:
       source: web-canonical
   - id: comedie
     name: Comédie
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -69,6 +74,7 @@ skills:
       source: web-canonical
   - id: mensonge
     name: Mensonge
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -80,6 +86,7 @@ skills:
       source: web-canonical
   - id: conduite-d-attelage
     name: Conduite d'attelage
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -91,6 +98,7 @@ skills:
       source: web-canonical
   - id: conte
     name: Conte
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -102,6 +110,7 @@ skills:
       source: web-canonical
   - id: danse
     name: Danse
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -113,6 +122,7 @@ skills:
       source: web-canonical
   - id: mutchka-putchka
     name: Mutchka Putchka
+    status: active
     family: art
     family_name: Art
     parent_id: danse
@@ -124,6 +134,7 @@ skills:
       source: web-canonical
   - id: dessin
     name: Dessin
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -135,6 +146,7 @@ skills:
       source: web-canonical
   - id: flute
     name: Flûte
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -146,6 +158,7 @@ skills:
       source: web-canonical
   - id: flute-de-pan
     name: Flûte de pan
+    status: active
     family: art
     family_name: Art
     parent_id: flute
@@ -157,6 +170,7 @@ skills:
       source: web-canonical
   - id: flute-traversiere
     name: Flûte traversière
+    status: active
     family: art
     family_name: Art
     parent_id: flute
@@ -168,6 +182,7 @@ skills:
       source: web-canonical
   - id: gravure
     name: Gravure
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -179,6 +194,7 @@ skills:
       source: web-canonical
   - id: guitare
     name: Guitare
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -190,6 +206,7 @@ skills:
       source: web-canonical
   - id: harpe
     name: Harpe
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -201,6 +218,7 @@ skills:
       source: web-canonical
   - id: orgue
     name: Orgue
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -212,6 +230,7 @@ skills:
       source: web-canonical
   - id: peinture
     name: Peinture
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -223,6 +242,7 @@ skills:
       source: web-canonical
   - id: poesie
     name: Poésie
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -234,6 +254,7 @@ skills:
       source: web-canonical
   - id: prestidigitation
     name: Prestidigitation
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -245,6 +266,7 @@ skills:
       source: web-canonical
   - id: redaction
     name: Rédaction
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -256,6 +278,7 @@ skills:
       source: web-canonical
   - id: sculpture
     name: Sculpture
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -267,6 +290,7 @@ skills:
       source: web-canonical
   - id: tambour
     name: Tambour
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -278,6 +302,7 @@ skills:
       source: web-canonical
   - id: trompette
     name: Trompette
+    status: active
     family: art
     family_name: Art
     parent_id: null
@@ -289,6 +314,7 @@ skills:
       source: web-canonical
   - id: bijouterie
     name: Bijouterie
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -300,6 +326,7 @@ skills:
       source: web-canonical
   - id: charpenterie
     name: Charpenterie
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -311,6 +338,7 @@ skills:
       source: web-canonical
   - id: charpenterie-navale
     name: Charpenterie navale
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: charpenterie
@@ -322,6 +350,7 @@ skills:
       source: web-canonical
   - id: cordonnerie
     name: Cordonnerie
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -333,6 +362,7 @@ skills:
       source: web-canonical
   - id: couture
     name: Couture
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -344,6 +374,7 @@ skills:
       source: web-canonical
   - id: broderie
     name: Broderie
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -355,6 +386,7 @@ skills:
       source: web-canonical
   - id: couture-de-robe
     name: Couture de robe
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: couture
@@ -366,6 +398,7 @@ skills:
       source: web-canonical
   - id: rapiecage
     name: Rapiéçage
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -377,6 +410,7 @@ skills:
       source: web-canonical
   - id: facture-d-arc
     name: Facture d'arc
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -388,6 +422,7 @@ skills:
       source: web-canonical
   - id: facture-de-fleche
     name: Facture de flèche
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -399,6 +434,7 @@ skills:
       source: web-canonical
   - id: facture-de-tonneau
     name: Facture de tonneau
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -410,6 +446,7 @@ skills:
       source: web-canonical
   - id: forge
     name: Forge
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -421,6 +458,7 @@ skills:
       source: web-canonical
   - id: menuiserie
     name: Menuiserie
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -432,6 +470,7 @@ skills:
       source: web-canonical
   - id: poterie
     name: Poterie
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -443,6 +482,7 @@ skills:
       source: web-canonical
   - id: serrurerie
     name: Serrurerie
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -454,6 +494,7 @@ skills:
       source: web-canonical
   - id: tannage
     name: Tannage
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -465,6 +506,7 @@ skills:
       source: web-canonical
   - id: vannerie
     name: Vannerie
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -476,6 +518,7 @@ skills:
       source: web-canonical
   - id: verrerie
     name: Verrerie
+    status: active
     family: artisanat
     family_name: Artisanat
     parent_id: null
@@ -487,6 +530,7 @@ skills:
       source: web-canonical
   - id: arbalete
     name: Arbalète
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -498,6 +542,7 @@ skills:
       source: web-canonical
   - id: archerie
     name: Archerie
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -509,6 +554,7 @@ skills:
       source: web-canonical
   - id: arc-court
     name: Arc court
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -520,6 +566,7 @@ skills:
       source: web-canonical
   - id: arc-long
     name: Arc long
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -531,6 +578,7 @@ skills:
       source: web-canonical
   - id: tir-dans-la-gorge
     name: Tir dans la gorge
+    status: active
     family: combat
     family_name: Combat
     parent_id: arc-long
@@ -542,6 +590,7 @@ skills:
       source: web-canonical
   - id: tir-dans-la-tete
     name: Tir dans la tête
+    status: active
     family: combat
     family_name: Combat
     parent_id: arc-long
@@ -553,6 +602,7 @@ skills:
       source: web-canonical
   - id: tir-en-mouvement
     name: Tir en mouvement
+    status: active
     family: combat
     family_name: Combat
     parent_id: arc-long
@@ -564,6 +614,7 @@ skills:
       source: web-canonical
   - id: tir-monte
     name: Tir monté
+    status: active
     family: combat
     family_name: Combat
     parent_id: arc-long
@@ -575,6 +626,7 @@ skills:
       source: web-canonical
   - id: tir-sur-cible-mouvante
     name: Tir sur cible mouvante
+    status: active
     family: combat
     family_name: Combat
     parent_id: arc-long
@@ -586,6 +638,7 @@ skills:
       source: web-canonical
   - id: bouclier
     name: Bouclier
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -597,6 +650,7 @@ skills:
       source: web-canonical
   - id: charge-au-bouclier
     name: Charge au bouclier
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -608,6 +662,7 @@ skills:
       source: web-canonical
   - id: parade-au-bouclier
     name: Parade au bouclier
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -619,6 +674,7 @@ skills:
       source: web-canonical
   - id: baton
     name: Bâton
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -630,6 +686,7 @@ skills:
       source: web-canonical
   - id: combat-a-mains-nues
     name: Combat à mains nues
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -641,6 +698,7 @@ skills:
       source: web-canonical
   - id: clef-de-bras
     name: Clef de bras
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -652,6 +710,7 @@ skills:
       source: web-canonical
   - id: coup-de-coude
     name: Coup de coude
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -663,6 +722,7 @@ skills:
       source: web-canonical
   - id: coup-de-genou
     name: Coup de genou
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -674,6 +734,7 @@ skills:
       source: web-canonical
   - id: coup-de-pied
     name: Coup de pied
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -685,6 +746,7 @@ skills:
       source: web-canonical
   - id: coup-de-pied-frontal
     name: Coup de pied frontal
+    status: active
     family: combat
     family_name: Combat
     parent_id: coup-de-pied
@@ -696,6 +758,7 @@ skills:
       source: web-canonical
   - id: coup-de-pied-retourne
     name: Coup de pied retourné
+    status: active
     family: combat
     family_name: Combat
     parent_id: coup-de-pied
@@ -707,6 +770,7 @@ skills:
       source: web-canonical
   - id: coup-de-pied-saute
     name: Coup de pied sauté
+    status: active
     family: combat
     family_name: Combat
     parent_id: coup-de-pied
@@ -718,6 +782,7 @@ skills:
       source: web-canonical
   - id: fauchage
     name: Fauchage
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -729,6 +794,7 @@ skills:
       source: web-canonical
   - id: coup-de-poing
     name: Coup de poing
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -740,6 +806,7 @@ skills:
       source: web-canonical
   - id: crochet
     name: Crochet
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -751,6 +818,7 @@ skills:
       source: web-canonical
   - id: direct
     name: Direct
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -762,6 +830,7 @@ skills:
       source: web-canonical
   - id: uppercut
     name: Uppercut
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -773,6 +842,7 @@ skills:
       source: web-canonical
   - id: coup-de-queue
     name: Coup de queue
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -784,6 +854,7 @@ skills:
       source: web-canonical
   - id: desarmement
     name: Désarmement
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -795,6 +866,7 @@ skills:
       source: web-canonical
   - id: esquive
     name: Esquive
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -806,6 +878,7 @@ skills:
       source: web-canonical
   - id: esquive-baissee
     name: Esquive baissée
+    status: active
     family: combat
     family_name: Combat
     parent_id: esquive
@@ -817,6 +890,7 @@ skills:
       source: web-canonical
   - id: esquive-sautee
     name: Esquive sautée
+    status: active
     family: combat
     family_name: Combat
     parent_id: esquive
@@ -828,6 +902,7 @@ skills:
       source: web-canonical
   - id: giffle
     name: Giffle
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -839,6 +914,7 @@ skills:
       source: web-canonical
   - id: griffure
     name: Griffure
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -850,6 +926,7 @@ skills:
       source: web-canonical
   - id: morsure
     name: Morsure
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -861,6 +938,7 @@ skills:
       source: web-canonical
   - id: couteau-de-lancer
     name: Couteau de lancer
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -872,6 +950,7 @@ skills:
       source: web-canonical
   - id: lance-dans-l-epaule
     name: Lancé dans l'épaule
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -883,6 +962,7 @@ skills:
       source: web-canonical
   - id: lance-dans-la-gorge
     name: Lancé dans la gorge
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -894,6 +974,7 @@ skills:
       source: web-canonical
   - id: lance-dans-la-jambe
     name: Lancé dans la jambe
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -905,6 +986,7 @@ skills:
       source: web-canonical
   - id: lance-dans-la-main
     name: Lancé dans la main
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -916,6 +998,7 @@ skills:
       source: web-canonical
   - id: lance-dans-la-tete
     name: Lancé dans la tête
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -927,6 +1010,7 @@ skills:
       source: web-canonical
   - id: dague
     name: Dague
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -938,6 +1022,7 @@ skills:
       source: web-canonical
   - id: epee
     name: Epée
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -949,6 +1034,7 @@ skills:
       source: web-canonical
   - id: cimeterre
     name: Cimeterre
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -960,6 +1046,7 @@ skills:
       source: web-canonical
   - id: epee-batarde
     name: Epée bâtarde
+    status: active
     family: combat
     family_name: Combat
     parent_id: epee
@@ -971,6 +1058,7 @@ skills:
       source: web-canonical
   - id: frappe-a-la-gorge
     name: Frappe à la gorge
+    status: active
     family: combat
     family_name: Combat
     parent_id: epee-batarde
@@ -982,6 +1070,7 @@ skills:
       source: web-canonical
   - id: frappe-a-la-tete
     name: Frappe à la tête
+    status: active
     family: combat
     family_name: Combat
     parent_id: epee-batarde
@@ -993,6 +1082,7 @@ skills:
       source: web-canonical
   - id: parade
     name: Parade
+    status: active
     family: combat
     family_name: Combat
     parent_id: epee-batarde
@@ -1004,6 +1094,7 @@ skills:
       source: web-canonical
   - id: epee-a-deux-mains
     name: Epée à deux mains
+    status: active
     family: combat
     family_name: Combat
     parent_id: epee
@@ -1015,6 +1106,7 @@ skills:
       source: web-canonical
   - id: epee-a-une-main
     name: Epée à une main
+    status: active
     family: combat
     family_name: Combat
     parent_id: epee
@@ -1026,6 +1118,7 @@ skills:
       source: web-canonical
   - id: parade-combat-1
     name: Parade
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1037,6 +1130,7 @@ skills:
       source: web-canonical
   - id: katana
     name: Katana
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1048,6 +1142,7 @@ skills:
       source: web-canonical
   - id: sabre
     name: Sabre
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1059,6 +1154,7 @@ skills:
       source: web-canonical
   - id: fouet
     name: Fouet
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1070,6 +1166,7 @@ skills:
       source: web-canonical
   - id: fronde
     name: Fronde
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1081,6 +1178,7 @@ skills:
       source: web-canonical
   - id: hache
     name: Hache
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1092,6 +1190,7 @@ skills:
       source: web-canonical
   - id: hachette
     name: Hachette
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1103,6 +1202,7 @@ skills:
       source: web-canonical
   - id: hallebarde
     name: Hallebarde
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1114,6 +1214,7 @@ skills:
       source: web-canonical
   - id: javelot
     name: Javelot
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1125,6 +1226,7 @@ skills:
       source: web-canonical
   - id: kunai
     name: Kunai
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1136,6 +1238,7 @@ skills:
       source: web-canonical
   - id: lance
     name: Lance
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1147,6 +1250,7 @@ skills:
       source: web-canonical
   - id: lance-pierre
     name: Lance-pierre
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1158,6 +1262,7 @@ skills:
       source: web-canonical
   - id: main-gauche
     name: Main gauche
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1169,6 +1274,7 @@ skills:
       source: web-canonical
   - id: marteau-de-guerre
     name: Marteau de guerre
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1180,6 +1286,7 @@ skills:
       source: web-canonical
   - id: frappe-a-la-tete-marteau-de-guerre
     name: Frappe à la tête
+    status: active
     family: combat
     family_name: Combat
     parent_id: marteau-de-guerre
@@ -1191,6 +1298,7 @@ skills:
       source: web-canonical
   - id: parade-marteau-de-guerre
     name: Parade
+    status: active
     family: combat
     family_name: Combat
     parent_id: marteau-de-guerre
@@ -1202,6 +1310,7 @@ skills:
       source: web-canonical
   - id: masse-d-arme
     name: Masse d'arme
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1213,6 +1322,7 @@ skills:
       source: web-canonical
   - id: frappe-dans-le-torse
     name: Frappe dans le torse
+    status: active
     family: combat
     family_name: Combat
     parent_id: masse-d-arme
@@ -1224,6 +1334,7 @@ skills:
       source: web-canonical
   - id: frappe-dans-les-jambes
     name: Frappe dans les jambes
+    status: active
     family: combat
     family_name: Combat
     parent_id: masse-d-arme
@@ -1235,6 +1346,7 @@ skills:
       source: web-canonical
   - id: frappe-a-la-main
     name: Frappe à la main
+    status: active
     family: combat
     family_name: Combat
     parent_id: masse-d-arme
@@ -1246,6 +1358,7 @@ skills:
       source: web-canonical
   - id: frappe-a-la-tete-masse-d-arme
     name: Frappe à la tête
+    status: active
     family: combat
     family_name: Combat
     parent_id: masse-d-arme
@@ -1257,6 +1370,7 @@ skills:
       source: web-canonical
   - id: poignard
     name: Poignard
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1268,6 +1382,7 @@ skills:
       source: web-canonical
   - id: sarbacane
     name: Sarbacane
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1279,6 +1394,7 @@ skills:
       source: web-canonical
   - id: shuriken
     name: Shuriken
+    status: active
     family: combat
     family_name: Combat
     parent_id: null
@@ -1290,6 +1406,7 @@ skills:
       source: web-canonical
   - id: alchimie
     name: Alchimie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1301,6 +1418,7 @@ skills:
       source: web-canonical
   - id: alphabetisation
     name: Alphabetisation
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1312,6 +1430,7 @@ skills:
       source: web-canonical
   - id: ecriture
     name: Ecriture
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1323,6 +1442,7 @@ skills:
       source: web-canonical
   - id: lecture
     name: Lecture
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1334,6 +1454,7 @@ skills:
       source: web-canonical
   - id: alphabetisation-connaissance-1
     name: Alphabetisation
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1345,6 +1466,7 @@ skills:
       source: web-canonical
   - id: alphabetisation-connaissance-2
     name: Alphabetisation
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1356,6 +1478,7 @@ skills:
       source: web-canonical
   - id: arcanologie
     name: Arcanologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1367,6 +1490,7 @@ skills:
       source: web-canonical
   - id: arcanologie-abjuratrice
     name: Arcanologie abjuratrice
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1378,6 +1502,7 @@ skills:
       source: web-canonical
   - id: arcanologie-alteratrice
     name: Arcanologie altératrice
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1389,6 +1514,7 @@ skills:
       source: web-canonical
   - id: arcanologie-ancienne
     name: Arcanologie ancienne
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1400,6 +1526,7 @@ skills:
       source: web-canonical
   - id: arcanologie-blanche
     name: Arcanologie blanche
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1411,6 +1538,7 @@ skills:
       source: web-canonical
   - id: arcanologie-chaotique
     name: Arcanologie chaotique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1422,6 +1550,7 @@ skills:
       source: web-canonical
   - id: arcanologie-conceptuelle
     name: Arcanologie conceptuelle
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1433,6 +1562,7 @@ skills:
       source: web-canonical
   - id: arcanologie-des-cibles-non-communes
     name: Arcanologie des cibles non-communes
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1444,6 +1574,7 @@ skills:
       source: web-canonical
   - id: arcanologie-des-rituels
     name: Arcanologie des rituels
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1455,6 +1586,7 @@ skills:
       source: web-canonical
   - id: arcanologie-divinatoire
     name: Arcanologie divinatoire
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1466,6 +1598,7 @@ skills:
       source: web-canonical
   - id: arcanologie-enchanteresse
     name: Arcanologie enchanteresse
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1477,6 +1610,7 @@ skills:
       source: web-canonical
   - id: arcanologie-illusoire
     name: Arcanologie illusoire
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1488,6 +1622,7 @@ skills:
       source: web-canonical
   - id: arcanologie-invocatrice
     name: Arcanologie invocatrice
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1499,6 +1634,7 @@ skills:
       source: web-canonical
   - id: arcanologie-naturelle
     name: Arcanologie naturelle
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1510,6 +1646,7 @@ skills:
       source: web-canonical
   - id: arcanologie-noire
     name: Arcanologie noire
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1521,6 +1658,7 @@ skills:
       source: web-canonical
   - id: arcanologie-necromantique
     name: Arcanologie nécromantique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1532,6 +1670,7 @@ skills:
       source: web-canonical
   - id: arcanologie-elementaliste
     name: Arcanologie élémentaliste
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1543,6 +1682,7 @@ skills:
       source: web-canonical
   - id: arcanologie-energetique
     name: Arcanologie énergétique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: arcanologie
@@ -1554,6 +1694,7 @@ skills:
       source: web-canonical
   - id: identification-de-sort
     name: Identification de sort
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1565,6 +1706,7 @@ skills:
       source: web-canonical
   - id: architecture
     name: Architecture
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1576,6 +1718,7 @@ skills:
       source: web-canonical
   - id: astronomie
     name: Astronomie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1587,6 +1730,7 @@ skills:
       source: web-canonical
   - id: balistique
     name: Balistique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1598,6 +1742,7 @@ skills:
       source: web-canonical
   - id: botanique
     name: Botanique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1609,6 +1754,7 @@ skills:
       source: web-canonical
   - id: dendrologie
     name: Dendrologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1620,6 +1766,7 @@ skills:
       source: web-canonical
   - id: herbologie
     name: Herbologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1631,6 +1778,7 @@ skills:
       source: web-canonical
   - id: phycologie
     name: Phycologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1642,6 +1790,7 @@ skills:
       source: web-canonical
   - id: pomoligie
     name: Pomoligie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1653,6 +1802,7 @@ skills:
       source: web-canonical
   - id: cartographie
     name: Cartographie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1664,6 +1814,7 @@ skills:
       source: web-canonical
   - id: connaissance-des-armes
     name: Connaissance des armes
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1675,6 +1826,7 @@ skills:
       source: web-canonical
   - id: cryptologie
     name: Cryptologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1686,6 +1838,7 @@ skills:
       source: web-canonical
   - id: droit
     name: Droit
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1697,6 +1850,7 @@ skills:
       source: web-canonical
   - id: droit-aderandais
     name: Droit aderandais
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: droit
@@ -1708,6 +1862,7 @@ skills:
       source: web-canonical
   - id: droit-alterien
     name: Droit altérien
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: droit
@@ -1719,6 +1874,7 @@ skills:
       source: web-canonical
   - id: droit-cortegan
     name: Droit cortegan
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: droit
@@ -1730,6 +1886,7 @@ skills:
       source: web-canonical
   - id: droit-nordique
     name: Droit nordique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: droit
@@ -1741,6 +1898,7 @@ skills:
       source: web-canonical
   - id: economie
     name: Economie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1752,6 +1910,7 @@ skills:
       source: web-canonical
   - id: ethnologie
     name: Ethnologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1763,6 +1922,7 @@ skills:
       source: web-canonical
   - id: connaissance-des-coutumes
     name: Connaissance des coutumes
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1774,6 +1934,7 @@ skills:
       source: web-canonical
   - id: connaissance-des-traditions
     name: Connaissance des traditions
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1785,6 +1946,7 @@ skills:
       source: web-canonical
   - id: exorcisme
     name: Exorcisme
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1796,6 +1958,7 @@ skills:
       source: web-canonical
   - id: gemmologie
     name: Gemmologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1807,6 +1970,7 @@ skills:
       source: web-canonical
   - id: graphologie
     name: Graphologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1818,6 +1982,7 @@ skills:
       source: web-canonical
   - id: geographie
     name: Géographie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1829,6 +1994,7 @@ skills:
       source: web-canonical
   - id: geographie-alterienne
     name: Géographie altérienne
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: geographie
@@ -1840,6 +2006,7 @@ skills:
       source: web-canonical
   - id: geographie-du-monde-sombre
     name: Géographie du Monde Sombre
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: geographie
@@ -1851,6 +2018,7 @@ skills:
       source: web-canonical
   - id: geographie-irtanienne
     name: Géographie irtanienne
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: geographie
@@ -1862,6 +2030,7 @@ skills:
       source: web-canonical
   - id: histoire
     name: Histoire
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1873,6 +2042,7 @@ skills:
       source: web-canonical
   - id: histoire-de-l-art
     name: Histoire de l'art
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: histoire
@@ -1884,6 +2054,7 @@ skills:
       source: web-canonical
   - id: numismatique
     name: Numismatique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1895,6 +2066,7 @@ skills:
       source: web-canonical
   - id: heraldique
     name: Héraldique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1906,6 +2078,7 @@ skills:
       source: web-canonical
   - id: heraldique-alterien
     name: Héraldique altérien
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: heraldique
@@ -1917,6 +2090,7 @@ skills:
       source: web-canonical
   - id: langage-alterien
     name: Langage altérien
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1928,6 +2102,7 @@ skills:
       source: web-canonical
   - id: langage-carenien
     name: Langage carénien
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1939,6 +2114,7 @@ skills:
       source: web-canonical
   - id: langage-cortegan
     name: Langage cortegan
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1950,6 +2126,7 @@ skills:
       source: web-canonical
   - id: langage-dundorien
     name: Langage dundorien
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1961,6 +2138,7 @@ skills:
       source: web-canonical
   - id: langage-elfique
     name: Langage elfique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1972,6 +2150,7 @@ skills:
       source: web-canonical
   - id: langue-sombre
     name: Langue sombre
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1983,6 +2162,7 @@ skills:
       source: web-canonical
   - id: langage-enorien
     name: Langage enorien
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -1994,6 +2174,7 @@ skills:
       source: web-canonical
   - id: langage-imperial
     name: Langage impérial
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2005,6 +2186,7 @@ skills:
       source: web-canonical
   - id: langage-irtanien
     name: Langage irtanien
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2016,6 +2198,7 @@ skills:
       source: web-canonical
   - id: langage-nordique
     name: Langage nordique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2027,6 +2210,7 @@ skills:
       source: web-canonical
   - id: langage-onarien
     name: Langage onarien
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2038,6 +2222,7 @@ skills:
       source: web-canonical
   - id: langage-yonnen
     name: Langage yonnen
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2049,6 +2234,7 @@ skills:
       source: web-canonical
   - id: langue-verte
     name: Langue verte
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2060,6 +2246,7 @@ skills:
       source: web-canonical
   - id: lingua-mortis
     name: Lingua Mortis
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2071,6 +2258,7 @@ skills:
       source: web-canonical
   - id: mathematique
     name: Mathématique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2082,6 +2270,7 @@ skills:
       source: web-canonical
   - id: algebre
     name: Algèbre
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2093,6 +2282,7 @@ skills:
       source: web-canonical
   - id: trigonometrie
     name: Trigonométrie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2104,6 +2294,7 @@ skills:
       source: web-canonical
   - id: musicologie
     name: Musicologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2115,6 +2306,7 @@ skills:
       source: web-canonical
   - id: organologie
     name: Organologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2126,6 +2318,7 @@ skills:
       source: web-canonical
   - id: solfege
     name: Solfège
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2137,6 +2330,7 @@ skills:
       source: web-canonical
   - id: mycologie
     name: Mycologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2148,6 +2342,7 @@ skills:
       source: web-canonical
   - id: oenologie
     name: Oenologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2159,6 +2354,7 @@ skills:
       source: web-canonical
   - id: olfactologie
     name: Olfactologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2170,6 +2366,7 @@ skills:
       source: web-canonical
   - id: philosophie
     name: Philosophie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2181,6 +2378,7 @@ skills:
       source: web-canonical
   - id: politique
     name: Politique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2192,6 +2390,7 @@ skills:
       source: web-canonical
   - id: diplomatie
     name: Diplomatie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2203,6 +2402,7 @@ skills:
       source: web-canonical
   - id: negociation-diplomatique
     name: Négociation diplomatique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2214,6 +2414,7 @@ skills:
       source: web-canonical
   - id: gestion-des-ressources
     name: Gestion des ressources
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2225,6 +2426,7 @@ skills:
       source: web-canonical
   - id: psychologie
     name: Psychologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2236,6 +2438,7 @@ skills:
       source: web-canonical
   - id: detection-du-mensonge
     name: Détection du mensonge
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2247,6 +2450,7 @@ skills:
       source: web-canonical
   - id: manipulation
     name: Manipulation
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2258,6 +2462,7 @@ skills:
       source: web-canonical
   - id: psychologie-elfique
     name: Psychologie elfique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: psychologie
@@ -2269,6 +2474,7 @@ skills:
       source: web-canonical
   - id: psychologie-elfe-sombre
     name: Psychologie elfe sombre
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: psychologie
@@ -2280,6 +2486,7 @@ skills:
       source: web-canonical
   - id: psychologie-humaine
     name: Psychologie humaine
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: psychologie
@@ -2291,6 +2498,7 @@ skills:
       source: web-canonical
   - id: sociologie
     name: Sociologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2302,6 +2510,7 @@ skills:
       source: web-canonical
   - id: sociologie-dundorienne
     name: Sociologie dundorienne
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: sociologie
@@ -2313,6 +2522,7 @@ skills:
       source: web-canonical
   - id: strategie-millitaire
     name: Stratégie millitaire
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2324,6 +2534,7 @@ skills:
       source: web-canonical
   - id: semiologie
     name: Sémiologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2335,6 +2546,7 @@ skills:
       source: web-canonical
   - id: theologie
     name: Théologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2346,6 +2558,7 @@ skills:
       source: web-canonical
   - id: theologie-ancestrale
     name: Théologie ancestrâle
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: theologie
@@ -2357,6 +2570,7 @@ skills:
       source: web-canonical
   - id: runologie-ancestrale
     name: Runologie ancestrâle
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2368,6 +2582,7 @@ skills:
       source: web-canonical
   - id: theologie-du-dieu-unique
     name: Théologie du Dieu Unique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: theologie
@@ -2379,6 +2594,7 @@ skills:
       source: web-canonical
   - id: angelologie
     name: Angélologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2390,6 +2606,7 @@ skills:
       source: web-canonical
   - id: connaissance-des-saintes-ecritures
     name: Connaissance des Saintes Ecritures
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2401,6 +2618,7 @@ skills:
       source: web-canonical
   - id: demonologie
     name: Démonologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2412,6 +2630,7 @@ skills:
       source: web-canonical
   - id: theologie-elfique
     name: Théologie elfique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: theologie
@@ -2423,6 +2642,7 @@ skills:
       source: web-canonical
   - id: culte-de-meliokyss
     name: Culte de Meliokyss
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2434,6 +2654,7 @@ skills:
       source: web-canonical
   - id: culte-de-sarh
     name: Culte de Sarh
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2445,6 +2666,7 @@ skills:
       source: web-canonical
   - id: theologie-nordique
     name: Théologie nordique
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: theologie
@@ -2456,6 +2678,7 @@ skills:
       source: web-canonical
   - id: runologie-nordiques
     name: Runologie nordiques
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2467,6 +2690,7 @@ skills:
       source: web-canonical
   - id: theologie-paienne
     name: Théologie païenne
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: theologie
@@ -2478,6 +2702,7 @@ skills:
       source: web-canonical
   - id: culte-d-ilis
     name: Culte d'Ilis
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2489,6 +2714,7 @@ skills:
       source: web-canonical
   - id: toxicologie
     name: Toxicologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2500,6 +2726,7 @@ skills:
       source: web-canonical
   - id: mycotoxicologie
     name: Mycotoxicologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2511,6 +2738,7 @@ skills:
       source: web-canonical
   - id: urbanisme
     name: Urbanisme
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2522,6 +2750,7 @@ skills:
       source: web-canonical
   - id: zoologie
     name: Zoologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2533,6 +2762,7 @@ skills:
       source: web-canonical
   - id: arachnologie
     name: Arachnologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2544,6 +2774,7 @@ skills:
       source: web-canonical
   - id: carcinologie
     name: Carcinologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2555,6 +2786,7 @@ skills:
       source: web-canonical
   - id: entomologie
     name: Entomologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2566,6 +2798,7 @@ skills:
       source: web-canonical
   - id: ichtyologie
     name: Ichtyologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2577,6 +2810,7 @@ skills:
       source: web-canonical
   - id: malacologie
     name: Malacologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2588,6 +2822,7 @@ skills:
       source: web-canonical
   - id: ornithologie
     name: Ornithologie
+    status: active
     family: connaissance
     family_name: Connaissance
     parent_id: null
@@ -2599,6 +2834,7 @@ skills:
       source: web-canonical
   - id: dames
     name: Dames
+    status: active
     family: jeu
     family_name: Jeu
     parent_id: null
@@ -2610,6 +2846,7 @@ skills:
       source: web-canonical
   - id: echecs
     name: Echecs
+    status: active
     family: jeu
     family_name: Jeu
     parent_id: null
@@ -2621,6 +2858,7 @@ skills:
       source: web-canonical
   - id: jeu-du-couteau
     name: Jeu du couteau
+    status: active
     family: jeu
     family_name: Jeu
     parent_id: null
@@ -2632,6 +2870,7 @@ skills:
       source: web-canonical
   - id: poker
     name: Poker
+    status: active
     family: jeu
     family_name: Jeu
     parent_id: null
@@ -2643,6 +2882,7 @@ skills:
       source: web-canonical
   - id: apprentissage
     name: Apprentissage
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: null
@@ -2654,6 +2894,7 @@ skills:
       source: web-canonical
   - id: apprentissage-de-la-magie
     name: Apprentissage de la magie
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: apprentissage
@@ -2665,6 +2906,7 @@ skills:
       source: web-canonical
   - id: apprentissage-de-la-musique
     name: Apprentissage de la musique
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: apprentissage
@@ -2676,6 +2918,7 @@ skills:
       source: web-canonical
   - id: apprentissage-des-langues
     name: Apprentissage des langues
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: apprentissage
@@ -2687,6 +2930,7 @@ skills:
       source: web-canonical
   - id: furtivite
     name: Furtivité
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: null
@@ -2698,6 +2942,7 @@ skills:
       source: web-canonical
   - id: camouflage
     name: Camouflage
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: null
@@ -2709,6 +2954,7 @@ skills:
       source: web-canonical
   - id: deplacement-silencieux
     name: Déplacement silencieux
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: null
@@ -2720,6 +2966,7 @@ skills:
       source: web-canonical
   - id: furtivite-en-foret
     name: Furtivité en forêt
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: furtivite
@@ -2731,6 +2978,7 @@ skills:
       source: web-canonical
   - id: furtivite-en-ville
     name: Furtivité en ville
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: furtivite
@@ -2742,6 +2990,7 @@ skills:
       source: web-canonical
   - id: meditation
     name: Méditation
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: null
@@ -2753,6 +3002,7 @@ skills:
       source: web-canonical
   - id: memoire
     name: Mémoire
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: null
@@ -2764,6 +3014,7 @@ skills:
       source: web-canonical
   - id: memoire-des-noms
     name: Mémoire des noms
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: memoire
@@ -2775,6 +3026,7 @@ skills:
       source: web-canonical
   - id: memoire-des-visages
     name: Mémoire des visages
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: memoire
@@ -2786,6 +3038,7 @@ skills:
       source: web-canonical
   - id: stoicisme
     name: Stoïcisme
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: null
@@ -2797,6 +3050,7 @@ skills:
       source: web-canonical
   - id: technique-de-relaxation
     name: Technique de relaxation
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: null
@@ -2808,6 +3062,7 @@ skills:
       source: web-canonical
   - id: yoga
     name: Yoga
+    status: active
     family: maitrise-de-soi
     family_name: Maîtrise de soi
     parent_id: null
@@ -2819,6 +3074,7 @@ skills:
       source: web-canonical
   - id: agriculture
     name: Agriculture
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -2830,6 +3086,7 @@ skills:
       source: web-canonical
   - id: apiculture
     name: Apiculture
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -2841,6 +3098,7 @@ skills:
       source: web-canonical
   - id: bucheronnage
     name: Bûcheronnage
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -2852,6 +3110,7 @@ skills:
       source: web-canonical
   - id: chasse
     name: Chasse
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -2863,6 +3122,7 @@ skills:
       source: web-canonical
   - id: chasse-d-oiseau
     name: Chasse d'oiseau
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: chasse
@@ -2874,6 +3134,7 @@ skills:
       source: web-canonical
   - id: chasse-de-reptile
     name: Chasse de reptile
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: chasse
@@ -2885,6 +3146,7 @@ skills:
       source: web-canonical
   - id: chasse-de-rongeur
     name: Chasse de rongeur
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: chasse
@@ -2896,6 +3158,7 @@ skills:
       source: web-canonical
   - id: traque
     name: Traque
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -2907,6 +3170,7 @@ skills:
       source: web-canonical
   - id: cuisine
     name: Cuisine
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -2918,6 +3182,7 @@ skills:
       source: web-canonical
   - id: cuisine-alterienne
     name: Cuisine alterienne
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: cuisine
@@ -2929,6 +3194,7 @@ skills:
       source: web-canonical
   - id: cuisine-carenienne
     name: Cuisine carénienne
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: cuisine
@@ -2940,6 +3206,7 @@ skills:
       source: web-canonical
   - id: cuisine-corteganne
     name: Cuisine corteganne
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: cuisine
@@ -2951,6 +3218,7 @@ skills:
       source: web-canonical
   - id: cuisine-dundorienne
     name: Cuisine dundorienne
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: cuisine
@@ -2962,6 +3230,7 @@ skills:
       source: web-canonical
   - id: cuisine-irtanienne
     name: Cuisine irtanienne
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: cuisine
@@ -2973,6 +3242,7 @@ skills:
       source: web-canonical
   - id: cuisine-onarienne
     name: Cuisine onarienne
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: cuisine
@@ -2984,6 +3254,7 @@ skills:
       source: web-canonical
   - id: cuisine-yonnienne
     name: Cuisine yonnienne
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: cuisine
@@ -2995,6 +3266,7 @@ skills:
       source: web-canonical
   - id: patisserie
     name: Patisserie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3006,6 +3278,7 @@ skills:
       source: web-canonical
   - id: sandwich
     name: Sandwich
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3017,6 +3290,7 @@ skills:
       source: web-canonical
   - id: dressage
     name: Dressage
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3028,6 +3302,7 @@ skills:
       source: web-canonical
   - id: dressage-de-cheval
     name: Dressage de cheval
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: dressage
@@ -3039,6 +3314,7 @@ skills:
       source: web-canonical
   - id: dressage-de-chien
     name: Dressage de chien
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: dressage
@@ -3050,6 +3326,7 @@ skills:
       source: web-canonical
   - id: elevage-de-bovins
     name: Elevage de bovins
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3061,6 +3338,7 @@ skills:
       source: web-canonical
   - id: elevage-de-chevres
     name: Elevage de chèvres
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3072,6 +3350,7 @@ skills:
       source: web-canonical
   - id: elevage-de-moutons
     name: Elevage de moutons
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3083,6 +3362,7 @@ skills:
       source: web-canonical
   - id: elevage-de-porcs
     name: Elevage de porcs
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3094,6 +3374,7 @@ skills:
       source: web-canonical
   - id: elevage-de-volailes
     name: Elevage de volailes
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3105,6 +3386,7 @@ skills:
       source: web-canonical
   - id: hotellerie
     name: Hôtellerie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3116,6 +3398,7 @@ skills:
       source: web-canonical
   - id: jardinage
     name: Jardinage
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3127,6 +3410,7 @@ skills:
       source: web-canonical
   - id: medecine
     name: Médecine
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3138,6 +3422,7 @@ skills:
       source: web-canonical
   - id: addictologie
     name: Addictologie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3149,6 +3434,7 @@ skills:
       source: web-canonical
   - id: cardiologie
     name: Cardiologie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3160,6 +3446,7 @@ skills:
       source: web-canonical
   - id: chirurgie
     name: Chirurgie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3171,6 +3458,7 @@ skills:
       source: web-canonical
   - id: chirurgie-infantile
     name: Chirurgie infantile
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: chirurgie
@@ -3182,6 +3470,7 @@ skills:
       source: web-canonical
   - id: chirurgie-thoracique
     name: Chirurgie thoracique
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: chirurgie
@@ -3193,6 +3482,7 @@ skills:
       source: web-canonical
   - id: chirurgie-viscerale
     name: Chirurgie viscérale
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: chirurgie
@@ -3204,6 +3494,7 @@ skills:
       source: web-canonical
   - id: odontologie
     name: Odontologie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3215,6 +3506,7 @@ skills:
       source: web-canonical
   - id: ophtalmologie
     name: Ophtalmologie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3226,6 +3518,7 @@ skills:
       source: web-canonical
   - id: sutures
     name: Sutures
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3237,6 +3530,7 @@ skills:
       source: web-canonical
   - id: amputation
     name: Amputation
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3248,6 +3542,7 @@ skills:
       source: web-canonical
   - id: amputation-de-bras
     name: Amputation de bras
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: amputation
@@ -3259,6 +3554,7 @@ skills:
       source: web-canonical
   - id: amputation-de-jambe
     name: Amputation de jambe
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: amputation
@@ -3270,6 +3566,7 @@ skills:
       source: web-canonical
   - id: dermatologie
     name: Dermatologie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3281,6 +3578,7 @@ skills:
       source: web-canonical
   - id: diagnostic
     name: Diagnostic
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3292,6 +3590,7 @@ skills:
       source: web-canonical
   - id: gastroenterologie
     name: Gastroentérologie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3303,6 +3602,7 @@ skills:
       source: web-canonical
   - id: geriatrie
     name: Gériatrie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3314,6 +3614,7 @@ skills:
       source: web-canonical
   - id: medecine-legale
     name: Médecine légale
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: medecine
@@ -3325,6 +3626,7 @@ skills:
       source: web-canonical
   - id: traumatologie
     name: Traumatologie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3336,6 +3638,7 @@ skills:
       source: web-canonical
   - id: medecine-veterinaire
     name: Médecine vétérinaire
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: medecine
@@ -3347,6 +3650,7 @@ skills:
       source: web-canonical
   - id: obstetrique
     name: Obstétrique
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3358,6 +3662,7 @@ skills:
       source: web-canonical
   - id: pansement
     name: Pansement
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3369,6 +3674,7 @@ skills:
       source: web-canonical
   - id: pneumologie
     name: Pneumologie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3380,6 +3686,7 @@ skills:
       source: web-canonical
   - id: pediatrie
     name: Pédiatrie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3391,6 +3698,7 @@ skills:
       source: web-canonical
   - id: rhumatologie
     name: Rhumatologie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3402,6 +3710,7 @@ skills:
       source: web-canonical
   - id: metallurgie
     name: Métallurgie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3413,6 +3722,7 @@ skills:
       source: web-canonical
   - id: metallurgie-des-metaux-precieux
     name: Métallurgie des métaux précieux
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: metallurgie
@@ -3424,6 +3734,7 @@ skills:
       source: web-canonical
   - id: siderurgie
     name: Sidérurgie
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3435,6 +3746,7 @@ skills:
       source: web-canonical
   - id: navigation
     name: Navigation
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3446,6 +3758,7 @@ skills:
       source: web-canonical
   - id: nettoyage
     name: Nettoyage
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3457,6 +3770,7 @@ skills:
       source: web-canonical
   - id: peche
     name: Pêche
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3468,6 +3782,7 @@ skills:
       source: web-canonical
   - id: service
     name: Service
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3479,6 +3794,7 @@ skills:
       source: web-canonical
   - id: sexualite
     name: Sexualité
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3490,6 +3806,7 @@ skills:
       source: web-canonical
   - id: torture
     name: Torture
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3501,6 +3818,7 @@ skills:
       source: web-canonical
   - id: vol-a-la-tire
     name: Vol à la tire
+    status: active
     family: savoir-faire
     family_name: Savoir-faire
     parent_id: null
@@ -3512,6 +3830,7 @@ skills:
       source: web-canonical
   - id: gout
     name: Goût
+    status: active
     family: sens
     family_name: Sens
     parent_id: null
@@ -3523,6 +3842,7 @@ skills:
       source: web-canonical
   - id: odorat
     name: Odorat
+    status: active
     family: sens
     family_name: Sens
     parent_id: null
@@ -3534,6 +3854,7 @@ skills:
       source: web-canonical
   - id: ouie
     name: Ouïe
+    status: active
     family: sens
     family_name: Sens
     parent_id: null
@@ -3545,6 +3866,7 @@ skills:
       source: web-canonical
   - id: touche
     name: Touché
+    status: active
     family: sens
     family_name: Sens
     parent_id: null
@@ -3556,6 +3878,7 @@ skills:
       source: web-canonical
   - id: vue
     name: Vue
+    status: active
     family: sens
     family_name: Sens
     parent_id: null
@@ -3567,6 +3890,7 @@ skills:
       source: web-canonical
   - id: observation-du-terrain
     name: Observation du terrain
+    status: active
     family: sens
     family_name: Sens
     parent_id: null
@@ -3578,6 +3902,7 @@ skills:
       source: web-canonical
   - id: vue-en-foret
     name: Vue en forêt
+    status: active
     family: sens
     family_name: Sens
     parent_id: vue
@@ -3589,6 +3914,7 @@ skills:
       source: web-canonical
   - id: commandement
     name: Commandement
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3600,6 +3926,7 @@ skills:
       source: web-canonical
   - id: commerce
     name: Commerce
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3611,6 +3938,7 @@ skills:
       source: web-canonical
   - id: marchandage
     name: Marchandage
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3622,6 +3950,7 @@ skills:
       source: web-canonical
   - id: marchandage-d-achat
     name: Marchandage d'achat
+    status: active
     family: social
     family_name: Social
     parent_id: marchandage
@@ -3633,6 +3962,7 @@ skills:
       source: web-canonical
   - id: marchandage-de-vente
     name: Marchandage de vente
+    status: active
     family: social
     family_name: Social
     parent_id: marchandage
@@ -3644,6 +3974,7 @@ skills:
       source: web-canonical
   - id: enseignement
     name: Enseignement
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3655,6 +3986,7 @@ skills:
       source: web-canonical
   - id: enseignement-de-l-equitation
     name: Enseignement de l'équitation
+    status: active
     family: social
     family_name: Social
     parent_id: enseignement
@@ -3666,6 +3998,7 @@ skills:
       source: web-canonical
   - id: enseignement-de-la-magie
     name: Enseignement de la magie
+    status: active
     family: social
     family_name: Social
     parent_id: enseignement
@@ -3677,6 +4010,7 @@ skills:
       source: web-canonical
   - id: etiquette
     name: Etiquette
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3688,6 +4022,7 @@ skills:
       source: web-canonical
   - id: etiquette-alterienne
     name: Etiquette altérienne
+    status: active
     family: social
     family_name: Social
     parent_id: etiquette
@@ -3699,6 +4034,7 @@ skills:
       source: web-canonical
   - id: etiquette-carenienne
     name: Etiquette carénienne
+    status: active
     family: social
     family_name: Social
     parent_id: etiquette
@@ -3710,6 +4046,7 @@ skills:
       source: web-canonical
   - id: etiquette-cortegane
     name: Etiquette cortegane
+    status: active
     family: social
     family_name: Social
     parent_id: etiquette
@@ -3721,6 +4058,7 @@ skills:
       source: web-canonical
   - id: etiquette-de-la-table
     name: Etiquette de la table
+    status: active
     family: social
     family_name: Social
     parent_id: etiquette
@@ -3732,6 +4070,7 @@ skills:
       source: web-canonical
   - id: intimidation
     name: Intimidation
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3743,6 +4082,7 @@ skills:
       source: web-canonical
   - id: menace
     name: Menace
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3754,6 +4094,7 @@ skills:
       source: web-canonical
   - id: regard-noir
     name: Regard noir
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3765,6 +4106,7 @@ skills:
       source: web-canonical
   - id: oration
     name: Oration
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3776,6 +4118,7 @@ skills:
       source: web-canonical
   - id: discours-de-foule
     name: Discours de foule
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3787,6 +4130,7 @@ skills:
       source: web-canonical
   - id: provocation
     name: Provocation
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3798,6 +4142,7 @@ skills:
       source: web-canonical
   - id: grimace
     name: Grimace
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3809,6 +4154,7 @@ skills:
       source: web-canonical
   - id: insulte
     name: Insulte
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3820,6 +4166,7 @@ skills:
       source: web-canonical
   - id: reconfort
     name: Réconfort
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3831,6 +4178,7 @@ skills:
       source: web-canonical
   - id: seduction
     name: Séduction
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3842,6 +4190,7 @@ skills:
       source: web-canonical
   - id: oeillade
     name: Oeillade
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3853,6 +4202,7 @@ skills:
       source: web-canonical
   - id: pose-aguicheuse
     name: Pose aguicheuse
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3864,6 +4214,7 @@ skills:
       source: web-canonical
   - id: sourire
     name: Sourire
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3875,6 +4226,7 @@ skills:
       source: web-canonical
   - id: voix-sensuelle
     name: Voix sensuelle
+    status: active
     family: social
     family_name: Social
     parent_id: null
@@ -3886,6 +4238,7 @@ skills:
       source: web-canonical
   - id: bras-de-fer
     name: Bras de fer
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -3897,6 +4250,7 @@ skills:
       source: web-canonical
   - id: course
     name: Course
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -3908,6 +4262,7 @@ skills:
       source: web-canonical
   - id: course-d-endurance
     name: Course d'endurance
+    status: active
     family: sport
     family_name: Sport
     parent_id: course
@@ -3919,6 +4274,7 @@ skills:
       source: web-canonical
   - id: sprint
     name: Sprint
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -3930,6 +4286,7 @@ skills:
       source: web-canonical
   - id: equitation
     name: Equitation
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -3941,6 +4298,7 @@ skills:
       source: web-canonical
   - id: galop
     name: Galop
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -3952,6 +4310,7 @@ skills:
       source: web-canonical
   - id: equitation-sport-1
     name: Equitation
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -3963,6 +4322,7 @@ skills:
       source: web-canonical
   - id: escalade
     name: Escalade
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -3974,6 +4334,7 @@ skills:
       source: web-canonical
   - id: gymnastique
     name: Gymnastique
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -3985,6 +4346,7 @@ skills:
       source: web-canonical
   - id: contorsion
     name: Contorsion
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -3996,6 +4358,7 @@ skills:
       source: web-canonical
   - id: saut
     name: Saut
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -4007,6 +4370,7 @@ skills:
       source: web-canonical
   - id: lutte
     name: Lutte
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -4018,6 +4382,7 @@ skills:
       source: web-canonical
   - id: natation
     name: Natation
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -4029,6 +4394,7 @@ skills:
       source: web-canonical
   - id: apnee
     name: Apnée
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -4040,6 +4406,7 @@ skills:
       source: web-canonical
   - id: surf
     name: Surf
+    status: active
     family: sport
     family_name: Sport
     parent_id: null
@@ -4051,6 +4418,7 @@ skills:
       source: web-canonical
   - id: vol
     name: Vol
+    status: active
     family: sport
     family_name: Sport
     parent_id: null

--- a/data/catalogs/magic-schools.yaml
+++ b/data/catalogs/magic-schools.yaml
@@ -12,6 +12,7 @@ metadata:
 schools:
   - id: abjuration
     name: Abjuration
+    status: active
     source_label: Abjuration
     color: jaune
     specialist_class_id: abjurateur
@@ -22,6 +23,7 @@ schools:
         ref: school:Abjuration
   - id: alteration
     name: Altération
+    status: active
     source_label: Altération
     color: rouge
     specialist_class_id: alterateur
@@ -32,6 +34,7 @@ schools:
         ref: school:Altération
   - id: magie-blanche
     name: Magie blanche
+    status: active
     source_label: Blanche
     color: blanc
     specialist_class_id: clerc
@@ -42,6 +45,7 @@ schools:
         ref: school:Blanche
   - id: divination
     name: Divination
+    status: active
     source_label: Divinatoire
     color: brun
     specialist_class_id: devin
@@ -52,6 +56,7 @@ schools:
         ref: school:Divinatoire
   - id: enchantement
     name: Enchantement
+    status: active
     source_label: Enchantement
     color: turquoise
     specialist_class_id: enchanteur
@@ -62,6 +67,7 @@ schools:
         ref: school:Enchantement
   - id: elementaire
     name: Élémentaire
+    status: active
     source_label: Elémentaire
     color: bleu
     specialist_class_id: elementaliste
@@ -72,6 +78,7 @@ schools:
         ref: school:Elémentaire
   - id: illusion
     name: Illusion
+    status: active
     source_label: Illusion
     color: violet
     specialist_class_id: illusionniste
@@ -82,6 +89,7 @@ schools:
         ref: school:Illusion
   - id: invocation
     name: Invocation
+    status: active
     source_label: Invocation
     color: orange
     specialist_class_id: invocateur
@@ -92,6 +100,7 @@ schools:
         ref: school:Invocation
   - id: magie-naturelle
     name: Magie naturelle
+    status: active
     source_label: Naturelle
     color: vert
     specialist_class_id: druide
@@ -102,6 +111,7 @@ schools:
         ref: school:Naturelle
   - id: magie-noire
     name: Magie noire
+    status: active
     source_label: Noire
     color: noir
     specialist_class_id: sorcier
@@ -112,6 +122,7 @@ schools:
         ref: school:Noire
   - id: necromancie
     name: Nécromancie
+    status: active
     source_label: Nécromancie
     color: gris
     specialist_class_id: necromancien

--- a/data/catalogs/orientations.yaml
+++ b/data/catalogs/orientations.yaml
@@ -12,6 +12,7 @@ metadata:
 orientations:
   - id: artisan
     name: Artisan
+    status: active
     is_magical: false
     source_refs:
       - path: data/legacy/web-scraped/documents/classes/index.md
@@ -19,6 +20,7 @@ orientations:
         ref: line:8
   - id: artiste
     name: Artiste
+    status: active
     is_magical: false
     source_refs:
       - path: data/legacy/web-scraped/documents/classes/index.md
@@ -26,6 +28,7 @@ orientations:
         ref: line:20
   - id: commercant
     name: Commerçant
+    status: active
     is_magical: false
     source_refs:
       - path: data/legacy/web-scraped/documents/classes/index.md
@@ -33,6 +36,7 @@ orientations:
         ref: line:30
   - id: dommestique
     name: Dommestique
+    status: active
     is_magical: false
     source_refs:
       - path: data/legacy/web-scraped/documents/classes/index.md
@@ -40,6 +44,7 @@ orientations:
         ref: line:37
   - id: guerrier
     name: Guerrier
+    status: active
     is_magical: false
     source_refs:
       - path: data/legacy/web-scraped/documents/classes/index.md
@@ -47,6 +52,7 @@ orientations:
         ref: line:43
   - id: hors-la-loi
     name: Hors-la-loi
+    status: active
     is_magical: false
     source_refs:
       - path: data/legacy/web-scraped/documents/classes/index.md
@@ -54,6 +60,7 @@ orientations:
         ref: line:60
   - id: intellectuel
     name: Intellectuel
+    status: active
     is_magical: false
     source_refs:
       - path: data/legacy/web-scraped/documents/classes/index.md
@@ -61,6 +68,7 @@ orientations:
         ref: line:68
   - id: magicien
     name: Magicien
+    status: active
     is_magical: true
     source_refs:
       - path: data/legacy/web-scraped/documents/classes/index.md
@@ -68,6 +76,7 @@ orientations:
         ref: line:77
   - id: ouvrier
     name: Ouvrier
+    status: active
     is_magical: false
     source_refs:
       - path: data/legacy/web-scraped/documents/classes/index.md
@@ -75,6 +84,7 @@ orientations:
         ref: line:90
   - id: paysan
     name: Paysan
+    status: active
     is_magical: false
     source_refs:
       - path: data/legacy/web-scraped/documents/classes/index.md
@@ -82,6 +92,7 @@ orientations:
         ref: line:92
   - id: religieux
     name: Religieux
+    status: active
     is_magical: false
     source_refs:
       - path: data/legacy/web-scraped/documents/classes/index.md
@@ -89,6 +100,7 @@ orientations:
         ref: line:100
   - id: voyageur
     name: Voyageur
+    status: active
     is_magical: false
     source_refs:
       - path: data/legacy/web-scraped/documents/classes/index.md

--- a/data/catalogs/spells.yaml
+++ b/data/catalogs/spells.yaml
@@ -12,6 +12,7 @@ metadata:
 spells:
   - id: annihilation
     name: Annihilation
+    status: active
     school_id: abjuration
     energy: 169
     incantation_time: 118
@@ -24,6 +25,7 @@ spells:
         ref: entry:annihilation
   - id: augmentation-energetique
     name: Augmentation énergétique
+    status: active
     school_id: abjuration
     energy: 6
     incantation_time: 4
@@ -36,6 +38,7 @@ spells:
         ref: entry:augmentation-energetique
   - id: barriere-psychique
     name: Barrière psychique
+    status: active
     school_id: abjuration
     energy: 6
     incantation_time: 4
@@ -48,6 +51,7 @@ spells:
         ref: entry:barriere-psychique
   - id: barriere-psychique-de-masse
     name: Barrière psychique de masse
+    status: active
     school_id: abjuration
     energy: 7
     incantation_time: 5
@@ -60,6 +64,7 @@ spells:
         ref: entry:barriere-psychique-de-masse
   - id: boomerang
     name: Boomerang
+    status: active
     school_id: abjuration
     energy: 7
     incantation_time: 5
@@ -72,6 +77,7 @@ spells:
         ref: entry:boomerang
   - id: captage-d-energie
     name: Captage d'énergie
+    status: active
     school_id: abjuration
     energy: 7
     incantation_time: 5
@@ -84,6 +90,7 @@ spells:
         ref: entry:captage-d-energie
   - id: complexite-magique
     name: Complexité magique
+    status: active
     school_id: abjuration
     energy: 7
     incantation_time: 5
@@ -96,6 +103,7 @@ spells:
         ref: entry:complexite-magique
   - id: contre-blanc
     name: Contre-blanc
+    status: active
     school_id: abjuration
     energy: 8
     incantation_time: 5
@@ -108,6 +116,7 @@ spells:
         ref: entry:contre-blanc
   - id: contre-bleu
     name: Contre-bleu
+    status: active
     school_id: abjuration
     energy: 8
     incantation_time: 5
@@ -120,6 +129,7 @@ spells:
         ref: entry:contre-bleu
   - id: contre-brun
     name: Contre-brun
+    status: active
     school_id: abjuration
     energy: 8
     incantation_time: 5
@@ -132,6 +142,7 @@ spells:
         ref: entry:contre-brun
   - id: contre-gris
     name: Contre-gris
+    status: active
     school_id: abjuration
     energy: 8
     incantation_time: 5
@@ -144,6 +155,7 @@ spells:
         ref: entry:contre-gris
   - id: contre-jaune
     name: Contre-jaune
+    status: active
     school_id: abjuration
     energy: 8
     incantation_time: 5
@@ -156,6 +168,7 @@ spells:
         ref: entry:contre-jaune
   - id: contre-noir
     name: Contre-noir
+    status: active
     school_id: abjuration
     energy: 8
     incantation_time: 5
@@ -168,6 +181,7 @@ spells:
         ref: entry:contre-noir
   - id: contre-orange
     name: Contre-orange
+    status: active
     school_id: abjuration
     energy: 8
     incantation_time: 5
@@ -180,6 +194,7 @@ spells:
         ref: entry:contre-orange
   - id: contre-rouge
     name: Contre-rouge
+    status: active
     school_id: abjuration
     energy: 8
     incantation_time: 5
@@ -192,6 +207,7 @@ spells:
         ref: entry:contre-rouge
   - id: contre-turquoise
     name: Contre-turquoise
+    status: active
     school_id: abjuration
     energy: 8
     incantation_time: 5
@@ -204,6 +220,7 @@ spells:
         ref: entry:contre-turquoise
   - id: contre-vert
     name: Contre-vert
+    status: active
     school_id: abjuration
     energy: 8
     incantation_time: 5
@@ -216,6 +233,7 @@ spells:
         ref: entry:contre-vert
   - id: contre-violet
     name: Contre-violet
+    status: active
     school_id: abjuration
     energy: 8
     incantation_time: 5
@@ -228,6 +246,7 @@ spells:
         ref: entry:contre-violet
   - id: deplacement-magique
     name: Déplacement magique
+    status: active
     school_id: abjuration
     energy: 7
     incantation_time: 5
@@ -240,6 +259,7 @@ spells:
         ref: entry:deplacement-magique
   - id: deplacement-magique-de-masse
     name: Déplacement magique de masse
+    status: active
     school_id: abjuration
     energy: 9
     incantation_time: 6
@@ -252,6 +272,7 @@ spells:
         ref: entry:deplacement-magique-de-masse
   - id: detournement-du-lien-du-mort-vivant
     name: Détournement du lien du mort-vivant
+    status: active
     school_id: abjuration
     energy: 11
     incantation_time: 7
@@ -264,6 +285,7 @@ spells:
         ref: entry:detournement-du-lien-du-mort-vivant
   - id: dispersion-du-familier
     name: Dispersion du familier
+    status: active
     school_id: abjuration
     energy: 9
     incantation_time: 6
@@ -276,6 +298,7 @@ spells:
         ref: entry:dispersion-du-familier
   - id: dissipation
     name: Dissipation
+    status: active
     school_id: abjuration
     energy: 11
     incantation_time: 8
@@ -288,6 +311,7 @@ spells:
         ref: entry:dissipation
   - id: interdiction-magique
     name: Interdiction magique
+    status: active
     school_id: abjuration
     energy: 13
     incantation_time: 9
@@ -300,6 +324,7 @@ spells:
         ref: entry:interdiction-magique
   - id: irreductibilite
     name: Irréductibilité
+    status: active
     school_id: abjuration
     energy: 13
     incantation_time: 9
@@ -312,6 +337,7 @@ spells:
         ref: entry:irreductibilite
   - id: irreductibilite-de-masse
     name: Irréductibilité de masse
+    status: active
     school_id: abjuration
     energy: 14
     incantation_time: 10
@@ -324,6 +350,7 @@ spells:
         ref: entry:irreductibilite-de-masse
   - id: perturbation
     name: Perturbation
+    status: active
     school_id: abjuration
     energy: 14
     incantation_time: 10
@@ -336,6 +363,7 @@ spells:
         ref: entry:perturbation
   - id: piegeage-magique
     name: Piégeage magique
+    status: active
     school_id: abjuration
     energy: 16
     incantation_time: 12
@@ -348,6 +376,7 @@ spells:
         ref: entry:piegeage-magique
   - id: ralentissement-magique
     name: Ralentissement magique
+    status: active
     school_id: abjuration
     energy: 19
     incantation_time: 13
@@ -360,6 +389,7 @@ spells:
         ref: entry:ralentissement-magique
   - id: rets-des-ames
     name: Rets des âmes
+    status: active
     school_id: abjuration
     energy: 21
     incantation_time: 14
@@ -372,6 +402,7 @@ spells:
         ref: entry:rets-des-ames
   - id: rets-des-cadavres
     name: Rets des cadavres
+    status: active
     school_id: abjuration
     energy: 24
     incantation_time: 17
@@ -384,6 +415,7 @@ spells:
         ref: entry:rets-des-cadavres
   - id: rupture-de-lien-d-invocation
     name: Rupture de lien d'invocation
+    status: active
     school_id: abjuration
     energy: 10
     incantation_time: 7
@@ -398,6 +430,7 @@ spells:
         ref: entry:rupture-de-lien-d-invocation
   - id: substitution-de-sort
     name: Substitution de sort
+    status: active
     school_id: abjuration
     energy: 25
     incantation_time: 18
@@ -410,6 +443,7 @@ spells:
         ref: entry:substitution-de-sort
   - id: agrandissement
     name: Agrandissement
+    status: active
     school_id: alteration
     energy: 36
     incantation_time: 53
@@ -422,6 +456,7 @@ spells:
         ref: entry:agrandissement
   - id: branchie
     name: Branchie
+    status: active
     school_id: alteration
     energy: 8
     incantation_time: 12
@@ -434,6 +469,7 @@ spells:
         ref: entry:branchie
   - id: branchie-de-masse
     name: Branchie de masse
+    status: active
     school_id: alteration
     energy: 8
     incantation_time: 12
@@ -446,6 +482,7 @@ spells:
         ref: entry:branchie-de-masse
   - id: changement-de-sexe
     name: Changement de sexe
+    status: active
     school_id: alteration
     energy: 12
     incantation_time: 18
@@ -458,6 +495,7 @@ spells:
         ref: entry:changement-de-sexe
   - id: changement-en-corbeau
     name: Changement en corbeau
+    status: active
     school_id: alteration
     energy: 14
     incantation_time: 20
@@ -470,6 +508,7 @@ spells:
         ref: entry:changement-en-corbeau
   - id: changement-en-crapaud
     name: Changement en crapaud
+    status: active
     school_id: alteration
     energy: 12
     incantation_time: 17
@@ -482,6 +521,7 @@ spells:
         ref: entry:changement-en-crapaud
   - id: changement-en-furet
     name: Changement en furet
+    status: active
     school_id: alteration
     energy: 13
     incantation_time: 19
@@ -494,6 +534,7 @@ spells:
         ref: entry:changement-en-furet
   - id: changement-en-humain
     name: Changement en humain
+    status: active
     school_id: alteration
     energy: 28
     incantation_time: 42
@@ -506,6 +547,7 @@ spells:
         ref: entry:changement-en-humain
   - id: changement-en-lapin
     name: Changement en lapin
+    status: active
     school_id: alteration
     energy: 12
     incantation_time: 18
@@ -518,6 +560,7 @@ spells:
         ref: entry:changement-en-lapin
   - id: changer-l-eau-en-vin
     name: Changer l’eau en vin
+    status: active
     school_id: alteration
     energy: 4
     incantation_time: 7
@@ -530,6 +573,7 @@ spells:
         ref: entry:changer-l-eau-en-vin
   - id: chatiment-de-la-matiere
     name: Châtiment de la matière
+    status: active
     school_id: alteration
     energy: 124
     incantation_time: 186
@@ -542,6 +586,7 @@ spells:
         ref: entry:chatiment-de-la-matiere
   - id: corrosion
     name: Corrosion
+    status: active
     school_id: alteration
     energy: 6
     incantation_time: 9
@@ -554,6 +599,7 @@ spells:
         ref: entry:corrosion
   - id: corrosion-de-masse
     name: Corrosion de masse
+    status: active
     school_id: alteration
     energy: 8
     incantation_time: 12
@@ -566,6 +612,7 @@ spells:
         ref: entry:corrosion-de-masse
   - id: creation-d-aile
     name: Création d'aile
+    status: active
     school_id: alteration
     energy: 14
     incantation_time: 21
@@ -578,6 +625,7 @@ spells:
         ref: entry:creation-d-aile
   - id: creation-d-oeil
     name: Création d'oeil
+    status: active
     school_id: alteration
     energy: 11
     incantation_time: 16
@@ -590,6 +638,7 @@ spells:
         ref: entry:creation-d-oeil
   - id: creation-de-bras
     name: Création de bras
+    status: active
     school_id: alteration
     energy: 14
     incantation_time: 21
@@ -602,6 +651,7 @@ spells:
         ref: entry:creation-de-bras
   - id: creation-de-dent
     name: Création de dent
+    status: active
     school_id: alteration
     energy: 4
     incantation_time: 5
@@ -614,6 +664,7 @@ spells:
         ref: entry:creation-de-dent
   - id: creation-de-jambe
     name: Création de jambe
+    status: active
     school_id: alteration
     energy: 14
     incantation_time: 22
@@ -626,6 +677,7 @@ spells:
         ref: entry:creation-de-jambe
   - id: creation-de-kyste
     name: Création de kyste
+    status: active
     school_id: alteration
     energy: 4
     incantation_time: 5
@@ -638,6 +690,7 @@ spells:
         ref: entry:creation-de-kyste
   - id: creation-de-main
     name: Création de main
+    status: active
     school_id: alteration
     energy: 12
     incantation_time: 17
@@ -650,6 +703,7 @@ spells:
         ref: entry:creation-de-main
   - id: creation-de-pied
     name: Création de pied
+    status: active
     school_id: alteration
     energy: 11
     incantation_time: 17
@@ -662,6 +716,7 @@ spells:
         ref: entry:creation-de-pied
   - id: creation-de-queue
     name: Création de queue
+    status: active
     school_id: alteration
     energy: 10
     incantation_time: 15
@@ -674,6 +729,7 @@ spells:
         ref: entry:creation-de-queue
   - id: evaporation
     name: Evaporation
+    status: active
     school_id: alteration
     energy: 4
     incantation_time: 5
@@ -686,6 +742,7 @@ spells:
         ref: entry:evaporation
   - id: gel
     name: Gel
+    status: active
     school_id: alteration
     energy: 5
     incantation_time: 8
@@ -698,6 +755,7 @@ spells:
         ref: entry:gel
   - id: membre-telescopique
     name: Membre téléscopique
+    status: active
     school_id: alteration
     energy: 7
     incantation_time: 10
@@ -710,6 +768,7 @@ spells:
         ref: entry:membre-telescopique
   - id: miniaturisation
     name: Miniaturisation
+    status: active
     school_id: alteration
     energy: 36
     incantation_time: 53
@@ -722,6 +781,7 @@ spells:
         ref: entry:miniaturisation
   - id: petrification
     name: Pétrification
+    status: active
     school_id: alteration
     energy: 62
     incantation_time: 93
@@ -734,6 +794,7 @@ spells:
         ref: entry:petrification
   - id: rendre-forme
     name: Rendre forme
+    status: active
     school_id: alteration
     energy: 5
     incantation_time: 8
@@ -746,6 +807,7 @@ spells:
         ref: entry:rendre-forme
   - id: soudure
     name: Soudure
+    status: active
     school_id: alteration
     energy: 6
     incantation_time: 9
@@ -758,6 +820,7 @@ spells:
         ref: entry:soudure
   - id: barriere-de-holn
     name: Barrière de Höln
+    status: active
     school_id: magie-blanche
     energy: 27
     incantation_time: 30
@@ -770,6 +833,7 @@ spells:
         ref: entry:barriere-de-holn
   - id: benediction
     name: Bénédiction
+    status: active
     school_id: magie-blanche
     energy: 13
     incantation_time: 14
@@ -782,6 +846,7 @@ spells:
         ref: entry:benediction
   - id: benediction-de-masse
     name: Bénédiction de masse
+    status: active
     school_id: magie-blanche
     energy: 18
     incantation_time: 20
@@ -794,6 +859,7 @@ spells:
         ref: entry:benediction-de-masse
   - id: bouclier
     name: Bouclier
+    status: active
     school_id: magie-blanche
     energy: 9
     incantation_time: 9
@@ -806,6 +872,7 @@ spells:
         ref: entry:bouclier
   - id: bouclier-anti-feu
     name: Bouclier anti-feu
+    status: active
     school_id: magie-blanche
     energy: 7
     incantation_time: 8
@@ -818,6 +885,7 @@ spells:
         ref: entry:bouclier-anti-feu
   - id: bouclier-anti-foudre
     name: Bouclier anti-foudre
+    status: active
     school_id: magie-blanche
     energy: 7
     incantation_time: 8
@@ -830,6 +898,7 @@ spells:
         ref: entry:bouclier-anti-foudre
   - id: bouclier-anti-froid
     name: Bouclier anti-froid
+    status: active
     school_id: magie-blanche
     energy: 7
     incantation_time: 8
@@ -842,6 +911,7 @@ spells:
         ref: entry:bouclier-anti-froid
   - id: bouclier-anti-lave
     name: Bouclier anti-lave
+    status: active
     school_id: magie-blanche
     energy: 7
     incantation_time: 8
@@ -854,6 +924,7 @@ spells:
         ref: entry:bouclier-anti-lave
   - id: bouclier-anti-mal
     name: Bouclier anti-mal
+    status: active
     school_id: magie-blanche
     energy: 7
     incantation_time: 8
@@ -866,6 +937,7 @@ spells:
         ref: entry:bouclier-anti-mal
   - id: charisme
     name: Charisme
+    status: active
     school_id: magie-blanche
     energy: 8
     incantation_time: 9
@@ -878,6 +950,7 @@ spells:
         ref: entry:charisme
   - id: charisme-de-masse
     name: Charisme de masse
+    status: active
     school_id: magie-blanche
     energy: 11
     incantation_time: 13
@@ -890,6 +963,7 @@ spells:
         ref: entry:charisme-de-masse
   - id: courage
     name: Courage
+    status: active
     school_id: magie-blanche
     energy: 7
     incantation_time: 7
@@ -902,6 +976,7 @@ spells:
         ref: entry:courage
   - id: deviation
     name: Déviation
+    status: active
     school_id: magie-blanche
     energy: 9
     incantation_time: 10
@@ -914,6 +989,7 @@ spells:
         ref: entry:deviation
   - id: deviation-de-masse
     name: Déviation de masse
+    status: active
     school_id: magie-blanche
     energy: 13
     incantation_time: 14
@@ -926,6 +1002,7 @@ spells:
         ref: entry:deviation-de-masse
   - id: deviation-des-projectiles
     name: Déviation des projectiles
+    status: active
     school_id: magie-blanche
     energy: 8
     incantation_time: 9
@@ -938,6 +1015,7 @@ spells:
         ref: entry:deviation-des-projectiles
   - id: deviation-majeure
     name: Déviation majeure
+    status: active
     school_id: magie-blanche
     energy: 11
     incantation_time: 12
@@ -950,6 +1028,7 @@ spells:
         ref: entry:deviation-majeure
   - id: deviation-mineure
     name: Déviation mineure
+    status: active
     school_id: magie-blanche
     energy: 7
     incantation_time: 7
@@ -962,6 +1041,7 @@ spells:
         ref: entry:deviation-mineure
   - id: dexterite
     name: Dextérité
+    status: active
     school_id: magie-blanche
     energy: 8
     incantation_time: 9
@@ -974,6 +1054,7 @@ spells:
         ref: entry:dexterite
   - id: dexterite-de-masse
     name: Dextérité de masse
+    status: active
     school_id: magie-blanche
     energy: 11
     incantation_time: 13
@@ -986,6 +1067,7 @@ spells:
         ref: entry:dexterite-de-masse
   - id: don-d-energie
     name: Don d’énergie
+    status: active
     school_id: magie-blanche
     energy: 7
     incantation_time: 8
@@ -998,6 +1080,7 @@ spells:
         ref: entry:don-d-energie
   - id: empathie
     name: Empathie
+    status: active
     school_id: magie-blanche
     energy: 8
     incantation_time: 9
@@ -1010,6 +1093,7 @@ spells:
         ref: entry:empathie
   - id: empathie-de-masse
     name: Empathie de masse
+    status: active
     school_id: magie-blanche
     energy: 11
     incantation_time: 13
@@ -1022,6 +1106,7 @@ spells:
         ref: entry:empathie-de-masse
   - id: endurance
     name: Endurance
+    status: active
     school_id: magie-blanche
     energy: 8
     incantation_time: 9
@@ -1034,6 +1119,7 @@ spells:
         ref: entry:endurance
   - id: endurance-de-masse
     name: Endurance de masse
+    status: active
     school_id: magie-blanche
     energy: 11
     incantation_time: 13
@@ -1046,6 +1132,7 @@ spells:
         ref: entry:endurance-de-masse
   - id: esthetique
     name: Esthétique
+    status: active
     school_id: magie-blanche
     energy: 8
     incantation_time: 9
@@ -1058,6 +1145,7 @@ spells:
         ref: entry:esthetique
   - id: esthetique-de-masse
     name: Esthétique de masse
+    status: active
     school_id: magie-blanche
     energy: 11
     incantation_time: 13
@@ -1070,6 +1158,7 @@ spells:
         ref: entry:esthetique-de-masse
   - id: force
     name: Force
+    status: active
     school_id: magie-blanche
     energy: 8
     incantation_time: 9
@@ -1082,6 +1171,7 @@ spells:
         ref: entry:force
   - id: force-de-masse
     name: Force de masse
+    status: active
     school_id: magie-blanche
     energy: 11
     incantation_time: 13
@@ -1094,6 +1184,7 @@ spells:
         ref: entry:force-de-masse
   - id: guerison-absolue
     name: Guérison absolue
+    status: active
     school_id: magie-blanche
     energy: 131
     incantation_time: 145
@@ -1106,6 +1197,7 @@ spells:
         ref: entry:guerison-absolue
   - id: guerison-de-la-chair
     name: Guérison de la chair
+    status: active
     school_id: magie-blanche
     energy: 13
     incantation_time: 15
@@ -1118,6 +1210,7 @@ spells:
         ref: entry:guerison-de-la-chair
   - id: guerison-de-la-peau
     name: Guérison de la peau
+    status: active
     school_id: magie-blanche
     energy: 10
     incantation_time: 10
@@ -1130,6 +1223,7 @@ spells:
         ref: entry:guerison-de-la-peau
   - id: guerison-des-muscles
     name: Guérison des muscles
+    status: active
     school_id: magie-blanche
     energy: 10
     incantation_time: 10
@@ -1142,6 +1236,7 @@ spells:
         ref: entry:guerison-des-muscles
   - id: guerison-des-muscles-mineure
     name: Guérison des muscles mineure
+    status: active
     school_id: magie-blanche
     energy: 7
     incantation_time: 7
@@ -1154,6 +1249,7 @@ spells:
         ref: entry:guerison-des-muscles-mineure
   - id: guerison-des-organes
     name: Guérison des organes
+    status: active
     school_id: magie-blanche
     energy: 13
     incantation_time: 15
@@ -1166,6 +1262,7 @@ spells:
         ref: entry:guerison-des-organes
   - id: guerison-des-os
     name: Guérison des os
+    status: active
     school_id: magie-blanche
     energy: 10
     incantation_time: 10
@@ -1178,6 +1275,7 @@ spells:
         ref: entry:guerison-des-os
   - id: intelligence
     name: Intelligence
+    status: active
     school_id: magie-blanche
     energy: 8
     incantation_time: 9
@@ -1190,6 +1288,7 @@ spells:
         ref: entry:intelligence
   - id: intelligence-de-masse
     name: Intelligence de masse
+    status: active
     school_id: magie-blanche
     energy: 11
     incantation_time: 13
@@ -1202,6 +1301,7 @@ spells:
         ref: entry:intelligence-de-masse
   - id: lumiere
     name: Lumière
+    status: active
     school_id: magie-blanche
     energy: 6
     incantation_time: 7
@@ -1214,6 +1314,7 @@ spells:
         ref: entry:lumiere
   - id: purification-de-l-air
     name: Purification de l'air
+    status: active
     school_id: magie-blanche
     energy: 5
     incantation_time: 6
@@ -1226,6 +1327,7 @@ spells:
         ref: entry:purification-de-l-air
   - id: purification-de-l-eau
     name: Purification de l'eau
+    status: active
     school_id: magie-blanche
     energy: 5
     incantation_time: 6
@@ -1238,6 +1340,7 @@ spells:
         ref: entry:purification-de-l-eau
   - id: rapidite
     name: Rapidité
+    status: active
     school_id: magie-blanche
     energy: 13
     incantation_time: 14
@@ -1250,6 +1353,7 @@ spells:
         ref: entry:rapidite
   - id: rapidite-de-masse
     name: Rapidité de masse
+    status: active
     school_id: magie-blanche
     energy: 19
     incantation_time: 20
@@ -1262,6 +1366,7 @@ spells:
         ref: entry:rapidite-de-masse
   - id: renvoi-du-demon
     name: Renvoi du démon
+    status: active
     school_id: magie-blanche
     energy: 40
     incantation_time: 44
@@ -1274,6 +1379,7 @@ spells:
         ref: entry:renvoi-du-demon
   - id: respiration
     name: Respiration
+    status: active
     school_id: magie-blanche
     energy: 8
     incantation_time: 9
@@ -1286,6 +1392,7 @@ spells:
         ref: entry:respiration
   - id: respiration-de-masse
     name: Respiration de masse
+    status: active
     school_id: magie-blanche
     energy: 11
     incantation_time: 12
@@ -1298,6 +1405,7 @@ spells:
         ref: entry:respiration-de-masse
   - id: resurrection
     name: Résurrection
+    status: active
     school_id: magie-blanche
     energy: 141
     incantation_time: 156
@@ -1310,6 +1418,7 @@ spells:
         ref: entry:resurrection
   - id: connaitre-le-vice
     name: Connaître le vice
+    status: active
     school_id: divination
     energy: 19
     incantation_time: 32
@@ -1322,6 +1431,7 @@ spells:
         ref: entry:connaitre-le-vice
   - id: contact
     name: Contact
+    status: active
     school_id: divination
     energy: 7
     incantation_time: 12
@@ -1334,6 +1444,7 @@ spells:
         ref: entry:contact
   - id: contact-de-morphee
     name: Contact de Morphée
+    status: active
     school_id: divination
     energy: 10
     incantation_time: 7
@@ -1346,6 +1457,7 @@ spells:
         ref: entry:contact-de-morphee
   - id: contact-divin
     name: Contact divin
+    status: active
     school_id: divination
     energy: 113
     incantation_time: 192
@@ -1358,6 +1470,7 @@ spells:
         ref: entry:contact-divin
   - id: contacter-l-au-dela
     name: Contacter l’au-delà
+    status: active
     school_id: divination
     energy: 69
     incantation_time: 117
@@ -1370,6 +1483,7 @@ spells:
         ref: entry:contacter-l-au-dela
   - id: detection-du-danger
     name: Détection du danger
+    status: active
     school_id: divination
     energy: 10
     incantation_time: 17
@@ -1382,6 +1496,7 @@ spells:
         ref: entry:detection-du-danger
   - id: identification
     name: Identification
+    status: active
     school_id: divination
     energy: 7
     incantation_time: 12
@@ -1394,6 +1509,7 @@ spells:
         ref: entry:identification
   - id: localisation
     name: Localisation
+    status: active
     school_id: divination
     energy: 11
     incantation_time: 18
@@ -1406,6 +1522,7 @@ spells:
         ref: entry:localisation
   - id: nouvelle-du-monde
     name: Nouvelle du monde
+    status: active
     school_id: divination
     energy: 11
     incantation_time: 18
@@ -1418,6 +1535,7 @@ spells:
         ref: entry:nouvelle-du-monde
   - id: nouvelle-nationale
     name: Nouvelle nationale
+    status: active
     school_id: divination
     energy: 9
     incantation_time: 16
@@ -1430,6 +1548,7 @@ spells:
         ref: entry:nouvelle-nationale
   - id: nouvelle-regionale
     name: Nouvelle régionale
+    status: active
     school_id: divination
     energy: 8
     incantation_time: 13
@@ -1442,6 +1561,7 @@ spells:
         ref: entry:nouvelle-regionale
   - id: premonition
     name: Prémonition
+    status: active
     school_id: divination
     energy: 34
     incantation_time: 58
@@ -1454,6 +1574,7 @@ spells:
         ref: entry:premonition
   - id: regard-de-puissance
     name: Regard de puissance
+    status: active
     school_id: divination
     energy: 12
     incantation_time: 20
@@ -1466,6 +1587,7 @@ spells:
         ref: entry:regard-de-puissance
   - id: savoir-l-aptitude
     name: Savoir l'aptitude
+    status: active
     school_id: divination
     energy: 5
     incantation_time: 9
@@ -1478,6 +1600,7 @@ spells:
         ref: entry:savoir-l-aptitude
   - id: savoir-l-energie
     name: Savoir l'énergie
+    status: active
     school_id: divination
     energy: 6
     incantation_time: 9
@@ -1490,6 +1613,7 @@ spells:
         ref: entry:savoir-l-energie
   - id: savoir-la-vitalite
     name: Savoir la vitalité
+    status: active
     school_id: divination
     energy: 6
     incantation_time: 10
@@ -1502,6 +1626,7 @@ spells:
         ref: entry:savoir-la-vitalite
   - id: savoir-la-vitesse
     name: Savoir la vitesse
+    status: active
     school_id: divination
     energy: 5
     incantation_time: 9
@@ -1514,6 +1639,7 @@ spells:
         ref: entry:savoir-la-vitesse
   - id: savoir-la-volonte
     name: Savoir la volonté
+    status: active
     school_id: divination
     energy: 5
     incantation_time: 9
@@ -1526,6 +1652,7 @@ spells:
         ref: entry:savoir-la-volonte
   - id: savoir-le-nom
     name: Savoir le nom
+    status: active
     school_id: divination
     energy: 3
     incantation_time: 6
@@ -1538,6 +1665,7 @@ spells:
         ref: entry:savoir-le-nom
   - id: savoir-les-competences
     name: Savoir les compétences
+    status: active
     school_id: divination
     energy: 5
     incantation_time: 8
@@ -1550,6 +1678,7 @@ spells:
         ref: entry:savoir-les-competences
   - id: vision-ante-mortem
     name: Vision ante mortem
+    status: active
     school_id: divination
     energy: 7
     incantation_time: 11
@@ -1562,6 +1691,7 @@ spells:
         ref: entry:vision-ante-mortem
   - id: vision-de-reve
     name: Vision de rêve
+    status: active
     school_id: divination
     energy: 5
     incantation_time: 9
@@ -1574,6 +1704,7 @@ spells:
         ref: entry:vision-de-reve
   - id: appel-de-la-foudre
     name: Appel de la foudre
+    status: active
     school_id: elementaire
     energy: 37
     incantation_time: 30
@@ -1586,6 +1717,7 @@ spells:
         ref: entry:appel-de-la-foudre
   - id: appel-de-la-pluie
     name: Appel de la pluie
+    status: active
     school_id: elementaire
     energy: 10
     incantation_time: 8
@@ -1598,6 +1730,7 @@ spells:
         ref: entry:appel-de-la-pluie
   - id: bouclier-de-foudre
     name: Bouclier de foudre
+    status: active
     school_id: elementaire
     energy: 14
     incantation_time: 11
@@ -1610,6 +1743,7 @@ spells:
         ref: entry:bouclier-de-foudre
   - id: bouclier-d-eau
     name: Bouclier d’eau
+    status: active
     school_id: elementaire
     energy: 10
     incantation_time: 8
@@ -1622,6 +1756,7 @@ spells:
         ref: entry:bouclier-d-eau
   - id: boule-de-feu
     name: Boule de feu
+    status: active
     school_id: elementaire
     energy: 16
     incantation_time: 13
@@ -1634,6 +1769,7 @@ spells:
         ref: entry:boule-de-feu
   - id: boule-de-feu-majeure
     name: Boule de feu majeure
+    status: active
     school_id: elementaire
     energy: 19
     incantation_time: 15
@@ -1646,6 +1782,7 @@ spells:
         ref: entry:boule-de-feu-majeure
   - id: boule-de-foudre
     name: Boule de foudre
+    status: active
     school_id: elementaire
     energy: 16
     incantation_time: 13
@@ -1658,6 +1795,7 @@ spells:
         ref: entry:boule-de-foudre
   - id: boule-de-foudre-majeure
     name: Boule de foudre majeure
+    status: active
     school_id: elementaire
     energy: 19
     incantation_time: 15
@@ -1670,6 +1808,7 @@ spells:
         ref: entry:boule-de-foudre-majeure
   - id: brasier
     name: Brasier
+    status: active
     school_id: elementaire
     energy: 32
     incantation_time: 25
@@ -1682,6 +1821,7 @@ spells:
         ref: entry:brasier
   - id: cercle-de-feu
     name: Cercle de feu
+    status: active
     school_id: elementaire
     energy: 11
     incantation_time: 9
@@ -1694,6 +1834,7 @@ spells:
         ref: entry:cercle-de-feu
   - id: chaine-d-eclairs
     name: Chaîne d’éclairs
+    status: active
     school_id: elementaire
     energy: 35
     incantation_time: 28
@@ -1706,6 +1847,7 @@ spells:
         ref: entry:chaine-d-eclairs
   - id: champs-de-boue
     name: Champs de boue
+    status: active
     school_id: elementaire
     energy: 10
     incantation_time: 8
@@ -1718,6 +1860,7 @@ spells:
         ref: entry:champs-de-boue
   - id: colere-divine
     name: Colère divine
+    status: active
     school_id: elementaire
     energy: 173
     incantation_time: 139
@@ -1730,6 +1873,7 @@ spells:
         ref: entry:colere-divine
   - id: flash
     name: Flash
+    status: active
     school_id: elementaire
     energy: 9
     incantation_time: 8
@@ -1742,6 +1886,7 @@ spells:
         ref: entry:flash
   - id: fleche-de-feu
     name: Flèche de feu
+    status: active
     school_id: elementaire
     energy: 11
     incantation_time: 9
@@ -1754,6 +1899,7 @@ spells:
         ref: entry:fleche-de-feu
   - id: fleche-de-foudre
     name: Flèche de foudre
+    status: active
     school_id: elementaire
     energy: 11
     incantation_time: 9
@@ -1766,6 +1912,7 @@ spells:
         ref: entry:fleche-de-foudre
   - id: foudroiement
     name: Foudroiement
+    status: active
     school_id: elementaire
     energy: 12
     incantation_time: 10
@@ -1778,6 +1925,7 @@ spells:
         ref: entry:foudroiement
   - id: immolation
     name: Immolation
+    status: active
     school_id: elementaire
     energy: 9
     incantation_time: 7
@@ -1790,6 +1938,7 @@ spells:
         ref: entry:immolation
   - id: multi-flamme
     name: Multi-flamme
+    status: active
     school_id: elementaire
     energy: 16
     incantation_time: 13
@@ -1802,6 +1951,7 @@ spells:
         ref: entry:multi-flamme
   - id: mur-de-flammes
     name: Mur de flammes
+    status: active
     school_id: elementaire
     energy: 9
     incantation_time: 7
@@ -1814,6 +1964,7 @@ spells:
         ref: entry:mur-de-flammes
   - id: pilier-de-feu
     name: Pilier de feu
+    status: active
     school_id: elementaire
     energy: 37
     incantation_time: 30
@@ -1826,6 +1977,7 @@ spells:
         ref: entry:pilier-de-feu
   - id: pyramide-de-feu
     name: Pyramide de feu
+    status: active
     school_id: elementaire
     energy: 45
     incantation_time: 36
@@ -1838,6 +1990,7 @@ spells:
         ref: entry:pyramide-de-feu
   - id: rayon-d-eau
     name: Rayon d’eau
+    status: active
     school_id: elementaire
     energy: 12
     incantation_time: 10
@@ -1850,6 +2003,7 @@ spells:
         ref: entry:rayon-d-eau
   - id: raz-de-maree
     name: Raz de marée
+    status: active
     school_id: elementaire
     energy: 112
     incantation_time: 89
@@ -1862,6 +2016,7 @@ spells:
         ref: entry:raz-de-maree
   - id: sables-mouvants
     name: Sables mouvants
+    status: active
     school_id: elementaire
     energy: 16
     incantation_time: 13
@@ -1874,6 +2029,7 @@ spells:
         ref: entry:sables-mouvants
   - id: tornade
     name: Tornade
+    status: active
     school_id: elementaire
     energy: 39
     incantation_time: 31
@@ -1888,6 +2044,7 @@ spells:
         ref: entry:tornade
   - id: tornade-de-feu
     name: Tornade de feu
+    status: active
     school_id: elementaire
     energy: 43
     incantation_time: 34
@@ -1900,6 +2057,7 @@ spells:
         ref: entry:tornade-de-feu
   - id: touche-ardant
     name: Touché ardant
+    status: active
     school_id: elementaire
     energy: 6
     incantation_time: 5
@@ -1912,6 +2070,7 @@ spells:
         ref: entry:touche-ardant
   - id: vague-de-feu
     name: Vague de feu
+    status: active
     school_id: elementaire
     energy: 17
     incantation_time: 14
@@ -1924,6 +2083,7 @@ spells:
         ref: entry:vague-de-feu
   - id: animation-des-armures
     name: Animation des armures
+    status: active
     school_id: enchantement
     energy: 14
     incantation_time: 14
@@ -1936,6 +2096,7 @@ spells:
         ref: entry:animation-des-armures
   - id: arc-en-ciel
     name: Arc-en-ciel
+    status: active
     school_id: enchantement
     energy: 9
     incantation_time: 9
@@ -1948,6 +2109,7 @@ spells:
         ref: entry:arc-en-ciel
   - id: cauchemard
     name: Cauchemard
+    status: active
     school_id: enchantement
     energy: 4
     incantation_time: 4
@@ -1962,6 +2124,7 @@ spells:
         ref: entry:cauchemard
   - id: cauchemard-de-masse
     name: Cauchemard de masse
+    status: active
     school_id: enchantement
     energy: 6
     incantation_time: 6
@@ -1976,6 +2139,7 @@ spells:
         ref: entry:cauchemard-de-masse
   - id: cocon-thermique
     name: Cocon thermique
+    status: active
     school_id: enchantement
     energy: 5
     incantation_time: 5
@@ -1988,6 +2152,7 @@ spells:
         ref: entry:cocon-thermique
   - id: corde
     name: Corde
+    status: active
     school_id: enchantement
     energy: 8
     incantation_time: 8
@@ -2000,6 +2165,7 @@ spells:
         ref: entry:corde
   - id: enchantement-de-livre
     name: Enchantement de livre
+    status: active
     school_id: enchantement
     energy: 4
     incantation_time: 4
@@ -2012,6 +2178,7 @@ spells:
         ref: entry:enchantement-de-livre
   - id: extase
     name: Extase
+    status: active
     school_id: enchantement
     energy: 6
     incantation_time: 6
@@ -2024,6 +2191,7 @@ spells:
         ref: entry:extase
   - id: invisibilite
     name: Invisibilité
+    status: active
     school_id: enchantement
     energy: 10
     incantation_time: 10
@@ -2036,6 +2204,7 @@ spells:
         ref: entry:invisibilite
   - id: legerete
     name: Légèreté
+    status: active
     school_id: enchantement
     energy: 8
     incantation_time: 8
@@ -2048,6 +2217,7 @@ spells:
         ref: entry:legerete
   - id: lourdeur
     name: Lourdeur
+    status: active
     school_id: enchantement
     energy: 8
     incantation_time: 8
@@ -2060,6 +2230,7 @@ spells:
         ref: entry:lourdeur
   - id: marche-sur-l-eau
     name: Marche sur l'eau
+    status: active
     school_id: enchantement
     energy: 6
     incantation_time: 6
@@ -2072,6 +2243,7 @@ spells:
         ref: entry:marche-sur-l-eau
   - id: multilinguisme
     name: Multilinguisme
+    status: active
     school_id: enchantement
     energy: 7
     incantation_time: 7
@@ -2084,6 +2256,7 @@ spells:
         ref: entry:multilinguisme
   - id: nettoyage-magique
     name: Nettoyage magique
+    status: active
     school_id: enchantement
     energy: 4
     incantation_time: 4
@@ -2096,6 +2269,7 @@ spells:
         ref: entry:nettoyage-magique
   - id: parler-aux-oiseaux
     name: Parler aux oiseaux
+    status: active
     school_id: enchantement
     energy: 5
     incantation_time: 5
@@ -2108,6 +2282,7 @@ spells:
         ref: entry:parler-aux-oiseaux
   - id: passe-partout
     name: Passe-partout
+    status: active
     school_id: enchantement
     energy: 8
     incantation_time: 8
@@ -2120,6 +2295,7 @@ spells:
         ref: entry:passe-partout
   - id: porte-de-secours
     name: Porte de secours
+    status: active
     school_id: enchantement
     energy: 14
     incantation_time: 14
@@ -2132,6 +2308,7 @@ spells:
         ref: entry:porte-de-secours
   - id: rire
     name: Rire
+    status: active
     school_id: enchantement
     energy: 7
     incantation_time: 7
@@ -2144,6 +2321,7 @@ spells:
         ref: entry:rire
   - id: rire-de-masse
     name: Rire de masse
+    status: active
     school_id: enchantement
     energy: 10
     incantation_time: 10
@@ -2156,6 +2334,7 @@ spells:
         ref: entry:rire-de-masse
   - id: sommeil
     name: Sommeil
+    status: active
     school_id: enchantement
     energy: 7
     incantation_time: 7
@@ -2168,6 +2347,7 @@ spells:
         ref: entry:sommeil
   - id: vol-de-masse
     name: Vol de masse
+    status: active
     school_id: enchantement
     energy: 32
     incantation_time: 32
@@ -2180,6 +2360,7 @@ spells:
         ref: entry:vol-de-masse
   - id: vol-magique
     name: Vol magique
+    status: active
     school_id: enchantement
     energy: 22
     incantation_time: 22
@@ -2192,6 +2373,7 @@ spells:
         ref: entry:vol-magique
   - id: auto-clonage
     name: Auto clonage
+    status: active
     school_id: illusion
     energy: 9
     incantation_time: 12
@@ -2204,6 +2386,7 @@ spells:
         ref: entry:auto-clonage
   - id: centaure-illusoire
     name: Centaure illusoire
+    status: active
     school_id: illusion
     energy: 10
     incantation_time: 13
@@ -2216,6 +2399,7 @@ spells:
         ref: entry:centaure-illusoire
   - id: chat-illusoire
     name: Chat illusoire
+    status: active
     school_id: illusion
     energy: 7
     incantation_time: 10
@@ -2228,6 +2412,7 @@ spells:
         ref: entry:chat-illusoire
   - id: cheval-illusoire
     name: Cheval illusoire
+    status: active
     school_id: illusion
     energy: 7
     incantation_time: 10
@@ -2240,6 +2425,7 @@ spells:
         ref: entry:cheval-illusoire
   - id: chigr-illusoire
     name: Chigr Illusoire
+    status: active
     school_id: illusion
     energy: 9
     incantation_time: 11
@@ -2252,6 +2438,7 @@ spells:
         ref: entry:chigr-illusoire
   - id: clonage
     name: Clonage
+    status: active
     school_id: illusion
     energy: 10
     incantation_time: 13
@@ -2264,6 +2451,7 @@ spells:
         ref: entry:clonage
   - id: couteau-illusoire
     name: Couteau illusoire
+    status: active
     school_id: illusion
     energy: 7
     incantation_time: 9
@@ -2276,6 +2464,7 @@ spells:
         ref: entry:couteau-illusoire
   - id: demi-elfe-illusoire
     name: Demi-elfe illusoire
+    status: active
     school_id: illusion
     energy: 10
     incantation_time: 12
@@ -2288,6 +2477,7 @@ spells:
         ref: entry:demi-elfe-illusoire
   - id: dryade-illusoire
     name: Dryade illusoire
+    status: active
     school_id: illusion
     energy: 10
     incantation_time: 12
@@ -2300,6 +2490,7 @@ spells:
         ref: entry:dryade-illusoire
   - id: elfe-illusoire
     name: Elfe illusoire
+    status: active
     school_id: illusion
     energy: 10
     incantation_time: 12
@@ -2312,6 +2503,7 @@ spells:
         ref: entry:elfe-illusoire
   - id: fantome-illusoire
     name: Fantôme illusoire
+    status: active
     school_id: illusion
     energy: 12
     incantation_time: 16
@@ -2324,6 +2516,7 @@ spells:
         ref: entry:fantome-illusoire
   - id: fortune-illusoire
     name: Fortune illusoire
+    status: active
     school_id: illusion
     energy: 6
     incantation_time: 8
@@ -2336,6 +2529,7 @@ spells:
         ref: entry:fortune-illusoire
   - id: gnome-illusoire
     name: Gnome illusoire
+    status: active
     school_id: illusion
     energy: 8
     incantation_time: 11
@@ -2348,6 +2542,7 @@ spells:
         ref: entry:gnome-illusoire
   - id: gobelin-illusoire
     name: Gobelin illusoire
+    status: active
     school_id: illusion
     energy: 7
     incantation_time: 10
@@ -2360,6 +2555,7 @@ spells:
         ref: entry:gobelin-illusoire
   - id: hobbit-illusoire
     name: Hobbit illusoire
+    status: active
     school_id: illusion
     energy: 9
     incantation_time: 11
@@ -2372,6 +2568,7 @@ spells:
         ref: entry:hobbit-illusoire
   - id: homme-lezard-illusoire
     name: Homme lézard illusoire
+    status: active
     school_id: illusion
     energy: 9
     incantation_time: 12
@@ -2384,6 +2581,7 @@ spells:
         ref: entry:homme-lezard-illusoire
   - id: homme-oiseau-illusoire
     name: Homme oiseau illusoire
+    status: active
     school_id: illusion
     energy: 10
     incantation_time: 13
@@ -2396,6 +2594,7 @@ spells:
         ref: entry:homme-oiseau-illusoire
   - id: homme-rat-illusoire
     name: Homme rat illusoire
+    status: active
     school_id: illusion
     energy: 9
     incantation_time: 12
@@ -2408,6 +2607,7 @@ spells:
         ref: entry:homme-rat-illusoire
   - id: humain-illusoire
     name: Humain illusoire
+    status: active
     school_id: illusion
     energy: 10
     incantation_time: 12
@@ -2420,6 +2620,7 @@ spells:
         ref: entry:humain-illusoire
   - id: khochigr-illusoire
     name: Khochigr illusoire
+    status: active
     school_id: illusion
     energy: 10
     incantation_time: 12
@@ -2432,6 +2633,7 @@ spells:
         ref: entry:khochigr-illusoire
   - id: khogr-illusoire
     name: Khogr illusoire
+    status: active
     school_id: illusion
     energy: 10
     incantation_time: 13
@@ -2444,6 +2646,7 @@ spells:
         ref: entry:khogr-illusoire
   - id: loup-illusoire
     name: Loup illusoire
+    status: active
     school_id: illusion
     energy: 9
     incantation_time: 11
@@ -2456,6 +2659,7 @@ spells:
         ref: entry:loup-illusoire
   - id: loup-garou-illusoire
     name: Loup-garou illusoire
+    status: active
     school_id: illusion
     energy: 14
     incantation_time: 19
@@ -2468,6 +2672,7 @@ spells:
         ref: entry:loup-garou-illusoire
   - id: mur-illusoire
     name: Mur illusoire
+    status: active
     school_id: illusion
     energy: 8
     incantation_time: 10
@@ -2480,6 +2685,7 @@ spells:
         ref: entry:mur-illusoire
   - id: nain-illusoire
     name: Nain illusoire
+    status: active
     school_id: illusion
     energy: 10
     incantation_time: 12
@@ -2492,6 +2698,7 @@ spells:
         ref: entry:nain-illusoire
   - id: ogre-illusoire
     name: Ogre illusoire
+    status: active
     school_id: illusion
     energy: 15
     incantation_time: 20
@@ -2504,6 +2711,7 @@ spells:
         ref: entry:ogre-illusoire
   - id: ondine-illusoire
     name: Ondine illusoire
+    status: active
     school_id: illusion
     energy: 9
     incantation_time: 12
@@ -2516,6 +2724,7 @@ spells:
         ref: entry:ondine-illusoire
   - id: orc-illusoire
     name: Orc illusoire
+    status: active
     school_id: illusion
     energy: 10
     incantation_time: 12
@@ -2528,6 +2737,7 @@ spells:
         ref: entry:orc-illusoire
   - id: squelette-illusoire
     name: Squelette illusoire
+    status: active
     school_id: illusion
     energy: 9
     incantation_time: 11
@@ -2540,6 +2750,7 @@ spells:
         ref: entry:squelette-illusoire
   - id: troll-illusoire
     name: Troll illusoire
+    status: active
     school_id: illusion
     energy: 15
     incantation_time: 19
@@ -2552,6 +2763,7 @@ spells:
         ref: entry:troll-illusoire
   - id: vampire-illusoire
     name: Vampire illusoire
+    status: active
     school_id: illusion
     energy: 12
     incantation_time: 15
@@ -2564,6 +2776,7 @@ spells:
         ref: entry:vampire-illusoire
   - id: vide-sideral
     name: Vide sidéral
+    status: active
     school_id: illusion
     energy: 12
     incantation_time: 16
@@ -2576,6 +2789,7 @@ spells:
         ref: entry:vide-sideral
   - id: invocation-d-elfe
     name: Invocation d'elfe
+    status: active
     school_id: invocation
     energy: 11
     incantation_time: 15
@@ -2588,6 +2802,7 @@ spells:
         ref: entry:invocation-d-elfe
   - id: invocation-d-homme-lezard
     name: Invocation d'homme lézard
+    status: active
     school_id: invocation
     energy: 10
     incantation_time: 14
@@ -2600,6 +2815,7 @@ spells:
         ref: entry:invocation-d-homme-lezard
   - id: invocation-d-homme-oiseau
     name: Invocation d'homme oiseau
+    status: active
     school_id: invocation
     energy: 11
     incantation_time: 16
@@ -2612,6 +2828,7 @@ spells:
         ref: entry:invocation-d-homme-oiseau
   - id: invocation-d-homme-rat
     name: Invocation d'homme rat
+    status: active
     school_id: invocation
     energy: 10
     incantation_time: 14
@@ -2624,6 +2841,7 @@ spells:
         ref: entry:invocation-d-homme-rat
   - id: invocation-d-humain
     name: Invocation d'humain
+    status: active
     school_id: invocation
     energy: 11
     incantation_time: 15
@@ -2636,6 +2854,7 @@ spells:
         ref: entry:invocation-d-humain
   - id: invocation-d-ondine
     name: Invocation d'ondine
+    status: active
     school_id: invocation
     energy: 10
     incantation_time: 15
@@ -2648,6 +2867,7 @@ spells:
         ref: entry:invocation-d-ondine
   - id: invocation-de-centaure
     name: Invocation de centaure
+    status: active
     school_id: invocation
     energy: 11
     incantation_time: 16
@@ -2660,6 +2880,7 @@ spells:
         ref: entry:invocation-de-centaure
   - id: invocation-de-chat
     name: Invocation de chat
+    status: active
     school_id: invocation
     energy: 8
     incantation_time: 12
@@ -2672,6 +2893,7 @@ spells:
         ref: entry:invocation-de-chat
   - id: invocation-de-cheval
     name: Invocation de cheval
+    status: active
     school_id: invocation
     energy: 10
     incantation_time: 13
@@ -2684,6 +2906,7 @@ spells:
         ref: entry:invocation-de-cheval
   - id: invocation-de-chigr
     name: Invocation de chigr
+    status: active
     school_id: invocation
     energy: 10
     incantation_time: 14
@@ -2696,6 +2919,7 @@ spells:
         ref: entry:invocation-de-chigr
   - id: invocation-de-demi-elfe
     name: Invocation de demi elfe
+    status: active
     school_id: invocation
     energy: 11
     incantation_time: 15
@@ -2708,6 +2932,7 @@ spells:
         ref: entry:invocation-de-demi-elfe
   - id: invocation-de-dryade
     name: Invocation de dryade
+    status: active
     school_id: invocation
     energy: 11
     incantation_time: 15
@@ -2720,6 +2945,7 @@ spells:
         ref: entry:invocation-de-dryade
   - id: invocation-de-gnome
     name: Invocation de gnome
+    status: active
     school_id: invocation
     energy: 9
     incantation_time: 13
@@ -2732,6 +2958,7 @@ spells:
         ref: entry:invocation-de-gnome
   - id: invocation-de-gobelin
     name: Invocation de gobelin
+    status: active
     school_id: invocation
     energy: 8
     incantation_time: 12
@@ -2744,6 +2971,7 @@ spells:
         ref: entry:invocation-de-gobelin
   - id: invocation-de-guepe
     name: Invocation de guêpe
+    status: active
     school_id: invocation
     energy: 7
     incantation_time: 10
@@ -2756,6 +2984,7 @@ spells:
         ref: entry:invocation-de-guepe
   - id: invocation-de-hobbit
     name: Invocation de hobbit
+    status: active
     school_id: invocation
     energy: 10
     incantation_time: 13
@@ -2768,6 +2997,7 @@ spells:
         ref: entry:invocation-de-hobbit
   - id: invocation-de-khochigr
     name: Invocation de khochigr
+    status: active
     school_id: invocation
     energy: 11
     incantation_time: 15
@@ -2780,6 +3010,7 @@ spells:
         ref: entry:invocation-de-khochigr
   - id: invocation-de-khogr
     name: Invocation de khogr
+    status: active
     school_id: invocation
     energy: 11
     incantation_time: 16
@@ -2792,6 +3023,7 @@ spells:
         ref: entry:invocation-de-khogr
   - id: invocation-de-loup
     name: Invocation de loup
+    status: active
     school_id: invocation
     energy: 10
     incantation_time: 13
@@ -2804,6 +3036,7 @@ spells:
         ref: entry:invocation-de-loup
   - id: invocation-de-loup-garou
     name: Invocation de loup-garou
+    status: active
     school_id: invocation
     energy: 16
     incantation_time: 22
@@ -2816,6 +3049,7 @@ spells:
         ref: entry:invocation-de-loup-garou
   - id: invocation-de-nain
     name: Invocation de nain
+    status: active
     school_id: invocation
     energy: 11
     incantation_time: 15
@@ -2828,6 +3062,7 @@ spells:
         ref: entry:invocation-de-nain
   - id: invocation-de-squelette
     name: Invocation de squelette
+    status: active
     school_id: invocation
     energy: 10
     incantation_time: 13
@@ -2840,6 +3075,7 @@ spells:
         ref: entry:invocation-de-squelette
   - id: invocation-de-termite
     name: Invocation de termite
+    status: active
     school_id: invocation
     energy: 6
     incantation_time: 8
@@ -2852,6 +3088,7 @@ spells:
         ref: entry:invocation-de-termite
   - id: invocation-de-troll
     name: Invocation de troll
+    status: active
     school_id: invocation
     energy: 17
     incantation_time: 23
@@ -2864,6 +3101,7 @@ spells:
         ref: entry:invocation-de-troll
   - id: invocation-de-vampire
     name: Invocation de vampire
+    status: active
     school_id: invocation
     energy: 13
     incantation_time: 18
@@ -2876,6 +3114,7 @@ spells:
         ref: entry:invocation-de-vampire
   - id: invocation-d-abeilles
     name: Invocation d’abeilles
+    status: active
     school_id: invocation
     energy: 7
     incantation_time: 9
@@ -2888,6 +3127,7 @@ spells:
         ref: entry:invocation-d-abeilles
   - id: invocation-d-ogres
     name: Invocation d’ogres
+    status: active
     school_id: invocation
     energy: 15
     incantation_time: 20
@@ -2900,6 +3140,7 @@ spells:
         ref: entry:invocation-d-ogres
   - id: invocation-d-orc
     name: Invocation d’orc
+    status: active
     school_id: invocation
     energy: 11
     incantation_time: 15
@@ -2912,6 +3153,7 @@ spells:
         ref: entry:invocation-d-orc
   - id: lien-d-invocation
     name: Lien d'invocation
+    status: active
     school_id: invocation
     energy: 7
     incantation_time: 9
@@ -2926,6 +3168,7 @@ spells:
         ref: entry:lien-d-invocation
   - id: revocation
     name: Révocation
+    status: active
     school_id: invocation
     energy: 5
     incantation_time: 7
@@ -2938,6 +3181,7 @@ spells:
         ref: entry:revocation
   - id: appel-des-chats
     name: Appel des chats
+    status: active
     school_id: magie-naturelle
     energy: 6
     incantation_time: 8
@@ -2950,6 +3194,7 @@ spells:
         ref: entry:appel-des-chats
   - id: appel-des-chevaux
     name: Appel des chevaux
+    status: active
     school_id: magie-naturelle
     energy: 7
     incantation_time: 9
@@ -2962,6 +3207,7 @@ spells:
         ref: entry:appel-des-chevaux
   - id: appel-des-colombes
     name: Appel des colombes
+    status: active
     school_id: magie-naturelle
     energy: 6
     incantation_time: 7
@@ -2974,6 +3220,7 @@ spells:
         ref: entry:appel-des-colombes
   - id: appel-des-corbeaux
     name: Appel des corbeaux
+    status: active
     school_id: magie-naturelle
     energy: 6
     incantation_time: 7
@@ -2986,6 +3233,7 @@ spells:
         ref: entry:appel-des-corbeaux
   - id: appel-des-insectes
     name: Appel des insectes
+    status: active
     school_id: magie-naturelle
     energy: 9
     incantation_time: 11
@@ -2998,6 +3246,7 @@ spells:
         ref: entry:appel-des-insectes
   - id: appel-des-loups
     name: Appel des loups
+    status: active
     school_id: magie-naturelle
     energy: 7
     incantation_time: 9
@@ -3010,6 +3259,7 @@ spells:
         ref: entry:appel-des-loups
   - id: appel-des-mammiferes
     name: Appel des mammifères
+    status: active
     school_id: magie-naturelle
     energy: 11
     incantation_time: 13
@@ -3022,6 +3272,7 @@ spells:
         ref: entry:appel-des-mammiferes
   - id: cercle-de-fleur
     name: Cercle de fleur
+    status: active
     school_id: magie-naturelle
     energy: 4
     incantation_time: 5
@@ -3034,6 +3285,7 @@ spells:
         ref: entry:cercle-de-fleur
   - id: croissance
     name: Croissance
+    status: active
     school_id: magie-naturelle
     energy: 8
     incantation_time: 9
@@ -3046,6 +3298,7 @@ spells:
         ref: entry:croissance
   - id: eclosion
     name: Eclosion
+    status: active
     school_id: magie-naturelle
     energy: 4
     incantation_time: 5
@@ -3058,6 +3311,7 @@ spells:
         ref: entry:eclosion
   - id: effacement-des-traces
     name: Effacement des traces
+    status: active
     school_id: magie-naturelle
     energy: 6
     incantation_time: 7
@@ -3070,6 +3324,7 @@ spells:
         ref: entry:effacement-des-traces
   - id: effacement-des-traces-de-masses
     name: Effacement des traces de masses
+    status: active
     school_id: magie-naturelle
     energy: 8
     incantation_time: 10
@@ -3082,6 +3337,7 @@ spells:
         ref: entry:effacement-des-traces-de-masses
   - id: fertilite
     name: Fertilité
+    status: active
     school_id: magie-naturelle
     energy: 7
     incantation_time: 8
@@ -3094,6 +3350,7 @@ spells:
         ref: entry:fertilite
   - id: instinct-de-reproduction
     name: Instinct de reproduction
+    status: active
     school_id: magie-naturelle
     energy: 8
     incantation_time: 9
@@ -3106,6 +3363,7 @@ spells:
         ref: entry:instinct-de-reproduction
   - id: instinct-de-survie
     name: Instinct de survie
+    status: active
     school_id: magie-naturelle
     energy: 8
     incantation_time: 9
@@ -3118,6 +3376,7 @@ spells:
         ref: entry:instinct-de-survie
   - id: marecage
     name: Marécage
+    status: active
     school_id: magie-naturelle
     energy: 6
     incantation_time: 7
@@ -3130,6 +3389,7 @@ spells:
         ref: entry:marecage
   - id: murissement
     name: Mûrissement
+    status: active
     school_id: magie-naturelle
     energy: 5
     incantation_time: 6
@@ -3142,6 +3402,7 @@ spells:
         ref: entry:murissement
   - id: obstacles-vegetaux
     name: Obstacles végétaux
+    status: active
     school_id: magie-naturelle
     energy: 6
     incantation_time: 8
@@ -3154,6 +3415,7 @@ spells:
         ref: entry:obstacles-vegetaux
   - id: reveil-de-la-bete
     name: Réveil de la bête
+    status: active
     school_id: magie-naturelle
     energy: 11
     incantation_time: 13
@@ -3166,6 +3428,7 @@ spells:
         ref: entry:reveil-de-la-bete
   - id: sol-fertile
     name: Sol fertile
+    status: active
     school_id: magie-naturelle
     energy: 6
     incantation_time: 8
@@ -3178,6 +3441,7 @@ spells:
         ref: entry:sol-fertile
   - id: torsion-du-bois
     name: Torsion du bois
+    status: active
     school_id: magie-naturelle
     energy: 8
     incantation_time: 9
@@ -3190,6 +3454,7 @@ spells:
         ref: entry:torsion-du-bois
   - id: appel-des-morts
     name: Appel des morts
+    status: active
     school_id: necromancie
     energy: 14
     incantation_time: 22
@@ -3202,6 +3467,7 @@ spells:
         ref: entry:appel-des-morts
   - id: appel-des-morts-de-masse
     name: Appel des morts de masse
+    status: active
     school_id: necromancie
     energy: 19
     incantation_time: 31
@@ -3214,6 +3480,7 @@ spells:
         ref: entry:appel-des-morts-de-masse
   - id: appel-des-morts-majeur
     name: Appel des morts majeur
+    status: active
     school_id: necromancie
     energy: 17
     incantation_time: 27
@@ -3226,6 +3493,7 @@ spells:
         ref: entry:appel-des-morts-majeur
   - id: armure-d-os
     name: Armure d’os
+    status: active
     school_id: necromancie
     energy: 4
     incantation_time: 7
@@ -3238,6 +3506,7 @@ spells:
         ref: entry:armure-d-os
   - id: cage-d-os
     name: Cage d'os
+    status: active
     school_id: necromancie
     energy: 7
     incantation_time: 11
@@ -3250,6 +3519,7 @@ spells:
         ref: entry:cage-d-os
   - id: changement-spectral
     name: Changement spectral
+    status: active
     school_id: necromancie
     energy: 33
     incantation_time: 52
@@ -3262,6 +3532,7 @@ spells:
         ref: entry:changement-spectral
   - id: corruption-de-l-air
     name: Corruption de l'air
+    status: active
     school_id: necromancie
     energy: 24
     incantation_time: 38
@@ -3274,6 +3545,7 @@ spells:
         ref: entry:corruption-de-l-air
   - id: corruption-de-l-eau
     name: Corruption de l'eau
+    status: active
     school_id: necromancie
     energy: 24
     incantation_time: 38
@@ -3286,6 +3558,7 @@ spells:
         ref: entry:corruption-de-l-eau
   - id: corruption-vegetale
     name: Corruption végétale
+    status: active
     school_id: necromancie
     energy: 4
     incantation_time: 6
@@ -3298,6 +3571,7 @@ spells:
         ref: entry:corruption-vegetale
   - id: crane-hurlant
     name: Crâne hurlant
+    status: active
     school_id: necromancie
     energy: 10
     incantation_time: 16
@@ -3310,6 +3584,7 @@ spells:
         ref: entry:crane-hurlant
   - id: decret-de-non-repos
     name: Décret de non repos
+    status: active
     school_id: necromancie
     energy: 14
     incantation_time: 22
@@ -3322,6 +3597,7 @@ spells:
         ref: entry:decret-de-non-repos
   - id: mort-temporaire
     name: Mort temporaire
+    status: active
     school_id: necromancie
     energy: 22
     incantation_time: 36
@@ -3334,6 +3610,7 @@ spells:
         ref: entry:mort-temporaire
   - id: piege-d-os
     name: Piège d'os
+    status: active
     school_id: necromancie
     energy: 7
     incantation_time: 11
@@ -3346,6 +3623,7 @@ spells:
         ref: entry:piege-d-os
   - id: putrefaction
     name: Putréfaction
+    status: active
     school_id: necromancie
     energy: 9
     incantation_time: 15
@@ -3358,6 +3636,7 @@ spells:
         ref: entry:putrefaction
   - id: raideur-cadaverique
     name: Raideur cadavérique
+    status: active
     school_id: necromancie
     energy: 7
     incantation_time: 11
@@ -3370,6 +3649,7 @@ spells:
         ref: entry:raideur-cadaverique
   - id: reanimation-des-membres
     name: Réanimation des membres
+    status: active
     school_id: necromancie
     energy: 7
     incantation_time: 10
@@ -3382,6 +3662,7 @@ spells:
         ref: entry:reanimation-des-membres
   - id: renvoi
     name: Renvoi
+    status: active
     school_id: necromancie
     energy: 4
     incantation_time: 7
@@ -3394,6 +3675,7 @@ spells:
         ref: entry:renvoi
   - id: renvoie-de-masse
     name: Renvoie de masse
+    status: active
     school_id: necromancie
     energy: 6
     incantation_time: 10
@@ -3406,6 +3688,7 @@ spells:
         ref: entry:renvoie-de-masse
   - id: terre-sterile
     name: Terre stérile
+    status: active
     school_id: necromancie
     energy: 6
     incantation_time: 9
@@ -3418,6 +3701,7 @@ spells:
         ref: entry:terre-sterile
   - id: touche-mortel
     name: Touché mortel
+    status: active
     school_id: necromancie
     energy: 120
     incantation_time: 192
@@ -3430,6 +3714,7 @@ spells:
         ref: entry:touche-mortel
   - id: vieillissement
     name: Vieillissement
+    status: active
     school_id: necromancie
     energy: 7
     incantation_time: 11
@@ -3442,6 +3727,7 @@ spells:
         ref: entry:vieillissement
   - id: affaiblissement
     name: Affaiblissement
+    status: active
     school_id: magie-noire
     energy: 8
     incantation_time: 7
@@ -3454,6 +3740,7 @@ spells:
         ref: entry:affaiblissement
   - id: affaiblissement-de-masse
     name: Affaiblissement de masse
+    status: active
     school_id: magie-noire
     energy: 12
     incantation_time: 10
@@ -3466,6 +3753,7 @@ spells:
         ref: entry:affaiblissement-de-masse
   - id: antipathisme
     name: Antipathisme
+    status: active
     school_id: magie-noire
     energy: 9
     incantation_time: 8
@@ -3478,6 +3766,7 @@ spells:
         ref: entry:antipathisme
   - id: apathie
     name: Apathie
+    status: active
     school_id: magie-noire
     energy: 7
     incantation_time: 6
@@ -3490,6 +3779,7 @@ spells:
         ref: entry:apathie
   - id: arret-du-temps
     name: Arrêt du temps
+    status: active
     school_id: magie-noire
     energy: 47
     incantation_time: 42
@@ -3502,6 +3792,7 @@ spells:
         ref: entry:arret-du-temps
   - id: autodestruction
     name: Autodestruction
+    status: active
     school_id: magie-noire
     energy: 18
     incantation_time: 16
@@ -3516,6 +3807,7 @@ spells:
         ref: entry:autodestruction
   - id: betise
     name: Bêtise
+    status: active
     school_id: magie-noire
     energy: 9
     incantation_time: 8
@@ -3528,6 +3820,7 @@ spells:
         ref: entry:betise
   - id: contagion-du-peche
     name: Contagion du péché
+    status: active
     school_id: magie-noire
     energy: 207
     incantation_time: 186
@@ -3540,6 +3833,7 @@ spells:
         ref: entry:contagion-du-peche
   - id: control-charnel
     name: Control charnel
+    status: active
     school_id: magie-noire
     energy: 15
     incantation_time: 13
@@ -3552,6 +3846,7 @@ spells:
         ref: entry:control-charnel
   - id: controle-mental
     name: Contrôle mental
+    status: active
     school_id: magie-noire
     energy: 19
     incantation_time: 17
@@ -3564,6 +3859,7 @@ spells:
         ref: entry:controle-mental
   - id: douleur
     name: Douleur
+    status: active
     school_id: magie-noire
     energy: 9
     incantation_time: 8
@@ -3576,6 +3872,7 @@ spells:
         ref: entry:douleur
   - id: douleur-a-distance
     name: Douleur à distance
+    status: active
     school_id: magie-noire
     energy: 12
     incantation_time: 11
@@ -3588,6 +3885,7 @@ spells:
         ref: entry:douleur-a-distance
   - id: douleur-de-masse
     name: Douleur de masse
+    status: active
     school_id: magie-noire
     energy: 14
     incantation_time: 13
@@ -3600,6 +3898,7 @@ spells:
         ref: entry:douleur-de-masse
   - id: douleur-majeure
     name: Douleur majeure
+    status: active
     school_id: magie-noire
     energy: 12
     incantation_time: 10
@@ -3612,6 +3911,7 @@ spells:
         ref: entry:douleur-majeure
   - id: douleur-mineure
     name: Douleur mineure
+    status: active
     school_id: magie-noire
     energy: 7
     incantation_time: 6
@@ -3624,6 +3924,7 @@ spells:
         ref: entry:douleur-mineure
   - id: drain-de-jeunesse
     name: Drain de jeunesse
+    status: active
     school_id: magie-noire
     energy: 67
     incantation_time: 60
@@ -3636,6 +3937,7 @@ spells:
         ref: entry:drain-de-jeunesse
   - id: drain-de-sort
     name: Drain de sort
+    status: active
     school_id: magie-noire
     energy: 11
     incantation_time: 9
@@ -3648,6 +3950,7 @@ spells:
         ref: entry:drain-de-sort
   - id: drain-de-sort-majeur
     name: Drain de sort majeur
+    status: active
     school_id: magie-noire
     energy: 13
     incantation_time: 12
@@ -3660,6 +3963,7 @@ spells:
         ref: entry:drain-de-sort-majeur
   - id: drain-de-sort-mineur
     name: Drain de sort mineur
+    status: active
     school_id: magie-noire
     energy: 7
     incantation_time: 7
@@ -3672,6 +3976,7 @@ spells:
         ref: entry:drain-de-sort-mineur
   - id: drain-de-vie
     name: Drain de vie
+    status: active
     school_id: magie-noire
     energy: 11
     incantation_time: 9
@@ -3684,6 +3989,7 @@ spells:
         ref: entry:drain-de-vie
   - id: emprise-corporelle
     name: Emprise corporelle
+    status: active
     school_id: magie-noire
     energy: 18
     incantation_time: 16
@@ -3696,6 +4002,7 @@ spells:
         ref: entry:emprise-corporelle
   - id: faiblesse
     name: Faiblesse
+    status: active
     school_id: magie-noire
     energy: 9
     incantation_time: 8
@@ -3708,6 +4015,7 @@ spells:
         ref: entry:faiblesse
   - id: folie
     name: Folie
+    status: active
     school_id: magie-noire
     energy: 79
     incantation_time: 71
@@ -3720,6 +4028,7 @@ spells:
         ref: entry:folie
   - id: hibernation
     name: Hibernation
+    status: active
     school_id: magie-noire
     energy: 17
     incantation_time: 15
@@ -3732,6 +4041,7 @@ spells:
         ref: entry:hibernation
   - id: horreur
     name: Horreur
+    status: active
     school_id: magie-noire
     energy: 8
     incantation_time: 7
@@ -3744,6 +4054,7 @@ spells:
         ref: entry:horreur
   - id: implosion
     name: Implosion
+    status: active
     school_id: magie-noire
     energy: 45
     incantation_time: 40
@@ -3756,6 +4067,7 @@ spells:
         ref: entry:implosion
   - id: lachete
     name: Lâcheté
+    status: active
     school_id: magie-noire
     energy: 7
     incantation_time: 7
@@ -3768,6 +4080,7 @@ spells:
         ref: entry:lachete
   - id: laideur
     name: Laideur
+    status: active
     school_id: magie-noire
     energy: 9
     incantation_time: 8
@@ -3780,6 +4093,7 @@ spells:
         ref: entry:laideur
   - id: lenteur
     name: Lenteur
+    status: active
     school_id: magie-noire
     energy: 15
     incantation_time: 13
@@ -3792,6 +4106,7 @@ spells:
         ref: entry:lenteur
   - id: lenteur-de-masse
     name: Lenteur de masse
+    status: active
     school_id: magie-noire
     energy: 21
     incantation_time: 18
@@ -3804,6 +4119,7 @@ spells:
         ref: entry:lenteur-de-masse
   - id: malediction
     name: Malédiction
+    status: active
     school_id: magie-noire
     energy: 14
     incantation_time: 13
@@ -3816,6 +4132,7 @@ spells:
         ref: entry:malediction
   - id: oubli
     name: Oubli
+    status: active
     school_id: magie-noire
     energy: 9
     incantation_time: 8
@@ -3828,6 +4145,7 @@ spells:
         ref: entry:oubli
   - id: paralysie
     name: Paralysie
+    status: active
     school_id: magie-noire
     energy: 9
     incantation_time: 8
@@ -3840,6 +4158,7 @@ spells:
         ref: entry:paralysie
   - id: penombre
     name: Pénombre
+    status: active
     school_id: magie-noire
     energy: 7
     incantation_time: 6
@@ -3852,6 +4171,7 @@ spells:
         ref: entry:penombre
   - id: peur
     name: Peur
+    status: active
     school_id: magie-noire
     energy: 8
     incantation_time: 7
@@ -3864,6 +4184,7 @@ spells:
         ref: entry:peur
   - id: pluie-de-sang
     name: Pluie de sang
+    status: active
     school_id: magie-noire
     energy: 9
     incantation_time: 8
@@ -3876,6 +4197,7 @@ spells:
         ref: entry:pluie-de-sang
   - id: resserrement-des-murs
     name: Resserrement des murs
+    status: active
     school_id: magie-noire
     energy: 14
     incantation_time: 12
@@ -3888,6 +4210,7 @@ spells:
         ref: entry:resserrement-des-murs
   - id: vengeance
     name: Vengeance
+    status: active
     school_id: magie-noire
     energy: 9
     incantation_time: 8
@@ -3900,6 +4223,7 @@ spells:
         ref: entry:vengeance
   - id: vengeance-en-masse
     name: Vengeance en masse
+    status: active
     school_id: magie-noire
     energy: 13
     incantation_time: 11

--- a/docs/canonical/source-manifest.yaml
+++ b/docs/canonical/source-manifest.yaml
@@ -7906,7 +7906,7 @@ sources:
     notes: "Product catalog table."
   - id: "data-catalogs-atouts"
     path: "data/catalogs/atouts.yaml"
-    sha256: "4b88861f7ab2177e411097976074e0321805b7e20485ea14aef4f9e2d7b3a66c"
+    sha256: "309112ef179836b88a98802314f34124d762486103f810c4e8d4cd96136490d8"
     source_type: catalog_yaml
     priority: 90
     status: active
@@ -7915,7 +7915,7 @@ sources:
     notes: "Product YAML catalog."
   - id: "data-catalogs-bestiaire"
     path: "data/catalogs/bestiaire.yaml"
-    sha256: "0fd177814a8cba18e28ff59df5bd40b2d44dca343545088501b415dbffcdd763"
+    sha256: "b9b6c96d0d1ecb282da949b14040be56b3d370d688f54b8bf500ff24491508cb"
     source_type: catalog_yaml
     priority: 90
     status: active
@@ -7942,7 +7942,7 @@ sources:
     notes: "Product YAML catalog."
   - id: "data-catalogs-classes"
     path: "data/catalogs/classes.yaml"
-    sha256: "ca0f8b071238de3af184c2a13d300ff260482756bc661d844db16b1b9d0ed0d3"
+    sha256: "16822417735d45e9692d45318dc998eca88b70ac572c074fbcc7fe7ee97c5a7a"
     source_type: catalog_yaml
     priority: 90
     status: active
@@ -7951,7 +7951,7 @@ sources:
     notes: "Product YAML catalog."
   - id: "data-catalogs-competences"
     path: "data/catalogs/competences.yaml"
-    sha256: "07b5cb838a6f93548cb02cc4e611498cb07397630a580f8c3fb16ad588424058"
+    sha256: "c3f2bbf779626391287e720fa05ffc6cbf5506ab4b42d78ecaefeb6dd9f0cb07"
     source_type: catalog_yaml
     priority: 90
     status: active
@@ -7987,7 +7987,7 @@ sources:
     notes: "Product YAML catalog."
   - id: "data-catalogs-magic-schools"
     path: "data/catalogs/magic-schools.yaml"
-    sha256: "05286d621d627b28ca8ed509844cd07f982826b321b2f8b847b354bd7d74c7c6"
+    sha256: "e800ed7248c76f0683e32bbb9bb4148fa6bf555d66d1ace620164c5d9a5a7b6e"
     source_type: catalog_yaml
     priority: 90
     status: active
@@ -8014,7 +8014,7 @@ sources:
     notes: "Product YAML catalog."
   - id: "data-catalogs-orientations"
     path: "data/catalogs/orientations.yaml"
-    sha256: "2fface6be9852d23627263c7c39ffb212bd30cff6aca3ecdae19c58acf745a44"
+    sha256: "13a1cb8496628c2708ea9f53f12c2c63b230f9918effc3e68db5280b53526e6b"
     source_type: catalog_yaml
     priority: 90
     status: active
@@ -8059,7 +8059,7 @@ sources:
     notes: "Product YAML catalog."
   - id: "data-catalogs-spells"
     path: "data/catalogs/spells.yaml"
-    sha256: "7ee80f69170c015e80616adf56aeac6ce10a5fcc2165e1fdd9c368955dfbba7c"
+    sha256: "9791f9f5706c718d0c85545f10177a5887817e868ee47cb1c3450b857c14b51e"
     source_type: catalog_yaml
     priority: 90
     status: active

--- a/packages/catalogs/src/schemas.test.ts
+++ b/packages/catalogs/src/schemas.test.ts
@@ -26,7 +26,42 @@ const expectedCollections = [
   ['atouts.yaml', 'atouts', 416]
 ] as const;
 
+const traceableCollections = [
+  ['bestiaire.yaml', 'creatures'],
+  ['competences.yaml', 'skills'],
+  ['orientations.yaml', 'orientations'],
+  ['classes.yaml', 'classes'],
+  ['magic-schools.yaml', 'schools'],
+  ['spells.yaml', 'spells'],
+  ['legacy-characters.yaml', 'characters'],
+  ['atouts.yaml', 'atouts']
+] as const;
+
+const acceptedEntryStatuses = new Set(['active', 'ambiguous', 'deprecated', 'raw_reference_only']);
+
 describe('catalog Zod schemas', () => {
+  it.each(traceableCollections)(
+    'requires %s %s entries to carry status and source refs',
+    async (file, key) => {
+      const catalog = await loadValidatedCatalog(file);
+      const rows = (catalog as unknown as Record<string, Array<Record<string, unknown>>>)[key];
+
+      expect(rows.length).toBeGreaterThan(0);
+      for (const row of rows) {
+        expect(acceptedEntryStatuses.has(String(row.status))).toBe(true);
+        expect(row.source_refs).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              path: expect.stringMatching(/^(data|docs)\//),
+              ref: expect.any(String),
+              sha256: expect.stringMatching(/^[0-9a-f]{64}$/)
+            })
+          ])
+        );
+      }
+    }
+  );
+
   it.each(expectedCollections)(
     'validates %s %s against the canonical YAML',
     async (file, key, count) => {
@@ -284,6 +319,47 @@ describe('catalog Zod schemas', () => {
     expect(ids.has('ambidextrie')).toBe(true);
     expect(ids.has('anosmie')).toBe(true);
     expect(ids.has('demo-atout')).toBe(false);
+  });
+
+  it('rejects priority catalog entries without an explicit status', () => {
+    const validate = () =>
+      validateCatalogData(
+        'spells.yaml',
+        {
+          version: 1,
+          metadata: {
+            source: 'test'
+          },
+          spells: [
+            {
+              id: 'test-spell',
+              name: 'Test spell',
+              school_id: 'abjuration',
+              energy: 1,
+              incantation_time: 1,
+              difficulty: 1,
+              effect: 'Test effect',
+              value: 1,
+              source_refs: [
+                {
+                  path: 'data/legacy/web-scraped/documents/grimoire/index.md',
+                  ref: 'entry:test-spell',
+                  sha256: 'a'.repeat(64)
+                }
+              ]
+            }
+          ]
+        },
+        'fixtures/spells.yaml'
+      );
+
+    expect(validate).toThrow(CatalogValidationError);
+
+    try {
+      validate();
+    } catch (error) {
+      expect((error as Error).message).toContain('spells.0.status');
+    }
   });
 
   it('reports the file and data path when validation fails', () => {

--- a/packages/catalogs/src/schemas.ts
+++ b/packages/catalogs/src/schemas.ts
@@ -25,6 +25,13 @@ export const EntryMetadataSchema = z
   })
   .passthrough();
 
+export const CatalogEntryStatusSchema = z.enum([
+  'active',
+  'ambiguous',
+  'deprecated',
+  'raw_reference_only'
+]);
+
 export const DamageProfileSchema = z
   .object({
     P: z.number(),
@@ -62,6 +69,7 @@ export const BestiaryEntrySchema = z
   .object({
     id: NonEmptyStringSchema,
     name: NonEmptyStringSchema,
+    status: CatalogEntryStatusSchema,
     category: NonEmptyStringSchema,
     size_m: z.number(),
     life_expectancy: z.number(),
@@ -203,6 +211,7 @@ export const SkillSchema = z
   .object({
     id: NonEmptyStringSchema,
     name: NonEmptyStringSchema,
+    status: CatalogEntryStatusSchema,
     family: NonEmptyStringSchema,
     family_name: NonEmptyStringSchema.optional(),
     parent_id: NullableStringSchema.optional(),
@@ -219,6 +228,7 @@ export const OrientationSchema = z
   .object({
     id: NonEmptyStringSchema,
     name: NonEmptyStringSchema,
+    status: CatalogEntryStatusSchema,
     is_magical: z.boolean(),
     source_refs: z.array(SourceRefSchema).optional(),
     metadata: EntryMetadataSchema.optional()
@@ -235,6 +245,7 @@ export const ClassSchema = z
   .object({
     id: NonEmptyStringSchema,
     name: NonEmptyStringSchema,
+    status: CatalogEntryStatusSchema,
     orientation_id: NonEmptyStringSchema,
     primary_skill_id: NullableStringSchema.optional(),
     primary_skill_choice: PrimarySkillChoiceSchema,
@@ -251,6 +262,7 @@ export const MagicSchoolSchema = z
   .object({
     id: NonEmptyStringSchema,
     name: NonEmptyStringSchema,
+    status: CatalogEntryStatusSchema,
     source_label: NonEmptyStringSchema.optional(),
     color: NonEmptyStringSchema,
     specialist_class_id: NonEmptyStringSchema,
@@ -268,6 +280,7 @@ export const SpellSchema = z
   .object({
     id: NonEmptyStringSchema,
     name: NonEmptyStringSchema,
+    status: CatalogEntryStatusSchema,
     school_id: NonEmptyStringSchema,
     energy: z.number().int(),
     incantation_time: z.number().int(),
@@ -312,6 +325,7 @@ export const AtoutSchema = z
   .object({
     id: NonEmptyStringSchema,
     name: NonEmptyStringSchema,
+    status: CatalogEntryStatusSchema,
     effect: z.string(),
     value: z.number().int(),
     activation: AtoutActivationSchema,
@@ -340,6 +354,7 @@ export type OrganisationsCatalog = z.infer<typeof OrganisationsCatalogSchema>;
 export type Religion = z.infer<typeof ReligionSchema>;
 export type ReligionsCatalog = z.infer<typeof ReligionsCatalogSchema>;
 export type SourceRef = z.infer<typeof SourceRefSchema>;
+export type CatalogEntryStatus = z.infer<typeof CatalogEntryStatusSchema>;
 export type Skill = z.infer<typeof SkillSchema>;
 export type SkillsCatalog = z.infer<typeof SkillsCatalogSchema>;
 export type Orientation = z.infer<typeof OrientationSchema>;

--- a/tools/build-atouts-catalog.ts
+++ b/tools/build-atouts-catalog.ts
@@ -16,6 +16,7 @@ const ACTIVATION_VALUES = new Set(['Permanent', 'Ephémère']);
 interface AtoutEntry {
   id: string;
   name: string;
+  status: 'active';
   effect: string;
   value: number;
   activation: 'permanent' | 'ephemere';
@@ -87,6 +88,7 @@ function parse(): { atouts: AtoutEntry[]; sourceHash: string } {
     atouts.push({
       id,
       name,
+      status: 'active',
       effect,
       value,
       activation: activationLine === 'Permanent' ? 'permanent' : 'ephemere',

--- a/tools/build-orientations-classes-catalog.ts
+++ b/tools/build-orientations-classes-catalog.ts
@@ -89,6 +89,7 @@ const PRIMARY_SKILL_BY_CLASS: Record<string, string> = {
 interface OrientationEntry {
   id: string;
   name: string;
+  status: 'active';
   is_magical: boolean;
   source_refs: Array<{ path: string; sha256: string; ref: string }>;
 }
@@ -96,6 +97,7 @@ interface OrientationEntry {
 interface ClassEntry {
   id: string;
   name: string;
+  status: 'active';
   orientation_id: string;
   primary_skill_id: string | null;
   primary_skill_choice: 'fixed' | 'player_choice' | 'magician_no_primary';
@@ -139,6 +141,7 @@ function parse(): {
       const orientation: OrientationEntry = {
         id,
         name: trimmed,
+        status: 'active',
         is_magical: id === 'magicien',
         source_refs: [{ path: RELATIVE_SOURCE, sha256: sourceHash, ref: `line:${i + 1}` }]
       };
@@ -170,6 +173,7 @@ function parse(): {
     classes.push({
       id,
       name: trimmed,
+      status: 'active',
       orientation_id: currentOrientation.id,
       primary_skill_id: primarySkillId,
       primary_skill_choice: primarySkillChoice,

--- a/tools/build-skills-catalog.ts
+++ b/tools/build-skills-catalog.ts
@@ -25,6 +25,7 @@ const FAMILIES = new Set([
 interface SkillEntry {
   id: string;
   name: string;
+  status: 'active';
   family: string;
   family_name: string;
   parent_id: string | null;
@@ -110,6 +111,7 @@ function parse(): { skills: SkillEntry[]; sourceHash: string; relativeSourcePath
     skills.push({
       id,
       name: rawName,
+      status: 'active',
       family: slugify(currentFamily),
       family_name: currentFamily,
       parent_id: parentId,
@@ -150,6 +152,7 @@ function buildCatalog(): unknown {
     skills: skills.map((skill) => ({
       id: skill.id,
       name: skill.name,
+      status: skill.status,
       family: skill.family,
       family_name: skill.family_name,
       parent_id: skill.parent_id,

--- a/tools/build-spells-catalog.ts
+++ b/tools/build-spells-catalog.ts
@@ -114,6 +114,7 @@ const SOURCE_LABEL_TO_SCHOOL = new Map(SCHOOLS.map((s) => [s.source_label, s]));
 interface SpellEntry {
   id: string;
   name: string;
+  status: 'active';
   school_id: string;
   energy: number;
   incantation_time: number;
@@ -174,6 +175,7 @@ function parse(): { spells: SpellEntry[]; sourceHash: string } {
     spells.push({
       id,
       name: nameLine,
+      status: 'active',
       school_id: school.id,
       energy: parseNumeric(energyToken, i + 2),
       incantation_time: parseNumeric(tiToken, i + 3),
@@ -216,6 +218,7 @@ function main(): void {
     schools: SCHOOLS.map((school) => ({
       id: school.id,
       name: school.name,
+      status: 'active',
       source_label: school.source_label,
       color: school.color,
       specialist_class_id: school.specialist,


### PR DESCRIPTION
## Summary
- add required entry `status` to character, magic and atouts catalog schemas
- stamp active status into sourced P0 catalog entries while preserving source_refs
- update catalog generators and regenerate canonical source hashes/matrix

Resolves #43

## Validation
- pnpm exec vitest run packages/catalogs/src/schemas.test.ts packages/catalogs/src/loader.test.ts tools/canonical.test.ts
- pnpm validate