### PR TITLE
Add deep NOMOS binary gate to CI (#35)

### DIFF
--- a/.github/workflows/nomos-strict.yml
+++ b/.github/workflows/nomos-strict.yml
@@ -1,0 +1,61 @@
+name: NOMOS Binary Gate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+      - staging
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: nomos-strict-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nomos-strict:
+    name: NOMOS Binary Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      # Read access to the private RBOKproject/NOMOS repo (PAT in repo secrets).
+      # When the secret is absent (e.g. forks), the gate steps are skipped.
+      NOMOS_TOKEN: ${{ secrets.NOMOS_REPO_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Skip notice when NOMOS token is absent
+        if: ${{ env.NOMOS_TOKEN == '' }}
+        run: echo "NOMOS_REPO_TOKEN not configured - deep NOMOS gate skipped."
+
+      - name: Setup Go
+        if: ${{ env.NOMOS_TOKEN != '' }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Checkout NOMOS (pinned commit)
+        if: ${{ env.NOMOS_TOKEN != '' }}
+        uses: actions/checkout@v6
+        with:
+          repository: RBOKproject/NOMOS
+          ref: 0c9e8fa90c70b0c7ec25bc20a64f6464e14c15cb
+          token: ${{ env.NOMOS_TOKEN }}
+          path: .nomos-src
+
+      - name: Build NOMOS CLI
+        if: ${{ env.NOMOS_TOKEN != '' }}
+        run: |
+          cd .nomos-src/cli
+          CGO_ENABLED=1 go build -o "$GITHUB_WORKSPACE/nomos" .
+
+      - name: Validate canonical artifacts against NOMOS schemas
+        if: ${{ env.NOMOS_TOKEN != '' }}
+        run: ./nomos validate --format text nomos.project.yaml docs/canonical/nomos/source-manifest.yaml docs/canonical/nomos/canonical-matrix.yaml
+
+      - name: NOMOS admission diagnose (advisory)
+        if: ${{ env.NOMOS_TOKEN != '' }}
+        run: ./nomos diagnose -root . -mode auto -format markdown >> "$GITHUB_STEP_SUMMARY" || true


### PR DESCRIPTION
## Summary
Adds the **deep NOMOS gate**: a CI job that builds the NOMOS CLI (Go, pinned commit `0c9e8fa`) using the `NOMOS_REPO_TOKEN` secret and runs `nomos validate` on the canonical artifacts (`nomos.project.yaml` + `docs/canonical/nomos/source-manifest.yaml` + `canonical-matrix.yaml`) — **fail-closed schema conformance**, beyond the existing freshness/sync gate.

- Standalone workflow `.github/workflows/nomos-strict.yml`.
- **Skips cleanly** when the secret is absent (forks): steps are gated on `env.NOMOS_TOKEN`.
- Complements the **NOMOS Canonical Gate** (sync check) already on `dev`.
- Also emits an advisory `nomos diagnose` admission report to the job summary.

## Test plan
- [ ] "NOMOS Binary Gate" job builds NOMOS and `nomos validate` passes
- [ ] existing Validate + NOMOS Canonical Gate stay green

🤖 Generated with Claude Code