### PR TITLE
Externalize rules-core constants into versioned rules-config (#73)

### DIFF
--- a/packages/rules-core/src/character.ts
+++ b/packages/rules-core/src/character.ts
@@ -215,7 +215,8 @@ export function validateSkillDistribution(
 ): CharacterValidationResult {
   const errors: string[] = [];
   const total = sumPoints(skills);
-  const requiredSkillPoints = raceCategory - extraSpellPoints * config.creation.skillPointsPerSpellPoint;
+  const requiredSkillPoints =
+    raceCategory - extraSpellPoints * config.creation.skillPointsPerSpellPoint;
 
   if (requiredSkillPoints < 0) {
     errors.push(`extra spell points cannot consume more than ${raceCategory} skill points`);
@@ -285,7 +286,10 @@ export function createPlayerCharacter(
   }
 
   const energy = magician
-    ? { current: config.creation.magicianStartingEnergy, max: config.creation.magicianStartingEnergy }
+    ? {
+        current: config.creation.magicianStartingEnergy,
+        max: config.creation.magicianStartingEnergy
+      }
     : { current: 0, max: 0 };
 
   return {
@@ -318,7 +322,10 @@ export function createNonPlayerCharacter(
   config: RulesConfig = DEFAULT_RULES_CONFIG
 ): NonPlayerCharacter {
   const defaultEnergy = isMagician(input.orientation)
-    ? { current: config.creation.magicianStartingEnergy, max: config.creation.magicianStartingEnergy }
+    ? {
+        current: config.creation.magicianStartingEnergy,
+        max: config.creation.magicianStartingEnergy
+      }
     : { current: 0, max: 0 };
 
   return {

--- a/packages/rules-core/src/character.ts
+++ b/packages/rules-core/src/character.ts
@@ -1,4 +1,5 @@
 import { type Combatant } from './combat.js';
+import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
 
 export const ATTRIBUTE_KEYS = [
   'strength',
@@ -172,7 +173,8 @@ export class CharacterValidationError extends Error {
 
 export function validateAttributeDistribution(
   attributes: CharacterAttributes,
-  race: RaceProfile
+  race: RaceProfile,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
 ): CharacterValidationResult {
   const errors: string[] = [];
   const warnings: string[] = [];
@@ -184,7 +186,7 @@ export function validateAttributeDistribution(
 
   for (const key of ATTRIBUTE_KEYS) {
     const value = attributes[key];
-    const maximumAtCreation = race.attributeMax[key] - 1;
+    const maximumAtCreation = race.attributeMax[key] - config.creation.attributeMaxOffset;
 
     if (!Number.isInteger(value) || value < 0) {
       errors.push(`${key} must be a non-negative integer`);
@@ -208,11 +210,12 @@ export function validateAttributeDistribution(
 export function validateSkillDistribution(
   skills: CharacterSkill[],
   raceCategory: number,
-  extraSpellPoints = 0
+  extraSpellPoints = 0,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
 ): CharacterValidationResult {
   const errors: string[] = [];
   const total = sumPoints(skills);
-  const requiredSkillPoints = raceCategory - extraSpellPoints * 10;
+  const requiredSkillPoints = raceCategory - extraSpellPoints * config.creation.skillPointsPerSpellPoint;
 
   if (requiredSkillPoints < 0) {
     errors.push(`extra spell points cannot consume more than ${raceCategory} skill points`);
@@ -223,7 +226,7 @@ export function validateSkillDistribution(
   }
 
   for (const skill of skills) {
-    validatePointEntry('skill', skill, 4, errors);
+    validatePointEntry('skill', skill, config.creation.maxSkillPointsAtCreation, errors);
   }
 
   return buildValidationResult(errors, [], total);
@@ -232,40 +235,47 @@ export function validateSkillDistribution(
 export function validateSpellDistribution(
   spells: CharacterSpell[],
   isMagician: boolean,
-  extraSpellPoints = 0
+  extraSpellPoints = 0,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
 ): CharacterValidationResult {
   const errors: string[] = [];
   const total = sumPoints(spells);
-  const requiredSpellPoints = isMagician ? 2 + extraSpellPoints : 0;
+  const baseSpellPoints = config.creation.magicianBaseSpellPoints;
+  const requiredSpellPoints = isMagician ? baseSpellPoints + extraSpellPoints : 0;
 
   if (!isMagician && total > 0) {
     errors.push('non-magician characters cannot receive spell points at creation');
   }
 
-  if (isMagician && total < 2) {
-    errors.push('magician spell points must be at least 2 at creation');
+  if (isMagician && total < baseSpellPoints) {
+    errors.push(`magician spell points must be at least ${baseSpellPoints} at creation`);
   }
 
-  if (isMagician && total >= 2 && total !== requiredSpellPoints) {
+  if (isMagician && total >= baseSpellPoints && total !== requiredSpellPoints) {
     errors.push(`magician spell points must total ${requiredSpellPoints} at creation`);
   }
 
   for (const spell of spells) {
-    validatePointEntry('spell', spell, 2, errors);
+    validatePointEntry('spell', spell, config.creation.maxSpellPointsAtCreation, errors);
   }
 
   return buildValidationResult(errors, [], total);
 }
 
-export function createPlayerCharacter(input: CreatePlayerCharacterInput): PlayerCharacter {
+export function createPlayerCharacter(
+  input: CreatePlayerCharacterInput,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): PlayerCharacter {
   const spells = input.spells ?? [];
   const magician = isMagician(input.orientation);
   const spellTotal = sumPoints(spells);
-  const extraSpellPoints = magician ? Math.max(0, spellTotal - 2) : 0;
+  const extraSpellPoints = magician
+    ? Math.max(0, spellTotal - config.creation.magicianBaseSpellPoints)
+    : 0;
   const validationResults = [
-    validateAttributeDistribution(input.attributes, input.race),
-    validateSkillDistribution(input.skills, input.race.category, extraSpellPoints),
-    validateSpellDistribution(spells, magician, extraSpellPoints)
+    validateAttributeDistribution(input.attributes, input.race, config),
+    validateSkillDistribution(input.skills, input.race.category, extraSpellPoints, config),
+    validateSpellDistribution(spells, magician, extraSpellPoints, config)
   ];
   const errors = validationResults.flatMap((result) => result.errors);
   const warnings = validationResults.flatMap((result) => result.warnings);
@@ -274,7 +284,9 @@ export function createPlayerCharacter(input: CreatePlayerCharacterInput): Player
     throw new CharacterValidationError(errors, warnings);
   }
 
-  const energy = isMagician(input.orientation) ? { current: 60, max: 60 } : { current: 0, max: 0 };
+  const energy = magician
+    ? { current: config.creation.magicianStartingEnergy, max: config.creation.magicianStartingEnergy }
+    : { current: 0, max: 0 };
 
   return {
     id: input.id,
@@ -301,9 +313,12 @@ export function createPlayerCharacter(input: CreatePlayerCharacterInput): Player
   };
 }
 
-export function createNonPlayerCharacter(input: CreateNonPlayerCharacterInput): NonPlayerCharacter {
+export function createNonPlayerCharacter(
+  input: CreateNonPlayerCharacterInput,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): NonPlayerCharacter {
   const defaultEnergy = isMagician(input.orientation)
-    ? { current: 60, max: 60 }
+    ? { current: config.creation.magicianStartingEnergy, max: config.creation.magicianStartingEnergy }
     : { current: 0, max: 0 };
 
   return {
@@ -348,7 +363,10 @@ export function calculateEffectiveAttributes(character: Character): CharacterAtt
   return effective;
 }
 
-export function calculateLevelProgression(character: Character): LevelProgression {
+export function calculateLevelProgression(
+  character: Character,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): LevelProgression {
   if (isFamiliar(character.race)) {
     return {
       level: null,
@@ -362,7 +380,8 @@ export function calculateLevelProgression(character: Character): LevelProgressio
     ? []
     : collectPrimarySkillIds(character);
   const levelPoints = isMagician(character.orientation)
-    ? sumPoints(character.skills) + sumPoints(character.spells) * 2
+    ? sumPoints(character.skills) +
+      sumPoints(character.spells) * config.progression.magicianLevelSpellMultiplier
     : sumPoints(character.skills) + sumPrimaryTreePoints(character.skills, primarySkillIds);
 
   return {

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -286,7 +286,11 @@ export function resolveStaminaDamage(
   config: RulesConfig = DEFAULT_RULES_CONFIG
 ): CombatState {
   const target = findCombatant(state, targetId);
-  const staminaRoll = rollDice(target.attributes.stamina, config.combat.staminaRollDifficulty, options);
+  const staminaRoll = rollDice(
+    target.attributes.stamina,
+    config.combat.staminaRollDifficulty,
+    options
+  );
   const preventedDamage = staminaRoll.successes;
   const finalDamage = Math.max(0, damage - preventedDamage);
   const damagedState = finalDamage > 0 ? applyDamage(state, targetId, finalDamage) : state;

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -1,6 +1,7 @@
 import { type DiceRollResult, type RandomInteger, rollDice } from './dice.js';
+import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
 
-export const COMBAT_ROUND_LENGTH_DT = 50;
+export const COMBAT_ROUND_LENGTH_DT = DEFAULT_RULES_CONFIG.combat.roundLengthDT;
 
 export type TimelineDirection = '+' | '-' | '';
 export type CombatActionType = 'attack' | 'defense' | 'spell' | 'move' | 'wait';
@@ -281,10 +282,11 @@ export function resolveStaminaDamage(
   state: CombatState,
   targetId: string,
   damage: number,
-  options: CombatResolutionOptions = {}
+  options: CombatResolutionOptions = {},
+  config: RulesConfig = DEFAULT_RULES_CONFIG
 ): CombatState {
   const target = findCombatant(state, targetId);
-  const staminaRoll = rollDice(target.attributes.stamina, 7, options);
+  const staminaRoll = rollDice(target.attributes.stamina, config.combat.staminaRollDifficulty, options);
   const preventedDamage = staminaRoll.successes;
   const finalDamage = Math.max(0, damage - preventedDamage);
   const damagedState = finalDamage > 0 ? applyDamage(state, targetId, finalDamage) : state;

--- a/packages/rules-core/src/index.ts
+++ b/packages/rules-core/src/index.ts
@@ -4,4 +4,5 @@ export * from './combat.js';
 export * from './dice.js';
 export * from './npc-control.js';
 export * from './progression.js';
+export * from './rules-config.js';
 export * from './session.js';

--- a/packages/rules-core/src/progression.ts
+++ b/packages/rules-core/src/progression.ts
@@ -5,6 +5,7 @@ import {
   type CharacterSkill,
   type CharacterSpell
 } from './character.js';
+import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
 
 export type LearningKind =
   | 'skill'
@@ -65,11 +66,14 @@ export class ProgressionError extends Error {
   }
 }
 
-export function calculateSessionXPAward(criteria: SessionXPAwardCriteria): SessionXPAward {
+export function calculateSessionXPAward(
+  criteria: SessionXPAwardCriteria,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): SessionXPAward {
   const roleplayPoints = criteria.roleplayPoints ?? 0;
   const bonusXP = criteria.bonusXP ?? 0;
 
-  assertIntegerInRange('roleplayPoints', roleplayPoints, 0, 3);
+  assertIntegerInRange('roleplayPoints', roleplayPoints, 0, config.progression.maxRoleplayPoints);
   assertNonNegativeInteger('bonusXP', bonusXP);
 
   return {
@@ -112,7 +116,10 @@ export function finalizeDefinitiveDeath<TCharacter extends Character>(
   });
 }
 
-export function calculateLearningPlan(input: LearningPlanInput): LearningPlan {
+export function calculateLearningPlan(
+  input: LearningPlanInput,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): LearningPlan {
   assertPositiveInteger('xpCost', input.xpCost);
   assertNonNegativeInteger('learningSuccesses', input.learningSuccesses ?? 0);
   assertNonNegativeInteger('teachingSuccesses', input.teachingSuccesses ?? 0);
@@ -121,25 +128,29 @@ export function calculateLearningPlan(input: LearningPlanInput): LearningPlan {
 
   assertPositiveInteger('divisor', divisor);
 
-  const baseDays = input.xpCost * 3 * (input.selfTaught === true ? 2 : 1);
+  const baseDays =
+    input.xpCost *
+    config.progression.learningDaysPerXP *
+    (input.selfTaught === true ? config.progression.selfTaughtMultiplier : 1);
   const successes = (input.learningSuccesses ?? 0) + (input.teachingSuccesses ?? 0);
   const reducedDays = Math.ceil(Math.max(0, baseDays - successes) / divisor);
 
   return {
     baseDays,
-    finalDays: Math.max(learningFloor(input.kind), reducedDays)
+    finalDays: Math.max(learningFloor(input.kind, config), reducedDays)
   };
 }
 
 export function learnSkill<TCharacter extends Character>(
   character: TCharacter,
   skillId: string,
-  options: LearnSkillOptions = {}
+  options: LearnSkillOptions = {},
+  config: RulesConfig = DEFAULT_RULES_CONFIG
 ): TCharacter {
   assertNarrativeAccess(options.hasNarrativeAccess);
 
   const currentSkill = character.skills.find((skill) => skill.id === skillId);
-  const cost = skillImprovementCost(currentSkill?.points ?? 0);
+  const cost = skillImprovementCost(currentSkill?.points ?? 0, config);
 
   assertCanSpendXP(character, cost);
 
@@ -175,7 +186,8 @@ export function learnSkill<TCharacter extends Character>(
 export function learnSpell<TCharacter extends Character>(
   character: TCharacter,
   spellId: string,
-  options: LearnSpellOptions = {}
+  options: LearnSpellOptions = {},
+  config: RulesConfig = DEFAULT_RULES_CONFIG
 ): TCharacter {
   if (!isMagician(character)) {
     throw new ProgressionError('only magician characters can learn spells');
@@ -185,7 +197,7 @@ export function learnSpell<TCharacter extends Character>(
   assertMinimumLevel(character, options.minimumLevel);
 
   const currentSpell = character.spells.find((spell) => spell.id === spellId);
-  const cost = spellImprovementCost(currentSpell?.points ?? 0);
+  const cost = spellImprovementCost(currentSpell?.points ?? 0, config);
 
   assertCanSpendXP(character, cost);
 
@@ -216,14 +228,22 @@ export function learnSpell<TCharacter extends Character>(
   );
 }
 
-export function skillImprovementCost(currentPoints: number): number {
+export function skillImprovementCost(
+  currentPoints: number,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): number {
   assertNonNegativeInteger('currentPoints', currentPoints);
-  return currentPoints === 0 ? 3 : currentPoints * 3;
+  const base = config.progression.skillImprovementBaseCost;
+  return currentPoints === 0 ? base : currentPoints * base;
 }
 
-export function spellImprovementCost(currentPoints: number): number {
+export function spellImprovementCost(
+  currentPoints: number,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): number {
   assertNonNegativeInteger('currentPoints', currentPoints);
-  return currentPoints === 0 ? 10 : currentPoints * 10;
+  const base = config.progression.spellImprovementBaseCost;
+  return currentPoints === 0 ? base : currentPoints * base;
 }
 
 function spendXP(progression: CharacterProgression, cost: number): CharacterProgression {
@@ -279,19 +299,8 @@ function isMagician(character: Character): boolean {
   );
 }
 
-function learningFloor(kind: LearningKind): number {
-  switch (kind) {
-    case 'skill':
-      return 1;
-    case 'complex_skill':
-      return 3;
-    case 'new_spell':
-      return 7;
-    case 'spell_development':
-      return 14;
-    case 'conceptualization':
-      return 30;
-  }
+function learningFloor(kind: LearningKind, config: RulesConfig = DEFAULT_RULES_CONFIG): number {
+  return config.progression.learningFloors[kind];
 }
 
 function boolPoint(value?: boolean): number {

--- a/packages/rules-core/src/rules-config.test.ts
+++ b/packages/rules-core/src/rules-config.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import { addCombatant, createCombatState, resolveStaminaDamage } from './combat.js';
+import { calculateLearningPlan, skillImprovementCost, spellImprovementCost } from './progression.js';
+import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
+
+/**
+ * These tests prove rules-core is data-driven: the SAME function, fed a custom
+ * RulesConfig, produces different (rule-tuned) results, while DEFAULT_RULES_CONFIG
+ * reproduces the historical hard-coded behavior.
+ */
+
+function withProgression(overrides: Partial<RulesConfig['progression']>): RulesConfig {
+  return {
+    ...DEFAULT_RULES_CONFIG,
+    progression: {
+      ...DEFAULT_RULES_CONFIG.progression,
+      ...overrides
+    }
+  };
+}
+
+function withCombat(overrides: Partial<RulesConfig['combat']>): RulesConfig {
+  return {
+    ...DEFAULT_RULES_CONFIG,
+    combat: {
+      ...DEFAULT_RULES_CONFIG.combat,
+      ...overrides
+    }
+  };
+}
+
+function scriptedRolls(values: number[]) {
+  let index = 0;
+
+  return (sides: number): number => {
+    const value = values[index];
+    index += 1;
+
+    if (value === undefined) {
+      throw new Error(`No scripted roll left for D${sides}`);
+    }
+
+    return value;
+  };
+}
+
+describe('versioned rules-config', () => {
+  it('exposes the canonical default ruleset version', () => {
+    expect(DEFAULT_RULES_CONFIG.version).toBe(1);
+  });
+
+  it('drives skill improvement cost from config.skillImprovementBaseCost', () => {
+    const custom = withProgression({ skillImprovementBaseCost: 5 });
+
+    // default base 3: 0 pts -> 3, 2 pts -> 6
+    expect(skillImprovementCost(0)).toBe(3);
+    expect(skillImprovementCost(2)).toBe(6);
+
+    // custom base 5: 0 pts -> 5, 2 pts -> 10
+    expect(skillImprovementCost(0, custom)).toBe(5);
+    expect(skillImprovementCost(2, custom)).toBe(10);
+  });
+
+  it('drives spell improvement cost from config.spellImprovementBaseCost', () => {
+    const custom = withProgression({ spellImprovementBaseCost: 4 });
+
+    expect(spellImprovementCost(3)).toBe(30);
+    expect(spellImprovementCost(3, custom)).toBe(12);
+  });
+
+  it('drives learning duration from learningDaysPerXP, selfTaughtMultiplier and learningFloors', () => {
+    // Custom: 5 days per XP, self-taught x3, and a raised "skill" floor of 12.
+    const custom = withProgression({
+      learningDaysPerXP: 5,
+      selfTaughtMultiplier: 3,
+      learningFloors: {
+        ...DEFAULT_RULES_CONFIG.progression.learningFloors,
+        skill: 12
+      }
+    });
+
+    // Default: baseDays = 2 * 3 * 1 = 6, finalDays clamped to skill floor 1 -> 6.
+    expect(calculateLearningPlan({ xpCost: 2, kind: 'skill' })).toEqual({
+      baseDays: 6,
+      finalDays: 6
+    });
+
+    // Custom self-taught: baseDays = 2 * 5 * 3 = 30, no successes, floor 12 -> 30.
+    expect(calculateLearningPlan({ xpCost: 2, kind: 'skill', selfTaught: true }, custom)).toEqual({
+      baseDays: 30,
+      finalDays: 30
+    });
+
+    // Custom: enough successes to drop below the raised floor -> clamped to 12.
+    expect(
+      calculateLearningPlan({ xpCost: 2, kind: 'skill', learningSuccesses: 30 }, custom)
+    ).toEqual({
+      baseDays: 10,
+      finalDays: 12
+    });
+  });
+
+  it('drives the stamina endurance roll difficulty from config.staminaRollDifficulty', () => {
+    const makeState = () =>
+      addCombatant(createCombatState(1), {
+        id: 'target',
+        name: 'Target',
+        speedFactor: 5,
+        nextActionAt: 12,
+        reflexes: 3,
+        vitality: { current: 10, max: 10 },
+        attributes: { strength: 5, dexterity: 5, stamina: 3 },
+        baseAttributes: { strength: 5, dexterity: 5, stamina: 3 },
+        skills: {},
+        statuses: []
+      });
+
+    // Default difficulty 7: three dice showing 8 (>= 7) -> 3 successes -> 3 prevented.
+    const defaultResult = resolveStaminaDamage(makeState(), 'target', 5, {
+      randomInteger: scriptedRolls([8, 8, 8])
+    });
+    expect(defaultResult.log.at(-1)).toMatchObject({
+      type: 'stamina_roll_resolved',
+      preventedDamage: 3,
+      finalDamage: 2
+    });
+
+    // Custom difficulty 9: the SAME 8s now fail (8 < 9) -> 0 successes -> 0 prevented.
+    const custom = withCombat({ staminaRollDifficulty: 9 });
+    const customResult = resolveStaminaDamage(
+      makeState(),
+      'target',
+      5,
+      { randomInteger: scriptedRolls([8, 8, 8]) },
+      custom
+    );
+    expect(customResult.log.at(-1)).toMatchObject({
+      type: 'stamina_roll_resolved',
+      preventedDamage: 0,
+      finalDamage: 5
+    });
+  });
+});

--- a/packages/rules-core/src/rules-config.test.ts
+++ b/packages/rules-core/src/rules-config.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { addCombatant, createCombatState, resolveStaminaDamage } from './combat.js';
-import { calculateLearningPlan, skillImprovementCost, spellImprovementCost } from './progression.js';
+import {
+  calculateLearningPlan,
+  skillImprovementCost,
+  spellImprovementCost
+} from './progression.js';
 import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
 
 /**

--- a/packages/rules-core/src/rules-config.ts
+++ b/packages/rules-core/src/rules-config.ts
@@ -1,0 +1,105 @@
+/**
+ * Versioned, data-driven rule configuration ("les regles sont vivantes").
+ *
+ * Externalises constants that were previously hard-coded across rules-core so the
+ * ruleset can be tuned, versioned and migrated. `DEFAULT_RULES_CONFIG` reproduces
+ * the historical hard-coded values EXACTLY, so passing it (the default) is a no-op.
+ */
+
+export interface CombatRulesConfig {
+  /** Length of a combat round in DT (legacy cyclic 1..N display). */
+  roundLengthDT: number;
+  /** Difficulty of the stamina endurance roll that prevents damage. */
+  staminaRollDifficulty: number;
+  /** A hit knocks the target unconscious when finalDamage > vitality.current * this ratio. */
+  unconsciousDamageRatio: number;
+  /** Vitality malus = round(vitality.max * this ratio) - vitality.current (clamped >= 0). */
+  vitalityMalusRatio: number;
+}
+
+export interface CreationRulesConfig {
+  /** Per-attribute creation cap = race.attributeMax[attr] - this offset. */
+  attributeMaxOffset: number;
+  /** Maximum points on a single skill at creation. */
+  maxSkillPointsAtCreation: number;
+  /** Maximum points on a single spell at creation. */
+  maxSpellPointsAtCreation: number;
+  /** Spell points a magician receives at creation before conversion. */
+  magicianBaseSpellPoints: number;
+  /** Creation skill points consumed to buy one extra spell point. */
+  skillPointsPerSpellPoint: number;
+  /** Starting energy (current and max) for a magician character. */
+  magicianStartingEnergy: number;
+}
+
+export interface ProgressionRulesConfig {
+  /** XP cost to raise a skill: 0 pts -> base, otherwise currentPoints * base. */
+  skillImprovementBaseCost: number;
+  /** XP cost to raise a spell: 0 pts -> base, otherwise currentPoints * base. */
+  spellImprovementBaseCost: number;
+  /** Base learning days per XP cost point. */
+  learningDaysPerXP: number;
+  /** Multiplier applied to learning time when self-taught (no mentor). */
+  selfTaughtMultiplier: number;
+  /** Minimum learning-days floor per learning kind. */
+  learningFloors: {
+    skill: number;
+    complex_skill: number;
+    new_spell: number;
+    spell_development: number;
+    conceptualization: number;
+  };
+  /** Maximum roleplay points awardable per session. */
+  maxRoleplayPoints: number;
+  /** Magician level points = skill points + spell points * this multiplier. */
+  magicianLevelSpellMultiplier: number;
+}
+
+export interface RulesConfig {
+  /**
+   * Ruleset version. Persisted characters should record the version they were
+   * built under so they can be migrated when the ruleset changes.
+   */
+  version: number;
+  combat: CombatRulesConfig;
+  creation: CreationRulesConfig;
+  progression: ProgressionRulesConfig;
+}
+
+/**
+ * Canonical default ruleset. Values mirror the historical hard-coded constants
+ * in combat.ts / character.ts / progression.ts (do NOT change them here without
+ * a ruleset version bump and a character migration path).
+ */
+export const DEFAULT_RULES_CONFIG: RulesConfig = {
+  version: 1,
+  combat: {
+    roundLengthDT: 50,
+    staminaRollDifficulty: 7,
+    unconsciousDamageRatio: 0.5,
+    vitalityMalusRatio: 0.5
+  },
+  creation: {
+    attributeMaxOffset: 1,
+    maxSkillPointsAtCreation: 4,
+    maxSpellPointsAtCreation: 2,
+    magicianBaseSpellPoints: 2,
+    skillPointsPerSpellPoint: 10,
+    magicianStartingEnergy: 60
+  },
+  progression: {
+    skillImprovementBaseCost: 3,
+    spellImprovementBaseCost: 10,
+    learningDaysPerXP: 3,
+    selfTaughtMultiplier: 2,
+    learningFloors: {
+      skill: 1,
+      complex_skill: 3,
+      new_spell: 7,
+      spell_development: 14,
+      conceptualization: 30
+    },
+    maxRoleplayPoints: 3,
+    magicianLevelSpellMultiplier: 2
+  }
+};


### PR DESCRIPTION
## Summary
Externalizes hard-coded rule constants from `@knightandwizard/rules-core` into a **versioned, data-driven `RulesConfig`** (`packages/rules-core/src/rules-config.ts`), honoring the "les regles sont vivantes" invariant. Closes part of #73.

- `DEFAULT_RULES_CONFIG` reproduces the historical values EXACTLY — refactored functions take an optional trailing `config = DEFAULT_RULES_CONFIG`, so behavior and defaults are unchanged.
- Externalized: combat round length + stamina-roll difficulty; creation caps / energy / spell-point conversion; progression XP costs, learning floors & multipliers, roleplay cap, magician level multiplier.
- Adds `rules-config.test.ts` proving the engine is now tunable (custom configs change outcomes).

## Deferred (follow-ups, noted in #73)
- `unconsciousDamageRatio` / `vitalityMalusRatio` exist in config but `applyDamage` still uses literal `/2`.
- Magician/familiar detection by literal IDs (`'1'`/`'magicien'`/`'32'`) left unchanged — separate concern.
- Character `rules_version` stamping + `migrateCharacter()` (the migration half of #73).

## Test plan
- [x] `pnpm exec vitest run packages/rules-core` → 72 passed (8 files), incl. 5 new tests
- [x] rules-core typecheck + lint clean
- [ ] CI green on PR

🤖 Generated with Claude Code