### PR TITLE
feat(catalogs): import canonical read models

### DIFF
--- a/apps/server/src/catalogs/read-models.test.ts
+++ b/apps/server/src/catalogs/read-models.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { PRIORITY_CATALOG_NAMES } from '@knightandwizard/catalogs';
+
+import { createSqlClient } from '../db/client.js';
+import { runMigrations } from '../db/migrate.js';
+import { buildCatalogDocumentReadModels, upsertCatalogDocuments } from './read-models.js';
+
+const sql = createSqlClient();
+
+beforeAll(async () => {
+  await runMigrations();
+  await sql`DELETE FROM catalog_documents WHERE source_path LIKE 'data/catalogs/%'`;
+});
+
+afterAll(async () => {
+  await sql.end({ timeout: 5 });
+});
+
+describe('catalog document read models', () => {
+  it('builds one hashed read model per priority catalog with traced entries', async () => {
+    const documents = await buildCatalogDocumentReadModels();
+    const byName = new Map(documents.map((document) => [document.catalogName, document]));
+    const spells = byName.get('spells.yaml')?.document as
+      | { spells?: Array<{ source_refs?: unknown[]; status?: string }> }
+      | undefined;
+
+    expect(documents.map((document) => document.catalogName).sort()).toEqual(
+      [...PRIORITY_CATALOG_NAMES].sort()
+    );
+    expect(byName.get('spells.yaml')?.contentHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(spells?.spells?.[0]).toMatchObject({
+      status: 'active',
+      source_refs: expect.arrayContaining([
+        expect.objectContaining({ path: 'data/legacy/web-scraped/documents/grimoire/index.md' })
+      ])
+    });
+  });
+
+  it('upserts priority catalogs into catalog_documents with status, source refs and hash', async () => {
+    const documents = await buildCatalogDocumentReadModels();
+    const imported = await upsertCatalogDocuments(sql, documents);
+
+    const countRows = await sql<{ count: string }[]>`
+      SELECT count(*)::text AS count
+      FROM catalog_documents
+      WHERE source_path LIKE 'data/catalogs/%'
+    `;
+    const spellRows = await sql<
+      Array<{
+        catalog_name: string;
+        content_hash: string;
+        source_ref_path: string;
+        status: string;
+      }>
+    >`
+      SELECT
+        catalog_name,
+        content_hash,
+        document #>> '{spells,0,status}' AS status,
+        document #>> '{spells,0,source_refs,0,path}' AS source_ref_path
+      FROM catalog_documents
+      WHERE source_path = 'data/catalogs/spells.yaml'
+    `;
+
+    expect(imported).toBe(PRIORITY_CATALOG_NAMES.length);
+    expect(Number(countRows[0]?.count)).toBe(PRIORITY_CATALOG_NAMES.length);
+    expect(spellRows[0]).toMatchObject({
+      catalog_name: 'spells.yaml',
+      status: 'active',
+      source_ref_path: 'data/legacy/web-scraped/documents/grimoire/index.md'
+    });
+    expect(spellRows[0]?.content_hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/apps/server/src/catalogs/read-models.ts
+++ b/apps/server/src/catalogs/read-models.ts
@@ -1,0 +1,95 @@
+import 'dotenv/config';
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+import {
+  DEFAULT_CATALOGS_DIR,
+  PRIORITY_CATALOG_NAMES,
+  catalogPath,
+  loadValidatedCatalogs,
+  type PriorityCatalogName
+} from '@knightandwizard/catalogs';
+
+import { createSqlClient, type SqlClient } from '../db/client.js';
+
+type SqlJsonValue = Parameters<SqlClient['json']>[0];
+
+export interface CatalogDocumentReadModel {
+  catalogName: PriorityCatalogName;
+  contentHash: string;
+  document: SqlJsonValue;
+  sourcePath: string;
+}
+
+export async function buildCatalogDocumentReadModels(
+  catalogsDir = DEFAULT_CATALOGS_DIR
+): Promise<CatalogDocumentReadModel[]> {
+  const catalogs = await loadValidatedCatalogs(catalogsDir);
+
+  return Promise.all(
+    PRIORITY_CATALOG_NAMES.map(async (catalogName) => {
+      const absolutePath = catalogPath(catalogName, catalogsDir);
+      const content = await readFile(absolutePath, 'utf8');
+
+      return {
+        catalogName,
+        contentHash: createHash('sha256').update(content).digest('hex'),
+        document: catalogs[catalogName] as unknown as SqlJsonValue,
+        sourcePath: `data/catalogs/${catalogName}`
+      };
+    })
+  );
+}
+
+export async function upsertCatalogDocuments(
+  sql: SqlClient,
+  documents: CatalogDocumentReadModel[]
+): Promise<number> {
+  await sql.begin(async (tx) => {
+    for (const document of documents) {
+      await tx`
+        INSERT INTO catalog_documents (catalog_name, source_path, content_hash, document)
+        VALUES (
+          ${document.catalogName},
+          ${document.sourcePath},
+          ${document.contentHash},
+          ${tx.json(document.document)}::jsonb
+        )
+        ON CONFLICT (source_path) DO UPDATE SET
+          catalog_name = EXCLUDED.catalog_name,
+          content_hash = EXCLUDED.content_hash,
+          document = EXCLUDED.document,
+          updated_at = now()
+      `;
+    }
+  });
+
+  return documents.length;
+}
+
+export async function importCatalogDocuments(
+  sql: SqlClient,
+  catalogsDir = DEFAULT_CATALOGS_DIR
+): Promise<number> {
+  const documents = await buildCatalogDocumentReadModels(catalogsDir);
+  return upsertCatalogDocuments(sql, documents);
+}
+
+const isEntrypoint =
+  process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isEntrypoint) {
+  const sql = createSqlClient();
+  importCatalogDocuments(sql)
+    .then((count) => {
+      console.log(`catalog documents imported: ${count}`);
+    })
+    .catch((error: unknown) => {
+      console.error(error);
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await sql.end({ timeout: 5 });
+    });
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "dev:server": "pnpm --filter @knightandwizard/server dev",
     "devlab:reset": "bash scripts/devlab-reset.sh",
     "db:seed": "pnpm --filter @knightandwizard/server db:seed",
+    "db:import:catalogs": "tsx apps/server/src/catalogs/read-models.ts",
     "knowledge:dry-run": "tsx tools/index-knowledge-base.ts --dry-run",
     "knowledge:index": "tsx tools/index-knowledge-base.ts",
     "knowledge:index:dry-run": "tsx tools/index-knowledge-base.ts --dry-run",

--- a/tools/canonical.ts
+++ b/tools/canonical.ts
@@ -101,6 +101,22 @@ const generatedDir = 'docs/canonical';
 const sourceManifestPath = `${generatedDir}/source-manifest.yaml`;
 const canonicalMatrixPath = `${generatedDir}/canonical-matrix.yaml`;
 const coverageReportPath = `${generatedDir}/coverage-report.md`;
+const relationalReadModelCatalogPaths = new Set([
+  'data/catalogs/armes.yaml',
+  'data/catalogs/bestiaire.yaml',
+  'data/catalogs/protections.yaml',
+  'data/catalogs/potions.yaml',
+  'data/catalogs/nations.yaml',
+  'data/catalogs/organisations.yaml',
+  'data/catalogs/religions.yaml',
+  'data/catalogs/competences.yaml',
+  'data/catalogs/orientations.yaml',
+  'data/catalogs/classes.yaml',
+  'data/catalogs/magic-schools.yaml',
+  'data/catalogs/spells.yaml',
+  'data/catalogs/legacy-characters.yaml',
+  'data/catalogs/atouts.yaml'
+]);
 const ignoredDirectoryNames = new Set(['.git', '.next', '.turbo', 'dist', 'node_modules']);
 const textExtensions = new Set([
   '.css',
@@ -486,6 +502,12 @@ function collectCatalogUnits(
         'partial',
         'Zod schema coverage must be linked by domain implementation.'
       );
+      if (relationalReadModelCatalogPaths.has(source.path)) {
+        unit.relational_db = link(
+          'covered',
+          'apps/server/src/catalogs/read-models.ts imports validated catalog documents into catalog_documents with source hash, status and source_refs; apps/server/src/catalogs/read-models.test.ts verifies the PostgreSQL read model.'
+        );
+      }
       units.push(unit);
       for (const [childKey, childValue] of Object.entries(item)) {
         if (Array.isArray(childValue) || isRecord(childValue)) {
@@ -533,6 +555,10 @@ function extractAssetCsvUnits(source: SourceEntry, text: string): CanonicalMatri
       unit.zod_schema = link(
         'partial',
         'Zod schema coverage must be linked by domain implementation.'
+      );
+      unit.relational_db = link(
+        'covered',
+        'tools/import-catalogs.ts and apps/server/src/catalogs/read-models.ts preserve table/catalog rows in importable read models with source metadata; import tests verify idempotent loading.'
       );
       return unit;
     });


### PR DESCRIPTION
## Summary
- build validated priority catalog read-models for `catalog_documents`
- preserve source path, SHA-256 content hash, `status`, and `source_refs` in the PostgreSQL JSON document
- add DB-backed read-model tests and mark relational DB coverage in the canonical matrix

## Validation
- `pnpm exec vitest run apps/server/src/catalogs/read-models.test.ts tools/import-catalogs.test.ts packages/catalogs/src/schemas.test.ts tools/canonical.test.ts`
- `pnpm validate`

Resolves #44