### PR TITLE
Wire character inventory to canonical equipment catalogs (#74)

### DIFF
--- a/apps/game/src/app/character/page.tsx
+++ b/apps/game/src/app/character/page.tsx
@@ -28,6 +28,7 @@ export default async function CharacterPage() {
         attributeLabels={sheet.attributeLabels}
         attributeOrder={sheet.attributeOrder}
         character={sheet.character}
+        equipmentCatalog={sheet.equipmentCatalog}
         initialInventory={sheet.initialInventory}
         skillCatalog={sheet.skillCatalog}
         skillLabels={sheet.skillLabels}

--- a/apps/game/src/features/character-creation/read-models.ts
+++ b/apps/game/src/features/character-creation/read-models.ts
@@ -93,17 +93,25 @@ export interface SpellEntry {
   status?: string;
 }
 
+export interface EquipmentCatalogEntryDocument {
+  id?: string;
+  name?: string;
+  status?: string;
+  weight_kg?: number | string;
+  weight_kg_human?: number;
+}
+
 export interface WeaponsCatalogDocument {
-  weapons?: Array<{ id?: string; name?: string; status?: string }>;
+  weapons?: EquipmentCatalogEntryDocument[];
 }
 
 export interface ProtectionsCatalogDocument {
-  armor_pieces?: Array<{ id?: string; name?: string; status?: string }>;
-  shields?: Array<{ id?: string; name?: string; status?: string }>;
+  armor_pieces?: EquipmentCatalogEntryDocument[];
+  shields?: EquipmentCatalogEntryDocument[];
 }
 
 export interface PotionsCatalogDocument {
-  potions?: Array<{ id?: string; name?: string; status?: string }>;
+  potions?: EquipmentCatalogEntryDocument[];
 }
 
 export async function getCharacterCreationReadModel(): Promise<CharacterCreationReadModel> {

--- a/apps/game/src/features/character-sheet/CharacterSheet.tsx
+++ b/apps/game/src/features/character-sheet/CharacterSheet.tsx
@@ -15,6 +15,7 @@ import {
   socialAttributeKeys,
   type AttributeRollResult,
   type CharacterSheetMode,
+  type EquipmentCatalogEntry,
   type InventoryItem,
   type SkillCatalogEntry,
   type SpellEntry
@@ -24,6 +25,7 @@ interface CharacterSheetProps {
   attributeLabels: Record<AttributeKey, string>;
   attributeOrder: AttributeKey[];
   character: Character;
+  equipmentCatalog: EquipmentCatalogEntry[];
   initialInventory: InventoryItem[];
   skillCatalog: SkillCatalogEntry[];
   skillLabels: Record<string, string>;
@@ -44,18 +46,11 @@ const modeIcons: Record<CharacterSheetMode, typeof BookOpen> = {
   social: Sparkles
 };
 
-const quickItem: InventoryItem = {
-  category: 'gear',
-  id: 'torch',
-  name: 'Torche',
-  quantity: 1,
-  weightKg: 0.4
-};
-
 export function CharacterSheet({
   attributeLabels,
   attributeOrder,
   character,
+  equipmentCatalog,
   initialInventory,
   skillCatalog,
   skillLabels,
@@ -64,6 +59,27 @@ export function CharacterSheet({
   const [mode, setMode] = useState<CharacterSheetMode>('complete');
   const [inventory, setInventory] = useState(initialInventory);
   const [lastRoll, setLastRoll] = useState<AttributeRollResult | null>(null);
+  const [selectedEquipmentId, setSelectedEquipmentId] = useState<string>(
+    () => equipmentCatalog[0]?.id ?? ''
+  );
+
+  function addEquipment(equipmentId: string) {
+    const option = equipmentCatalog.find((entry) => entry.id === equipmentId);
+
+    if (!option) {
+      return;
+    }
+
+    setInventory((current) =>
+      addInventoryItem(current, {
+        category: option.category,
+        id: option.id,
+        name: option.name,
+        quantity: 1,
+        weightKg: option.weightKg
+      })
+    );
+  }
   const view = useMemo(
     () => buildCharacterSheetView({ character, inventory, mode, spells }),
     [character, inventory, mode, spells]
@@ -338,14 +354,33 @@ export function CharacterSheet({
       <div className="grid gap-5 lg:grid-cols-[1fr_0.85fr]">
         <Panel
           action={
-            <button
-              className="inline-flex min-h-10 items-center gap-2 rounded-md bg-forest px-3 text-sm font-semibold text-paper"
-              onClick={() => setInventory(addInventoryItem(inventory, quickItem))}
-              type="button"
-            >
-              <PackagePlus aria-hidden="true" className="size-4" />
-              Torche
-            </button>
+            equipmentCatalog.length > 0 ? (
+              <div className="flex items-center gap-2">
+                <label className="sr-only" htmlFor="equipment-picker">
+                  Équipement du catalogue
+                </label>
+                <select
+                  className="min-h-10 rounded-md border border-ink/15 bg-paper px-2 text-sm text-ink"
+                  id="equipment-picker"
+                  onChange={(event) => setSelectedEquipmentId(event.target.value)}
+                  value={selectedEquipmentId}
+                >
+                  {equipmentCatalog.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.name}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  className="inline-flex min-h-10 items-center gap-2 rounded-md bg-forest px-3 text-sm font-semibold text-paper"
+                  onClick={() => addEquipment(selectedEquipmentId)}
+                  type="button"
+                >
+                  <PackagePlus aria-hidden="true" className="size-4" />
+                  Ajouter
+                </button>
+              </div>
+            ) : undefined
           }
           title="Inventaire"
         >

--- a/apps/game/src/features/character-sheet/model.ts
+++ b/apps/game/src/features/character-sheet/model.ts
@@ -42,6 +42,135 @@ export interface InventoryItem {
   weightKg?: number;
 }
 
+/**
+ * A selectable equipment option derived from the canonical catalogs
+ * (armes/protections/potions). Used to populate the inventory picker so the UI
+ * never offers invented items.
+ */
+export interface EquipmentCatalogEntry {
+  category: InventoryCategory;
+  id: string;
+  name: string;
+  weightKg?: number;
+}
+
+/**
+ * Minimal shape of a catalog equipment entry as exposed by the catalog API
+ * documents (armes/protections/potions). Only the fields the inventory consumes
+ * are typed; the underlying read models carry the full canonical payload.
+ */
+export interface EquipmentCatalogEntryInput {
+  id?: string;
+  name?: string;
+  status?: string;
+  weight_kg?: number | string;
+  weight_kg_human?: number;
+}
+
+export interface WeaponsEquipmentDocument {
+  weapons?: EquipmentCatalogEntryInput[];
+}
+
+export interface ProtectionsEquipmentDocument {
+  armor_pieces?: EquipmentCatalogEntryInput[];
+  shields?: EquipmentCatalogEntryInput[];
+}
+
+export interface PotionsEquipmentDocument {
+  potions?: EquipmentCatalogEntryInput[];
+}
+
+/**
+ * Builds the canonical equipment picker list consumed by the inventory UI.
+ *
+ * Every entry is derived from the armes/protections/potions catalogs (no invented
+ * product data). Entries are normalized into inventory categories so the sheet can
+ * append them directly. Non-active entries are skipped when a status is present.
+ */
+export function buildEquipmentCatalog(input: {
+  potions: PotionsEquipmentDocument;
+  protections: ProtectionsEquipmentDocument;
+  weapons: WeaponsEquipmentDocument;
+}): EquipmentCatalogEntry[] {
+  return [
+    ...(input.weapons.weapons ?? []).map((entry) => toEquipmentCatalogEntry(entry, 'weapon')),
+    ...(input.protections.shields ?? []).map((entry) => toEquipmentCatalogEntry(entry, 'shield')),
+    ...(input.protections.armor_pieces ?? []).map((entry) =>
+      toEquipmentCatalogEntry(entry, 'armor')
+    ),
+    ...(input.potions.potions ?? []).map((entry) => toEquipmentCatalogEntry(entry, 'consumable'))
+  ].filter((entry): entry is EquipmentCatalogEntry => entry !== undefined);
+}
+
+/**
+ * Seeds the inventory from explicit canonical catalog ids. When a seed id is
+ * absent from the catalogs the slot is dropped rather than fabricated.
+ */
+export function buildInventory(input: {
+  potions: PotionsEquipmentDocument;
+  protections: ProtectionsEquipmentDocument;
+  weapons: WeaponsEquipmentDocument;
+}): InventoryItem[] {
+  const weapon = input.weapons.weapons?.find((entry) => entry.id === 'epee_batarde');
+  const shield = input.protections.shields?.find((entry) => entry.id === 'bouclier_bois');
+  const potion = input.potions.potions?.find((entry) => entry.id === 'soin');
+
+  const items: Array<InventoryItem | undefined> = [
+    weapon
+      ? {
+          category: 'weapon',
+          equipped: true,
+          id: weapon.id as string,
+          name: weapon.name as string,
+          quantity: 1,
+          weightKg: readEquipmentWeightKg(weapon)
+        }
+      : undefined,
+    shield
+      ? {
+          category: 'shield',
+          equipped: true,
+          id: shield.id as string,
+          name: shield.name as string,
+          quantity: 1,
+          weightKg: readEquipmentWeightKg(shield)
+        }
+      : undefined,
+    potion
+      ? {
+          category: 'consumable',
+          id: potion.id as string,
+          name: potion.name as string,
+          quantity: 2,
+          weightKg: readEquipmentWeightKg(potion)
+        }
+      : undefined
+  ];
+
+  return items.filter((item): item is InventoryItem => item !== undefined);
+}
+
+function toEquipmentCatalogEntry(
+  entry: EquipmentCatalogEntryInput,
+  category: InventoryCategory
+): EquipmentCatalogEntry | undefined {
+  if (!entry.id || !entry.name || (entry.status !== undefined && entry.status !== 'active')) {
+    return undefined;
+  }
+
+  return {
+    category,
+    id: entry.id,
+    name: entry.name,
+    weightKg: readEquipmentWeightKg(entry)
+  };
+}
+
+function readEquipmentWeightKg(entry: EquipmentCatalogEntryInput): number | undefined {
+  const weight = entry.weight_kg ?? entry.weight_kg_human;
+  return typeof weight === 'number' ? weight : undefined;
+}
+
 export interface SpellEntry {
   active?: boolean;
   id: string;

--- a/apps/game/src/features/character-sheet/read-models.test.ts
+++ b/apps/game/src/features/character-sheet/read-models.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildEquipmentCatalog,
+  buildInventory,
+  type PotionsEquipmentDocument,
+  type ProtectionsEquipmentDocument,
+  type WeaponsEquipmentDocument
+} from './model.js';
+
+const weapons: WeaponsEquipmentDocument = {
+  weapons: [
+    { id: 'epee_batarde', name: 'Épée bâtarde', weight_kg: 2.2 },
+    // Parametric weights (string) are intentionally left without a numeric weight.
+    { id: 'chaine', name: 'Chaîne', weight_kg: '0.8/1m' },
+    // Non-active entries must never reach the inventory picker.
+    { id: 'arme_demo', name: 'Arme démo', status: 'deprecated', weight_kg: 1 },
+    // Entries missing an id/name are skipped.
+    { name: 'Sans id' }
+  ]
+};
+
+const protections: ProtectionsEquipmentDocument = {
+  armor_pieces: [{ id: 'cuir_souple_bonnet', name: 'Bonnet (cuir souple)', weight_kg_human: 0.2 }],
+  shields: [{ id: 'bouclier_bois', name: 'Bouclier (bois)', weight_kg_human: 3 }]
+};
+
+const potions: PotionsEquipmentDocument = {
+  potions: [
+    { id: 'soin', name: 'Potion de Soin' },
+    { id: 'agrandissement', name: "Potion d'Agrandissement" }
+  ]
+};
+
+describe('character sheet equipment read-model', () => {
+  it('derives the equipment picker from the armes/protections/potions catalogs', () => {
+    const catalog = buildEquipmentCatalog({ potions, protections, weapons });
+
+    expect(catalog).toEqual([
+      { category: 'weapon', id: 'epee_batarde', name: 'Épée bâtarde', weightKg: 2.2 },
+      { category: 'weapon', id: 'chaine', name: 'Chaîne', weightKg: undefined },
+      { category: 'shield', id: 'bouclier_bois', name: 'Bouclier (bois)', weightKg: 3 },
+      { category: 'armor', id: 'cuir_souple_bonnet', name: 'Bonnet (cuir souple)', weightKg: 0.2 },
+      { category: 'consumable', id: 'soin', name: 'Potion de Soin', weightKg: undefined },
+      {
+        category: 'consumable',
+        id: 'agrandissement',
+        name: "Potion d'Agrandissement",
+        weightKg: undefined
+      }
+    ]);
+  });
+
+  it('excludes non-active and malformed catalog entries from the picker', () => {
+    const ids = buildEquipmentCatalog({ potions, protections, weapons }).map((entry) => entry.id);
+
+    expect(ids).not.toContain('arme_demo');
+    expect(ids.every((id) => id.length > 0)).toBe(true);
+  });
+
+  it('seeds the inventory from canonical catalog ids without inventing items', () => {
+    const inventory = buildInventory({ potions, protections, weapons });
+
+    expect(inventory).toEqual([
+      {
+        category: 'weapon',
+        equipped: true,
+        id: 'epee_batarde',
+        name: 'Épée bâtarde',
+        quantity: 1,
+        weightKg: 2.2
+      },
+      {
+        category: 'shield',
+        equipped: true,
+        id: 'bouclier_bois',
+        name: 'Bouclier (bois)',
+        quantity: 1,
+        weightKg: 3
+      },
+      {
+        category: 'consumable',
+        id: 'soin',
+        name: 'Potion de Soin',
+        quantity: 2,
+        weightKg: undefined
+      }
+    ]);
+  });
+
+  it('drops a seed slot when its canonical id is absent rather than fabricating one', () => {
+    const inventory = buildInventory({
+      potions: { potions: [] },
+      protections,
+      weapons
+    });
+
+    expect(inventory.map((item) => item.id)).toEqual(['epee_batarde', 'bouclier_bois']);
+  });
+});

--- a/apps/game/src/features/character-sheet/read-models.ts
+++ b/apps/game/src/features/character-sheet/read-models.ts
@@ -22,12 +22,20 @@ import {
   type SpellsCatalogDocument,
   type WeaponsCatalogDocument
 } from '../character-creation/read-models';
-import type { InventoryItem, SkillCatalogEntry, SpellEntry } from './model';
+import {
+  buildEquipmentCatalog,
+  buildInventory,
+  type EquipmentCatalogEntry,
+  type InventoryItem,
+  type SkillCatalogEntry,
+  type SpellEntry
+} from './model';
 
 export interface CharacterSheetReadModel {
   attributeLabels: Record<AttributeKey, string>;
   attributeOrder: AttributeKey[];
   character: ReturnType<typeof createPlayerCharacter>;
+  equipmentCatalog: EquipmentCatalogEntry[];
   initialInventory: InventoryItem[];
   skillCatalog: SkillCatalogEntry[];
   skillLabels: Record<string, string>;
@@ -53,6 +61,7 @@ export async function getCharacterSheetReadModel(): Promise<CharacterSheetReadMo
     attributeLabels,
     attributeOrder: [...ATTRIBUTE_KEYS],
     character: buildActiveCharacter({ classes, orientations, races }),
+    equipmentCatalog: buildEquipmentCatalog({ potions, protections, weapons }),
     initialInventory: buildInventory({ potions, protections, weapons }),
     skillCatalog,
     skillLabels,
@@ -118,50 +127,6 @@ function buildActiveCharacter(input: {
   });
 }
 
-function buildInventory(input: {
-  potions: PotionsCatalogDocument;
-  protections: ProtectionsCatalogDocument;
-  weapons: WeaponsCatalogDocument;
-}): InventoryItem[] {
-  const weapon = input.weapons.weapons?.find((entry) => entry.id === 'epee_batarde');
-  const shield = input.protections.shields?.find((entry) => entry.id === 'bouclier_bois');
-  const potion = input.potions.potions?.find((entry) => entry.id === 'potion_soin');
-
-  const items: Array<InventoryItem | undefined> = [
-    weapon
-      ? {
-          category: 'weapon',
-          equipped: true,
-          id: weapon.id as string,
-          name: weapon.name as string,
-          quantity: 1,
-          weightKg: readWeightKg(weapon)
-        }
-      : undefined,
-    shield
-      ? {
-          category: 'shield',
-          equipped: true,
-          id: shield.id as string,
-          name: shield.name as string,
-          quantity: 1,
-          weightKg: readWeightKg(shield)
-        }
-      : undefined,
-    potion
-      ? {
-          category: 'consumable',
-          id: potion.id as string,
-          name: potion.name as string,
-          quantity: 2,
-          weightKg: readWeightKg(potion)
-        }
-      : undefined
-  ];
-
-  return items.filter((item): item is InventoryItem => item !== undefined);
-}
-
 function buildSpells(catalog: SpellsCatalogDocument): SpellEntry[] {
   const activeSpellIds = new Set(['bouclier', 'boule-de-feu']);
 
@@ -173,14 +138,4 @@ function buildSpells(catalog: SpellsCatalogDocument): SpellEntry[] {
       name: spell.name as string,
       points: 1
     }));
-}
-
-function readWeightKg(entry: unknown): number | undefined {
-  if (typeof entry !== 'object' || entry === null) {
-    return undefined;
-  }
-
-  const record = entry as Record<string, unknown>;
-  const weight = record.weight_kg ?? record.weight_kg_human;
-  return typeof weight === 'number' ? weight : undefined;
 }

--- a/packages/catalogs/src/schemas.test.ts
+++ b/packages/catalogs/src/schemas.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, it } from 'vitest';
 import {
   CatalogValidationError,
   PRIORITY_CATALOG_NAMES,
+  PotionSchema,
+  ProtectionSchema,
+  WeaponSchema,
   loadValidatedCatalog,
   loadValidatedCatalogs,
   validateCatalogData
@@ -369,6 +372,64 @@ describe('catalog Zod schemas', () => {
     } catch (error) {
       expect((error as Error).message).toContain('spells.0.status');
     }
+  });
+
+  it('keeps equipment status and source refs optional while preserving them when present', () => {
+    const sourceRef = {
+      path: 'data/legacy/paper/regles-papier/extracted/listes/armes.md',
+      ref: 'entry:epee_batarde',
+      sha256: 'b'.repeat(64)
+    };
+
+    const weapon = WeaponSchema.parse({
+      id: 'epee_batarde',
+      name: 'Épée bâtarde',
+      category: 'melee',
+      damage_formula: 'F+6',
+      status: 'active',
+      weight_kg: 2.2,
+      source_refs: [sourceRef]
+    });
+    expect(weapon.status).toBe('active');
+    expect(weapon.source_refs).toEqual([sourceRef]);
+
+    const shield = ProtectionSchema.parse({
+      id: 'bouclier_bois',
+      name: 'Bouclier (bois)',
+      category: 'shield',
+      material: 'wood',
+      protection: { P: 2, E: 2, C: 1, T: 3 },
+      pass_chance_pct: 40,
+      weight_kg_human: 3,
+      size: 'medium',
+      source_refs: [sourceRef]
+    });
+    expect((shield as { source_refs?: unknown }).source_refs).toEqual([sourceRef]);
+
+    // Status and source refs remain optional: a minimal entry still validates.
+    const potion = PotionSchema.parse({
+      id: 'soin',
+      name: 'Potion de Soin',
+      category: 'potion',
+      output_type: 'potion',
+      effect: 'Restaure de la vitalité',
+      ingredients: [{ id: 'huile' }],
+      craft_check: { skill: 'alchimie' }
+    });
+    expect(potion.status).toBeUndefined();
+    expect(potion.source_refs).toBeUndefined();
+  });
+
+  it('rejects an invalid equipment status value', () => {
+    const parsed = WeaponSchema.safeParse({
+      id: 'broken',
+      name: 'Arme cassée',
+      category: 'melee',
+      damage_formula: 'F',
+      status: 'legendary'
+    });
+
+    expect(parsed.success).toBe(false);
   });
 
   it('reports the file and data path when validation fails', () => {

--- a/packages/catalogs/src/schemas.ts
+++ b/packages/catalogs/src/schemas.ts
@@ -67,10 +67,13 @@ export const WeaponSchema = z
     id: NonEmptyStringSchema,
     name: NonEmptyStringSchema,
     category: NonEmptyStringSchema,
+    status: CatalogEntryStatusSchema.optional(),
     damage_type: z.union([NonEmptyStringSchema, z.array(NonEmptyStringSchema)]).optional(),
     damage_formula: NonEmptyStringSchema,
     difficulty: z.number().optional(),
     hands_required: z.number().optional(),
+    weight_kg: z.union([z.number(), NonEmptyStringSchema]).optional(),
+    source_refs: z.array(z.lazy(() => SourceRefSchema)).optional(),
     metadata: EntryMetadataSchema.optional()
   })
   .passthrough();
@@ -140,9 +143,11 @@ export const ArmorPieceSchema = z
     name: NonEmptyStringSchema,
     layer: NonEmptyStringSchema,
     category: NonEmptyStringSchema,
+    status: CatalogEntryStatusSchema.optional(),
     protection: DamageProfileSchema,
     zones_covered: z.array(NonEmptyStringSchema),
     weight_kg_human: z.number(),
+    source_refs: z.array(z.lazy(() => SourceRefSchema)).optional(),
     metadata: EntryMetadataSchema.optional()
   })
   .passthrough();
@@ -153,10 +158,12 @@ export const ShieldSchema = z
     name: NonEmptyStringSchema,
     category: NonEmptyStringSchema,
     material: NonEmptyStringSchema,
+    status: CatalogEntryStatusSchema.optional(),
     protection: DamageProfileSchema,
     pass_chance_pct: z.number(),
     weight_kg_human: z.number(),
     size: NonEmptyStringSchema,
+    source_refs: z.array(z.lazy(() => SourceRefSchema)).optional(),
     metadata: EntryMetadataSchema.optional()
   })
   .passthrough();
@@ -182,10 +189,12 @@ export const PotionSchema = z
     id: NonEmptyStringSchema,
     name: NonEmptyStringSchema,
     category: NonEmptyStringSchema,
+    status: CatalogEntryStatusSchema.optional(),
     output_type: NonEmptyStringSchema,
     effect: NonEmptyStringSchema,
     ingredients: z.array(PotionIngredientSchema),
     craft_check: z.object({}).passthrough(),
+    source_refs: z.array(z.lazy(() => SourceRefSchema)).optional(),
     metadata: EntryMetadataSchema.optional()
   })
   .passthrough();

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -51,8 +51,12 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByRole('heading', { name: 'Audit complet' })).toBeVisible();
 
     await page.getByRole('button', { name: 'Complet' }).click();
-    await page.getByRole('button', { name: /Torche/ }).click();
-    await expect(page.getByText('gear · 0.4 kg')).toBeVisible();
+    const equipmentPicker = page.locator('#equipment-picker');
+    await expect(equipmentPicker).toBeVisible();
+    expect(await equipmentPicker.locator('option').count()).toBeGreaterThan(0);
+    await equipmentPicker.selectOption({ index: 0 });
+    await page.getByRole('button', { name: 'Ajouter' }).click();
+    await expect(page.getByText(/Charge .* kg/)).toBeVisible();
   });
 
   test('character creation validates fighter and magician creation budgets', async ({ page }) => {


### PR DESCRIPTION
## Summary
Wires the character-sheet inventory to the **canonical equipment catalogs** (armes / protections / potions) instead of hard-coded items. Implements #74.

- Replaces the invented "Torche" quick-add with a **catalog-fed equipment picker**.
- Adds a typed equipment read-model (`buildEquipmentCatalog` / `buildInventory`, pure builders) derived from the catalog documents (status-filtered).
- Fixes a broken seed inventory id (`potion_soin` -> `soin`).
- Types optional `status` / `source_refs` (+ `weight_kg`) on the weapon/armor/shield/potion Zod schemas so provenance is preserved when present (additive — canonical gate stays green).

Note: the data layer (schemas, priority allowlist, import, catalog API) already existed; the real gap was the UI/read-model, now closed.

## Test plan
- [x] `pnpm exec vitest run packages/catalogs apps/game` → 75 passed (incl. 4 new read-model + 2 schema tests)
- [x] typecheck (catalogs/game/server) + lint clean; `pnpm canonical:check` current
- [ ] CI green on PR

🤖 Generated with Claude Code