### PR TITLE
Harden async session journal: real rollback via event replay (#54)

### DIFF
--- a/apps/server/src/routes/sessions.test.ts
+++ b/apps/server/src/routes/sessions.test.ts
@@ -169,6 +169,69 @@ describe('session routes', () => {
     ]);
   });
 
+  it('returns a reverted state reconstructed from the event log', async () => {
+    const slug = `revert-session-${randomUUID()}`;
+
+    await app.inject({
+      method: 'POST',
+      payload: { mode: 'digital_human_gm', slug, title: 'Revert API' },
+      url: '/sessions'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        eventType: 'scene_opened',
+        payload: { location: 'Brumeval', sceneId: 'gate', title: 'Porte nord' }
+      },
+      url: `/sessions/${slug}/events`
+    });
+    const queuedResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        assignedTo: 'human_gm',
+        payload: { options: ['negotiate', 'fight'] },
+        priority: 'high',
+        requestedBy: 'llm',
+        title: 'Les brigands negocient-ils ?'
+      },
+      url: `/sessions/${slug}/decisions`
+    });
+    const decisionId = queuedResponse.json().decision.id;
+    // Resolving appends event sequence 3 (request was sequence 2, scene was 1).
+    await app.inject({
+      method: 'POST',
+      payload: { actorId: 'gm', resolution: { ruling: 'fight' }, status: 'approved' },
+      url: `/sessions/${slug}/decisions/${decisionId}/resolve`
+    });
+
+    // Revert to sequence 2 (decision requested) — the resolution at seq 3 must vanish.
+    const rollbackResponse = await app.inject({
+      method: 'POST',
+      payload: { actorId: 'gm', reason: 'Annule la resolution', targetSequence: 2 },
+      url: `/sessions/${slug}/rollback`
+    });
+
+    expect(rollbackResponse.statusCode).toBe(201);
+    const reverted = rollbackResponse.json().revertedState;
+    // The rollback marker (seq 4) and the resolution (seq 3) are excluded.
+    expect(reverted.events.map((event: { sequence: number }) => event.sequence)).toEqual([1, 2]);
+    expect(reverted.scenes).toMatchObject([{ id: 'gate', openedAtSequence: 1 }]);
+    expect(reverted.decisions).toMatchObject([{ id: decisionId, status: 'pending' }]);
+    expect(reverted.decisions[0].resolvedAt).toBeUndefined();
+
+    // The persisted journal still preserves the full history including the marker.
+    const readResponse = await app.inject({ method: 'GET', url: `/sessions/${slug}` });
+    expect(
+      readResponse.json().events.map((event: { eventType: string }) => event.eventType)
+    ).toEqual([
+      'scene_opened',
+      'gm_decision_requested',
+      'gm_decision_resolved',
+      'rollback_requested'
+    ]);
+  });
+
   it('rejects invalid session payloads', async () => {
     const response = await app.inject({
       method: 'POST',

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -1,4 +1,16 @@
 import type { FastifyInstance } from 'fastify';
+import {
+  type SessionDecision,
+  type SessionEvent,
+  type SessionState,
+  SESSION_CONTROLLER_ROLES,
+  SESSION_DECISION_PRIORITIES,
+  SESSION_DECISION_STATUSES,
+  SESSION_MODES,
+  SESSION_STATUSES,
+  createSessionState,
+  revertSessionToSequence
+} from '@knightandwizard/rules-core';
 import type postgres from 'postgres';
 import { createSqlClient } from '../db/client.js';
 
@@ -44,17 +56,16 @@ interface DecisionParams extends SessionParams {
   decisionId: string;
 }
 
-const validModes = new Set([
-  'classic_table',
-  'digital_human_gm',
-  'digital_llm_gm',
-  'digital_auto_gm',
-  'multiplayer_no_gm'
-]);
-const validStatuses = new Set(['planned', 'active', 'paused', 'archived']);
-const validPriorities = new Set(['low', 'normal', 'high', 'urgent']);
-const validDecisionStatuses = new Set(['approved', 'rejected', 'superseded']);
-const validControllerRoles = new Set(['player', 'human_gm', 'llm', 'auto']);
+// Validation vocabularies are derived from the canonical rules-core unions so
+// the SQL surface and the pure model never drift apart.
+const validModes = new Set<string>(SESSION_MODES);
+const validStatuses = new Set<string>(SESSION_STATUSES);
+const validPriorities = new Set<string>(SESSION_DECISION_PRIORITIES);
+// A decision cannot be *resolved* into the 'pending' state.
+const validDecisionStatuses = new Set<string>(
+  SESSION_DECISION_STATUSES.filter((status) => status !== 'pending')
+);
+const validControllerRoles = new Set<string>(SESSION_CONTROLLER_ROLES);
 const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
 export async function registerSessionRoutes(app: FastifyInstance): Promise<void> {
@@ -545,6 +556,12 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
     }
   );
 
+  // TODO(#54): the reverted projection is now computed by rules-core and
+  // returned to the caller, but the canonical journal still keeps every event
+  // (history-preserving markers). Deferred follow-ups: (a) event->entity links
+  // (characters/places/objects/cited rules) so reconstruction can re-project
+  // those relations, (b) frontend session-manager persistence of the reverted
+  // state, and (c) an e2e covering a multi-actor rollback round-trip.
   app.post<{ Body: RollbackRequestBody; Params: SessionParams }>(
     '/sessions/:slug/rollback',
     async (request, reply) => {
@@ -631,7 +648,43 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
             WHERE id = ${session.id}
           `;
 
-          return { event: eventRows[0]!, status: 'created' as const };
+          // Read the full (post-marker) journal so the reverted projection is
+          // computed by the pure rules-core reconstruction rather than re-derived
+          // in SQL. The marker we just inserted sits beyond `targetSequence`, so
+          // it is naturally excluded from the reverted state while remaining in
+          // the immutable log for audit.
+          const fullEventRows = await tx<SessionEventRow[]>`
+            SELECT id, session_id, sequence, event_type, actor_id, payload, created_at
+            FROM session_events
+            WHERE session_id = ${session.id}
+            ORDER BY sequence ASC
+          `;
+          const decisionRows = await tx<SessionDecisionRow[]>`
+            SELECT
+              id,
+              session_id,
+              title,
+              requested_by,
+              assigned_to,
+              priority,
+              status,
+              payload,
+              resolution,
+              created_at,
+              resolved_at,
+              updated_at
+            FROM session_decisions
+            WHERE session_id = ${session.id}
+          `;
+
+          return {
+            decisionRows,
+            event: eventRows[0]!,
+            fullEventRows,
+            session,
+            status: 'created' as const,
+            targetSequence: target.sequence
+          };
         });
 
         if (result.status === 'not_found') {
@@ -645,8 +698,19 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
           });
         }
 
+        // Delegate the actual revert to the canonical pure model. This replaces
+        // the previous behaviour where the endpoint only recorded a marker and
+        // never returned the reverted state (#54).
+        const priorState = buildSessionState(
+          result.session,
+          result.fullEventRows,
+          result.decisionRows
+        );
+        const revertedState = revertSessionToSequence(priorState, result.targetSequence);
+
         return reply.code(201).send({
           event: toEventResponse(result.event),
+          revertedState: toSessionStateResponse(revertedState),
           status: 'created'
         });
       } finally {
@@ -828,6 +892,84 @@ function toSessionResponse(
     status: session.status,
     title: session.title,
     updatedAt: serializeDate(session.updated_at)
+  };
+}
+
+/**
+ * Lifts persisted session rows into the canonical pure {@link SessionState}.
+ *
+ * Persisted `mode`/`status`/`priority`/role values originate from the validated
+ * write endpoints (see the `valid*` vocabularies), so the narrowing casts here
+ * are safe; the pure model is the single source of truth for derived projection
+ * logic such as rollback reconstruction.
+ */
+function buildSessionState(
+  session: SessionRow,
+  events: SessionEventRow[],
+  decisions: SessionDecisionRow[]
+): SessionState {
+  return createSessionState({
+    createdAt: serializeDate(session.created_at),
+    decisions: decisions.map(toDecisionModel),
+    events: events.map(toEventModel),
+    id: session.id,
+    metadata: session.metadata,
+    mode: session.mode as SessionState['mode'],
+    slug: session.slug,
+    status: session.status as SessionState['status'],
+    title: session.title,
+    updatedAt: serializeDate(session.updated_at)
+  });
+}
+
+function toEventModel(row: SessionEventRow): SessionEvent {
+  return {
+    actorId: row.actor_id ?? undefined,
+    createdAt: serializeDate(row.created_at),
+    id: row.id,
+    payload: row.payload,
+    sequence: row.sequence,
+    type: row.event_type as SessionEvent['type']
+  };
+}
+
+function toDecisionModel(row: SessionDecisionRow): SessionDecision {
+  return {
+    assignedTo: row.assigned_to as SessionDecision['assignedTo'],
+    createdAt: serializeDate(row.created_at),
+    id: row.id,
+    payload: row.payload,
+    priority: row.priority as SessionDecision['priority'],
+    requestedBy: row.requested_by,
+    resolution: row.resolution ?? undefined,
+    resolvedAt: row.resolved_at ? serializeDate(row.resolved_at) : undefined,
+    status: row.status as SessionDecision['status'],
+    title: row.title
+  };
+}
+
+/** Serializes a reverted {@link SessionState} projection for HTTP responses. */
+function toSessionStateResponse(state: SessionState) {
+  return {
+    createdAt: state.createdAt,
+    decisions: state.decisions,
+    events: state.events.map((event) => ({
+      actorId: event.actorId,
+      createdAt: event.createdAt,
+      eventType: event.type,
+      id: event.id,
+      payload: event.payload,
+      sequence: event.sequence,
+      sessionId: state.id
+    })),
+    id: state.id,
+    metadata: state.metadata,
+    mode: state.mode,
+    scenes: state.scenes,
+    slug: state.slug,
+    status: state.status,
+    title: state.title,
+    updatedAt: state.updatedAt
   };
 }
 

--- a/packages/rules-core/src/session.test.ts
+++ b/packages/rules-core/src/session.test.ts
@@ -4,8 +4,10 @@ import {
   createSessionState,
   getPendingDecisions,
   queueGmDecision,
+  rebuildSessionStateFromEvents,
   requestSessionRollback,
-  resolveGmDecision
+  resolveGmDecision,
+  revertSessionToSequence
 } from './session.js';
 
 describe('session event journal', () => {
@@ -147,5 +149,131 @@ describe('session event journal', () => {
         targetSequence: 4
       })
     ).toThrow('targetSequence must reference an existing event');
+  });
+});
+
+describe('session state reconstruction', () => {
+  function buildJournal() {
+    const session = createSessionState({
+      id: 'session-brumeval',
+      mode: 'digital_human_gm',
+      slug: 'brumeval',
+      title: 'Brumeval'
+    });
+    const withScene = appendSessionEvent(
+      session,
+      {
+        actorId: 'gm',
+        payload: { location: 'Porte nord', sceneId: 'gate', title: 'Porte nord' },
+        type: 'scene_opened'
+      },
+      { id: 'event-1', now: '2026-04-30T10:00:00.000Z' }
+    );
+    const queued = queueGmDecision(
+      withScene,
+      {
+        assignedTo: 'human_gm',
+        payload: { options: ['negotiate', 'fight'] },
+        priority: 'high',
+        requestedBy: 'llm',
+        title: 'Les brigands negocient-ils ?'
+      },
+      { decisionId: 'decision-1', eventId: 'event-2', now: '2026-04-30T10:01:00.000Z' }
+    );
+    const resolved = resolveGmDecision(
+      queued,
+      'decision-1',
+      { actorId: 'gm', resolution: { ruling: 'fight' }, status: 'approved' },
+      { eventId: 'event-3', now: '2026-04-30T10:02:00.000Z' }
+    );
+
+    return resolved;
+  }
+
+  it('rebuilds scenes and decisions purely from the ordered event log', () => {
+    const journal = buildJournal();
+    // Drop the derived projections to prove they are rebuilt from events alone.
+    const rebuilt = rebuildSessionStateFromEvents({
+      ...journal,
+      decisions: [],
+      scenes: []
+    });
+
+    expect(rebuilt.scenes).toEqual([
+      {
+        description: undefined,
+        id: 'gate',
+        location: 'Porte nord',
+        npcIds: undefined,
+        openedAtSequence: 1,
+        status: 'active',
+        title: 'Porte nord'
+      }
+    ]);
+    expect(rebuilt.decisions).toMatchObject([
+      {
+        assignedTo: 'human_gm',
+        id: 'decision-1',
+        priority: 'high',
+        requestedBy: 'llm',
+        resolution: { ruling: 'fight' },
+        resolvedAt: '2026-04-30T10:02:00.000Z',
+        status: 'approved',
+        title: 'Les brigands negocient-ils ?'
+      }
+    ]);
+    expect(rebuilt.updatedAt).toBe('2026-04-30T10:02:00.000Z');
+  });
+
+  it('reverts to a prior point, dropping later events and unresolving decisions', () => {
+    const journal = buildJournal();
+    // Revert to sequence 2 (decision requested) — the resolution at seq 3 disappears.
+    const reverted = revertSessionToSequence(journal, 2);
+
+    expect(reverted.events.map((event) => event.sequence)).toEqual([1, 2]);
+    expect(getPendingDecisions(reverted).map((decision) => decision.id)).toEqual(['decision-1']);
+    expect(reverted.decisions[0]).toMatchObject({ status: 'pending' });
+    expect(reverted.decisions[0]?.resolvedAt).toBeUndefined();
+    expect(reverted.scenes).toHaveLength(1);
+    expect(reverted.updatedAt).toBe('2026-04-30T10:01:00.000Z');
+  });
+
+  it('reverts to the very first event, dropping the decision entirely', () => {
+    const journal = buildJournal();
+    const reverted = revertSessionToSequence(journal, 1);
+
+    expect(reverted.events.map((event) => event.sequence)).toEqual([1]);
+    expect(reverted.decisions).toEqual([]);
+    expect(reverted.scenes).toHaveLength(1);
+  });
+
+  it('preserves session-level facts and the audit trail when reverting', () => {
+    const journal = buildJournal();
+    const reverted = revertSessionToSequence(journal, 1);
+
+    expect(reverted.id).toBe(journal.id);
+    expect(reverted.mode).toBe('digital_human_gm');
+    expect(reverted.slug).toBe('brumeval');
+    expect(reverted.audit).toEqual(journal.audit);
+  });
+
+  it('rejects reverts targeting unknown events', () => {
+    const journal = buildJournal();
+
+    expect(() => revertSessionToSequence(journal, 99)).toThrow(
+      'targetSequence must reference an existing event'
+    );
+  });
+
+  it('is stable across repeated rebuilds (fold is deterministic)', () => {
+    const journal = buildJournal();
+    const once = rebuildSessionStateFromEvents(journal);
+    const twice = rebuildSessionStateFromEvents(once);
+
+    expect(twice.scenes).toEqual(once.scenes);
+    expect(twice.decisions).toEqual(once.decisions);
+    expect(twice.events).toEqual(once.events);
+    // The decision derived from events matches the one the queue helper recorded.
+    expect(once.decisions).toEqual(journal.decisions);
   });
 });

--- a/packages/rules-core/src/session.ts
+++ b/packages/rules-core/src/session.ts
@@ -243,6 +243,7 @@ export function queueGmDecision(
       payload: {
         assignedTo: decision.assignedTo,
         decisionId: decision.id,
+        payload: decision.payload,
         priority: decision.priority,
         requestedBy: decision.requestedBy,
         title: decision.title
@@ -392,6 +393,174 @@ export function requestSessionRollback(
       })
     ]
   };
+}
+
+/**
+ * Validates a rollback target and returns the reconstructed prior state.
+ *
+ * Unlike {@link requestSessionRollback} — which preserves history by appending
+ * a `rollback_requested` marker — this performs the actual revert: it rebuilds
+ * the derived projection (scenes, decisions, retained events) from the ordered
+ * log up to and including `targetSequence`. Throws when the target does not
+ * reference an existing event.
+ */
+export function revertSessionToSequence(
+  state: SessionState,
+  targetSequence: number
+): SessionState {
+  const target = state.events.find((event) => event.sequence === targetSequence);
+
+  if (!target) {
+    throw new Error('targetSequence must reference an existing event');
+  }
+
+  return rebuildSessionStateFromEvents(state, { upToSequence: targetSequence });
+}
+
+export interface RebuildSessionStateOptions {
+  /**
+   * When provided, only events whose sequence is less than or equal to this
+   * value are folded into the reconstructed state. Events after the target are
+   * dropped from the rebuilt projection. Defaults to the latest event.
+   */
+  upToSequence?: number;
+  /** Timestamp used for the rebuilt `updatedAt`. Defaults to the last folded event's `createdAt`. */
+  now?: string;
+}
+
+/**
+ * Pure event-sourced reconstruction of the derived session projection.
+ *
+ * The immutable event log is the source of truth: `scenes` and `decisions` are
+ * recomputed by folding the ordered events up to (and including) the target
+ * sequence. This is a real rollback/revert — it reconstructs the prior state
+ * rather than appending a marker. Players, mode, slug, title and the audit
+ * trail are session-level facts and are preserved from the input `state`.
+ *
+ * Events strictly after `upToSequence` are removed from the rebuilt projection,
+ * so callers obtain the exact state the session had at that point in time.
+ */
+export function rebuildSessionStateFromEvents(
+  state: SessionState,
+  options: RebuildSessionStateOptions = {}
+): SessionState {
+  const ordered = sortEvents(state.events);
+  const target =
+    options.upToSequence ?? ordered.reduce((max, event) => Math.max(max, event.sequence), 0);
+  const retained = ordered.filter((event) => event.sequence <= target);
+  const projection = retained.reduce<SessionProjection>(reduceSessionEvent, {
+    decisions: [],
+    scenes: []
+  });
+  const lastEvent = retained.at(-1);
+
+  return {
+    ...state,
+    decisions: projection.decisions,
+    events: retained,
+    scenes: projection.scenes,
+    updatedAt: options.now ?? lastEvent?.createdAt ?? state.createdAt
+  };
+}
+
+interface SessionProjection {
+  decisions: SessionDecision[];
+  scenes: SessionScene[];
+}
+
+function reduceSessionEvent(projection: SessionProjection, event: SessionEvent): SessionProjection {
+  switch (event.type) {
+    case 'scene_opened':
+      return {
+        ...projection,
+        scenes: [...projection.scenes, sceneFromEvent(event)]
+      };
+    case 'gm_decision_requested':
+      return {
+        ...projection,
+        decisions: [...projection.decisions, decisionFromRequestEvent(event)]
+      };
+    case 'gm_decision_resolved':
+      return {
+        ...projection,
+        decisions: applyDecisionResolution(projection.decisions, event)
+      };
+    default:
+      return projection;
+  }
+}
+
+function sceneFromEvent(event: SessionEvent): SessionScene {
+  const payload = event.payload;
+
+  return {
+    description: optionalString(payload.description),
+    id: optionalString(payload.sceneId) ?? optionalString(payload.id) ?? `scene-${event.sequence}`,
+    location: optionalString(payload.location) ?? 'unknown',
+    npcIds: Array.isArray(payload.npcIds)
+      ? payload.npcIds.filter((value): value is string => typeof value === 'string')
+      : undefined,
+    openedAtSequence: event.sequence,
+    status: 'active',
+    title: optionalString(payload.title) ?? optionalString(payload.location) ?? 'Scene'
+  };
+}
+
+function decisionFromRequestEvent(event: SessionEvent): SessionDecision {
+  const payload = event.payload;
+  const assignedTo = optionalString(payload.assignedTo);
+  const priority = optionalString(payload.priority);
+
+  return {
+    assignedTo: isControllerRole(assignedTo) ? assignedTo : 'human_gm',
+    createdAt: event.createdAt,
+    id: optionalString(payload.decisionId) ?? `decision-${event.sequence}`,
+    payload: isRecord(payload.payload) ? { ...payload.payload } : {},
+    priority: isPriority(priority) ? priority : 'normal',
+    requestedBy: optionalString(payload.requestedBy) ?? event.actorId ?? 'unknown',
+    status: 'pending',
+    title: optionalString(payload.title) ?? 'Untitled decision'
+  };
+}
+
+function applyDecisionResolution(
+  decisions: SessionDecision[],
+  event: SessionEvent
+): SessionDecision[] {
+  const decisionId = optionalString(event.payload.decisionId);
+  const status = optionalString(event.payload.status);
+  const resolvedStatus: SessionDecisionStatus = isDecisionStatus(status) ? status : 'approved';
+
+  return decisions.map((decision) =>
+    decision.id === decisionId
+      ? {
+          ...decision,
+          resolution: isRecord(event.payload.resolution) ? { ...event.payload.resolution } : {},
+          resolvedAt: event.createdAt,
+          status: resolvedStatus
+        }
+      : decision
+  );
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isControllerRole(value: string | undefined): value is SessionControllerRole {
+  return value !== undefined && (SESSION_CONTROLLER_ROLES as readonly string[]).includes(value);
+}
+
+function isPriority(value: string | undefined): value is SessionDecisionPriority {
+  return value !== undefined && (SESSION_DECISION_PRIORITIES as readonly string[]).includes(value);
+}
+
+function isDecisionStatus(value: string | undefined): value is SessionDecisionStatus {
+  return value !== undefined && (SESSION_DECISION_STATUSES as readonly string[]).includes(value);
 }
 
 export function getPendingDecisions(state: SessionState): SessionDecision[] {

--- a/packages/rules-core/src/session.ts
+++ b/packages/rules-core/src/session.ts
@@ -404,10 +404,7 @@ export function requestSessionRollback(
  * log up to and including `targetSequence`. Throws when the target does not
  * reference an existing event.
  */
-export function revertSessionToSequence(
-  state: SessionState,
-  targetSequence: number
-): SessionState {
+export function revertSessionToSequence(state: SessionState, targetSequence: number): SessionState {
   const target = state.events.find((event) => event.sequence === targetSequence);
 
   if (!target) {


### PR DESCRIPTION
## Summary
Hardens the asynchronous session journal (#54): rollback now performs a REAL revert (reconstructs state from the ordered event log) instead of only recording a marker.

- **rules-core (pure)**: `rebuildSessionStateFromEvents` (event-sourced fold) + `revertSessionToSequence`; `gm_decision_requested` now carries the decision payload so the journal is self-sufficient for reconstruction. 6 new unit tests.
- **server**: `/rollback` delegates to `revertSessionToSequence` and returns `revertedState` (full DB history preserved); validation vocabularies now derive from the rules-core unions instead of duplicated literals (no SQL/model drift). DB-backed test added.

## Deferred (TODO(#54))
event→entity links (characters/places/objects/cited rules), frontend session-manager persistence, and e2e.

## Test plan
- [x] vitest: 78 pass (73 rules-core + 5 server session routes); typecheck clean
- [ ] CI green on PR

🤖 Generated with Claude Code