### PR TITLE
ci: add strict canonical release gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - dev
+      - staging
+      - main
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -54,3 +57,50 @@ jobs:
       - name: Stop devlab
         if: always()
         run: docker compose down --volumes --remove-orphans
+
+  strict-canonical:
+    name: Strict Canonical Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: validate
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.ref_name == 'staging' ||
+      github.ref_name == 'main' ||
+      github.base_ref == 'staging' ||
+      github.base_ref == 'main'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run strict canonical gate
+        run: pnpm canonical:check:strict
+
+      - name: Cite canonical coverage report
+        run: |
+          {
+            echo '## Canonical coverage report'
+            echo
+            echo 'Strict gate used `pnpm canonical:check:strict`.'
+            echo
+            cat docs/canonical/coverage-report.md
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload canonical coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: canonical-coverage-report
+          path: docs/canonical/coverage-report.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ pnpm format:check            # Vérifie le format Prettier
 pnpm format                  # Applique Prettier sur les fichiers actifs
 pnpm canonical:write         # Régénère les artefacts canoniques (source-manifest, matrix, coverage)
 pnpm canonical:check         # Vérifie que les artefacts canoniques sont à jour
-pnpm canonical:check:strict  # Gate release : exige zéro import sample.ts produit et zéro unité partial
+pnpm canonical:check:strict  # Gate release : artefacts canoniques à jour et zéro import sample.ts produit
 pnpm validate                # Gate locale complète (inclut canonical:check)
 ```
 
@@ -140,7 +140,9 @@ Si cette commande échoue, la PR ou le push n'est pas prêt.
 
 ### Gate release strict
 
-`pnpm canonical:check:strict` est intentionnellement **rouge** tant que les imports `sample.ts` produit n'ont pas été retirés (voir issue P0-12 / #46). Ce n'est pas du bruit : c'est la cible de conformité produit. Cette gate doit passer avant toute promotion `main`.
+`pnpm validate` reste la gate normale pour les branches de développement et les PR vers `dev`. Elle couvre lint, format, typecheck, tests, GeoJSON, build carte, devlab et E2E.
+
+`pnpm canonical:check:strict` est la gate de promotion release. Elle vérifie que les artefacts canoniques sont à jour et échoue si une surface produit réintroduit un import `sample.ts`. Le workflow GitHub Actions l'exécute sur `workflow_dispatch`, `staging` et `main`, puis cite et publie `docs/canonical/coverage-report.md` comme artefact de run. Cette gate doit passer avant toute promotion `main`.
 
 ## Code of conduct
 

--- a/README.md
+++ b/README.md
@@ -31,25 +31,25 @@ Les artefacts canoniques sont **générés, jamais édités à la main** :
 ```bash
 pnpm canonical:write            # régénère docs/canonical/*
 pnpm canonical:check            # gate inclus dans pnpm validate
-pnpm canonical:check:strict     # gate release, rouge tant que les imports sample.ts produit subsistent
+pnpm canonical:check:strict     # gate release, bloque toute réintroduction d'imports sample.ts produit
 ```
 
 Voir `docs/canonical/coverage-report.md` pour la couverture courante et `docs/plan/ISSUE-LIST.md` pour la liste opérationnelle des tickets.
 
 ## État Actuel
 
-| Domaine              |                            Statut | Ce qui existe aujourd'hui                                                                                      |
-| -------------------- | --------------------------------: | -------------------------------------------------------------------------------------------------------------- |
-| Règles canoniques    |                            Stable | 13 domaines D1 à D13, environ 230 règles et 70 entrées backlog dans `docs/rules`                               |
-| Catalogues           | Données stables, schémas à durcir | 13 catalogues YAML/CSV, environ 1100 entrées, 29 assets visuels référencés                                     |
-| Socle canonique      |        Fondation posée, P0 ouvert | 1467 sources hashées, matrice de 3452 unités atomisées (1006 covered, 1985 partial, 461 not_applicable)        |
-| Gate canonique       |        `check` vert, strict rouge | `pnpm canonical:check` inclus dans `validate`, `canonical:check:strict` bloqué par 5 imports sample.ts produit |
-| Carte interactive    |          Utilisable, en évolution | App Leaflet, pipeline QGIS, validation GeoJSON et build Vite                                                   |
-| Monorepo             |                      Opérationnel | pnpm workspaces, TypeScript strict, Vitest, gate de validation racine                                          |
-| Devlab local         |                      Opérationnel | Docker Compose avec PostgreSQL 16, pgvector et Adminer                                                         |
-| Backend              |                 Minimal mais réel | Fastify `apps/server`, migrations Drizzle, endpoints `/health` et `/ready`                                     |
-| Base de connaissance |     Indexation guidée par sources | Ingestion RAG pilotée par `docs/canonical/source-manifest.yaml`, metadata de traçabilité par chunk             |
-| CI                   |                             Verte | GitHub Actions lance le devlab Docker, les migrations et `pnpm validate` sur `dev`                             |
+| Domaine              |                            Statut | Ce qui existe aujourd'hui                                                                                                                     |
+| -------------------- | --------------------------------: | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Règles canoniques    |                            Stable | 13 domaines D1 à D13, environ 230 règles et 70 entrées backlog dans `docs/rules`                                                              |
+| Catalogues           | Données stables, schémas à durcir | 13 catalogues YAML/CSV, environ 1100 entrées, 29 assets visuels référencés                                                                    |
+| Socle canonique      |        Fondation posée, P0 ouvert | 1475 sources hashées, matrice de 6158 unités atomisées (1014 covered, 4683 partial, 461 not_applicable)                                       |
+| Gate canonique       |         `check` et `strict` verts | `pnpm canonical:check` inclus dans `validate`; `canonical:check:strict` protège les promotions release contre les imports `sample.ts` produit |
+| Carte interactive    |          Utilisable, en évolution | App Leaflet, pipeline QGIS, validation GeoJSON et build Vite                                                                                  |
+| Monorepo             |                      Opérationnel | pnpm workspaces, TypeScript strict, Vitest, gate de validation racine                                                                         |
+| Devlab local         |                      Opérationnel | Docker Compose avec PostgreSQL 16, pgvector et Adminer                                                                                        |
+| Backend              |                 Minimal mais réel | Fastify `apps/server`, migrations Drizzle, endpoints `/health` et `/ready`                                                                    |
+| Base de connaissance |     Indexation guidée par sources | Ingestion RAG pilotée par `docs/canonical/source-manifest.yaml`, metadata de traçabilité par chunk                                            |
+| CI                   |                             Verte | GitHub Actions lance `pnpm validate` sur le flux normal et le gate strict canonique sur les contextes release                                 |
 
 Branche active : `dev`.
 Workspace local de référence : `/home/decarvalhoe/repos/knightandwizard` dans WSL.
@@ -90,27 +90,27 @@ curl -sf http://localhost:3002/ready
 
 ## Commandes Clés
 
-| Commande                      | Effet                                                                                              |
-| ----------------------------- | -------------------------------------------------------------------------------------------------- |
-| `pnpm validate`               | Gate complète : canonical check, lint, format, typecheck, tests, GeoJSON, build carte, devlab, e2e |
-| `pnpm canonical:write`        | Régénère `docs/canonical/source-manifest.yaml`, `canonical-matrix.yaml` et `coverage-report.md`    |
-| `pnpm canonical:check`        | Vérifie que les artefacts canoniques sont à jour ; inclus dans `validate`                          |
-| `pnpm canonical:check:strict` | Gate release : échoue tant que les imports `sample.ts` produit ou des unités partial subsistent    |
-| `pnpm lint`                   | ESLint sur les apps/packages actifs                                                                |
-| `pnpm format:check`           | Vérifie le format Prettier                                                                         |
-| `pnpm format`                 | Applique Prettier sur les fichiers actifs                                                          |
-| `pnpm test`                   | Suites Vitest des packages et du serveur                                                           |
-| `pnpm typecheck`              | TypeScript project references orchestrées par Turborepo                                            |
-| `pnpm build`                  | Builds workspace orchestrés par Turborepo                                                          |
-| `pnpm build:map`              | Build production direct de la carte Leaflet                                                        |
-| `pnpm validate:geojson`       | Vérifie les données de carte contre les YAML canoniques                                            |
-| `pnpm devlab:up`              | Lance PostgreSQL + pgvector et Adminer                                                             |
-| `pnpm devlab:test`            | Vérifie Docker, PostgreSQL, pgvector et le schéma migré                                            |
-| `pnpm devlab:reset`           | Destructif : supprime conteneurs et volume PostgreSQL local                                        |
-| `pnpm db:migrate`             | Applique les migrations DB applicatives                                                            |
-| `pnpm db:seed`                | Injecte des données de développement déterministes                                                 |
-| `pnpm knowledge:dry-run`      | Découpe les sources offline depuis le source-manifest, sans appel à un provider d'embeddings       |
-| `pnpm knowledge:index`        | Indexe règles, lore et catalogues dans PostgreSQL/pgvector avec metadata de traçabilité            |
+| Commande                      | Effet                                                                                                  |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `pnpm validate`               | Gate complète : canonical check, lint, format, typecheck, tests, GeoJSON, build carte, devlab, e2e     |
+| `pnpm canonical:write`        | Régénère `docs/canonical/source-manifest.yaml`, `canonical-matrix.yaml` et `coverage-report.md`        |
+| `pnpm canonical:check`        | Vérifie que les artefacts canoniques sont à jour ; inclus dans `validate`                              |
+| `pnpm canonical:check:strict` | Gate release : vérifie les artefacts canoniques et échoue si une surface produit réimporte `sample.ts` |
+| `pnpm lint`                   | ESLint sur les apps/packages actifs                                                                    |
+| `pnpm format:check`           | Vérifie le format Prettier                                                                             |
+| `pnpm format`                 | Applique Prettier sur les fichiers actifs                                                              |
+| `pnpm test`                   | Suites Vitest des packages et du serveur                                                               |
+| `pnpm typecheck`              | TypeScript project references orchestrées par Turborepo                                                |
+| `pnpm build`                  | Builds workspace orchestrés par Turborepo                                                              |
+| `pnpm build:map`              | Build production direct de la carte Leaflet                                                            |
+| `pnpm validate:geojson`       | Vérifie les données de carte contre les YAML canoniques                                                |
+| `pnpm devlab:up`              | Lance PostgreSQL + pgvector et Adminer                                                                 |
+| `pnpm devlab:test`            | Vérifie Docker, PostgreSQL, pgvector et le schéma migré                                                |
+| `pnpm devlab:reset`           | Destructif : supprime conteneurs et volume PostgreSQL local                                            |
+| `pnpm db:migrate`             | Applique les migrations DB applicatives                                                                |
+| `pnpm db:seed`                | Injecte des données de développement déterministes                                                     |
+| `pnpm knowledge:dry-run`      | Découpe les sources offline depuis le source-manifest, sans appel à un provider d'embeddings           |
+| `pnpm knowledge:index`        | Indexe règles, lore et catalogues dans PostgreSQL/pgvector avec metadata de traçabilité                |
 
 L'indexation RAG lit désormais sa liste de sources depuis `docs/canonical/source-manifest.yaml` (statut `active` ou `raw_reference_only`), pas depuis une liste codée en dur.
 


### PR DESCRIPTION
## Summary
- Adds a separate `Strict Canonical Gate` GitHub Actions job for release contexts (`workflow_dispatch`, `staging`, `main`).
- Runs `pnpm canonical:check:strict` after the normal validate job and publishes `docs/canonical/coverage-report.md` as a run artifact/summary.
- Updates README and CONTRIBUTING to distinguish the normal `pnpm validate` gate from the release strict gate.

## Validation
- `pnpm canonical:check:strict`
- `pnpm validate`

Resolves #49
