### PR TITLE
feat(rules-core): finish rules config coverage

### DIFF
--- a/packages/rules-core/src/character.ts
+++ b/packages/rules-core/src/character.ts
@@ -288,7 +288,7 @@ export function createPlayerCharacter(
   config: RulesConfig = DEFAULT_RULES_CONFIG
 ): PlayerCharacter {
   const spells = input.spells ?? [];
-  const magician = isMagician(input.orientation);
+  const magician = isMagicianOrientation(input.orientation, config);
   const spellTotal = sumPoints(spells);
   const extraSpellPoints = magician
     ? Math.max(0, spellTotal - config.creation.magicianBaseSpellPoints)
@@ -342,7 +342,7 @@ export function createNonPlayerCharacter(
   input: CreateNonPlayerCharacterInput,
   config: RulesConfig = DEFAULT_RULES_CONFIG
 ): NonPlayerCharacter {
-  const defaultEnergy = isMagician(input.orientation)
+  const defaultEnergy = isMagicianOrientation(input.orientation, config)
     ? {
         current: config.creation.magicianStartingEnergy,
         max: config.creation.magicianStartingEnergy
@@ -402,7 +402,7 @@ export function migrateCharacter<T extends Character>(
   const energy: CharacterResource = { ...character.energy };
 
   // Recompute derived resources: magician energy ceiling comes from the ruleset.
-  if (isMagician(character.orientation)) {
+  if (isMagicianOrientation(character.orientation, toConfig)) {
     const newMax = toConfig.creation.magicianStartingEnergy;
 
     if (energy.max !== newMax) {
@@ -483,7 +483,7 @@ export function calculateLevelProgression(
   character: Character,
   config: RulesConfig = DEFAULT_RULES_CONFIG
 ): LevelProgression {
-  if (isFamiliar(character.race)) {
+  if (isFamiliarRace(character.race, config)) {
     return {
       level: null,
       levelPoints: null,
@@ -492,10 +492,10 @@ export function calculateLevelProgression(
     };
   }
 
-  const primarySkillIds = isMagician(character.orientation)
+  const primarySkillIds = isMagicianOrientation(character.orientation, config)
     ? []
     : collectPrimarySkillIds(character);
-  const levelPoints = isMagician(character.orientation)
+  const levelPoints = isMagicianOrientation(character.orientation, config)
     ? sumPoints(character.skills) +
       sumPoints(character.spells) * config.progression.magicianLevelSpellMultiplier
     : sumPoints(character.skills) + sumPrimaryTreePoints(character.skills, primarySkillIds);
@@ -570,12 +570,26 @@ function sumPoints(entries: Array<{ points: number }>): number {
   return entries.reduce((total, entry) => total + entry.points, 0);
 }
 
-function isMagician(orientation: CharacterOrientationProfile): boolean {
-  return orientation.isMagical === true || orientation.id === '1' || orientation.id === 'magicien';
+export function isMagicianOrientation(
+  orientation: CharacterOrientationProfile,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): boolean {
+  return (
+    orientation.isMagical === true ||
+    configuredIdMatches(orientation.id, config.creation.magicianOrientationIds)
+  );
 }
 
-function isFamiliar(race: RaceProfile): boolean {
-  return race.id === '32' || race.id.toLowerCase() === 'familiar';
+export function isFamiliarRace(
+  race: RaceProfile,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): boolean {
+  return configuredIdMatches(race.id, config.creation.familiarRaceIds);
+}
+
+function configuredIdMatches(id: string, configuredIds: string[]): boolean {
+  const normalizedId = id.toLowerCase();
+  return configuredIds.some((configuredId) => configuredId.toLowerCase() === normalizedId);
 }
 
 function collectPrimarySkillIds(character: Character): string[] {

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -117,26 +117,33 @@ export interface CombatResolutionOptions {
  * Legacy UI displays DT as a cyclic 1-50 value. The engine stores absolute DTs
  * to keep timeline sorting unambiguous, while `getCyclicDT` preserves the old counter behavior.
  */
-export function createCombatState(currentDT = 1): CombatState {
+export function createCombatState(
+  currentDT = 1,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): CombatState {
   assertPositiveInteger('currentDT', currentDT);
 
   return {
     timeline: [],
     currentDT,
-    round: roundForDT(currentDT),
+    round: roundForDT(currentDT, config),
     log: []
   };
 }
 
-export function getCyclicDT(currentDT: number, direction: TimelineDirection): number {
+export function getCyclicDT(
+  currentDT: number,
+  direction: TimelineDirection,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): number {
   assertPositiveInteger('currentDT', currentDT);
 
   if (direction === '+') {
-    return currentDT >= COMBAT_ROUND_LENGTH_DT ? 1 : currentDT + 1;
+    return currentDT >= config.combat.roundLengthDT ? 1 : currentDT + 1;
   }
 
   if (direction === '-') {
-    return currentDT <= 1 ? COMBAT_ROUND_LENGTH_DT : currentDT - 1;
+    return currentDT <= 1 ? config.combat.roundLengthDT : currentDT - 1;
   }
 
   return currentDT;
@@ -148,12 +155,21 @@ export function getCyclicDT(currentDT: number, direction: TimelineDirection): nu
  * If `nextActionAt` is not set, the first action follows the legacy assistant:
  * current DT + speed factor.
  */
-export function addCombatant(state: CombatState, combatant: Combatant): CombatState {
-  const normalized = normalizeCombatant({
-    ...combatant,
-    nextActionAt:
-      combatant.nextActionAt > 0 ? combatant.nextActionAt : state.currentDT + combatant.speedFactor
-  });
+export function addCombatant(
+  state: CombatState,
+  combatant: Combatant,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): CombatState {
+  const normalized = normalizeCombatant(
+    {
+      ...combatant,
+      nextActionAt:
+        combatant.nextActionAt > 0
+          ? combatant.nextActionAt
+          : state.currentDT + combatant.speedFactor
+    },
+    config
+  );
 
   return {
     ...state,
@@ -166,7 +182,8 @@ export function addCombatant(state: CombatState, combatant: Combatant): CombatSt
  */
 export function resolveNextAction(
   state: CombatState,
-  options: CombatResolutionOptions = {}
+  options: CombatResolutionOptions = {},
+  config: RulesConfig = DEFAULT_RULES_CONFIG
 ): CombatState {
   if (state.timeline.length === 0) {
     throw new Error('Cannot resolve combat action without combatants');
@@ -179,12 +196,16 @@ export function resolveNextAction(
   const activeState: CombatState = {
     ...state,
     currentDT,
-    round: roundForDT(currentDT),
+    round: roundForDT(currentDT, config),
     timeline
   };
 
   if (action.type === 'attack') {
-    return rescheduleActor(resolveAttack(activeState, actor, action, options), actor.id, action);
+    return rescheduleActor(
+      resolveAttack(activeState, actor, action, options, config),
+      actor.id,
+      action
+    );
   }
 
   const event: CombatEvent = {
@@ -209,25 +230,35 @@ export function resolveNextAction(
  *
  * Positive values are damage. Negative values are healing.
  */
-export function applyDamage(state: CombatState, targetId: string, damage: number): CombatState {
+export function applyDamage(
+  state: CombatState,
+  targetId: string,
+  damage: number,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): CombatState {
   const target = findCombatant(state, targetId);
   const previousVitality = target.vitality.current;
   const nextVitality = clamp(previousVitality - damage, 0, target.vitality.max);
   const finalDamage = Math.max(0, previousVitality - nextVitality);
   const healed = Math.max(0, nextVitality - previousVitality);
-  const nextTarget = recomputeVitalityMalus({
-    ...target,
-    vitality: {
-      ...target.vitality,
-      current: nextVitality
+  const nextTarget = recomputeVitalityMalus(
+    {
+      ...target,
+      vitality: {
+        ...target.vitality,
+        current: nextVitality
+      },
+      nextActionAt: finalDamage > 0 ? target.nextActionAt + finalDamage : target.nextActionAt
     },
-    nextActionAt: finalDamage > 0 ? target.nextActionAt + finalDamage : target.nextActionAt
-  });
+    config
+  );
 
   const withDeath =
     nextVitality === 0 ? withStatus(nextTarget, { id: 'dead' }, state.currentDT) : nextTarget;
   const withUnconscious =
-    finalDamage > previousVitality / 2 && nextVitality > 0 && !target.ignoresVitalityMalus
+    finalDamage > previousVitality * config.combat.unconsciousDamageRatio &&
+    nextVitality > 0 &&
+    !target.ignoresVitalityMalus
       ? withStatus(withDeath, { id: 'unconscious' }, state.currentDT)
       : withDeath;
 
@@ -293,7 +324,7 @@ export function resolveStaminaDamage(
   );
   const preventedDamage = staminaRoll.successes;
   const finalDamage = Math.max(0, damage - preventedDamage);
-  const damagedState = finalDamage > 0 ? applyDamage(state, targetId, finalDamage) : state;
+  const damagedState = finalDamage > 0 ? applyDamage(state, targetId, finalDamage, config) : state;
 
   return {
     ...damagedState,
@@ -316,7 +347,8 @@ function resolveAttack(
   state: CombatState,
   actor: Combatant,
   action: AttackAction,
-  options: CombatResolutionOptions
+  options: CombatResolutionOptions,
+  config: RulesConfig
 ): CombatState {
   const attackRoll = rollDice(action.attack.pool, action.attack.difficulty, options);
   const defenseRoll = action.defense
@@ -340,7 +372,7 @@ function resolveAttack(
   };
 
   if (successes > 0 && action.damageOnHit !== undefined && action.damageOnHit > 0) {
-    return applyDamage(withAttackLog, action.targetId, action.damageOnHit);
+    return applyDamage(withAttackLog, action.targetId, action.damageOnHit, config);
   }
 
   return withAttackLog;
@@ -357,20 +389,33 @@ function rescheduleActor(state: CombatState, actorId: string, action: CombatActi
   });
 }
 
-function normalizeCombatant(combatant: Combatant): Combatant {
-  return recomputeVitalityMalus({
-    ...combatant,
-    baseAttributes: combatant.baseAttributes ?? combatant.attributes,
-    statuses: combatant.statuses ?? [],
-    skills: combatant.skills ?? {}
-  });
+function normalizeCombatant(
+  combatant: Combatant,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): Combatant {
+  return recomputeVitalityMalus(
+    {
+      ...combatant,
+      baseAttributes: combatant.baseAttributes ?? combatant.attributes,
+      statuses: combatant.statuses ?? [],
+      skills: combatant.skills ?? {}
+    },
+    config
+  );
 }
 
-function recomputeVitalityMalus(combatant: Combatant): Combatant {
+function recomputeVitalityMalus(
+  combatant: Combatant,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): Combatant {
   const baseAttributes = combatant.baseAttributes ?? combatant.attributes;
   const malus = combatant.ignoresVitalityMalus
     ? 0
-    : Math.max(0, Math.round(combatant.vitality.max / 2) - combatant.vitality.current);
+    : Math.max(
+        0,
+        Math.round(combatant.vitality.max * config.combat.vitalityMalusRatio) -
+          combatant.vitality.current
+      );
 
   return {
     ...combatant,
@@ -437,8 +482,8 @@ function sortTimeline(timeline: Combatant[]): Combatant[] {
   });
 }
 
-function roundForDT(currentDT: number): number {
-  return Math.floor((currentDT - 1) / COMBAT_ROUND_LENGTH_DT) + 1;
+function roundForDT(currentDT: number, config: RulesConfig = DEFAULT_RULES_CONFIG): number {
+  return Math.floor((currentDT - 1) / config.combat.roundLengthDT) + 1;
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/packages/rules-core/src/progression.ts
+++ b/packages/rules-core/src/progression.ts
@@ -1,5 +1,6 @@
 import {
   calculateLevelProgression,
+  isMagicianOrientation,
   type Character,
   type CharacterProgression,
   type CharacterSkill,
@@ -189,12 +190,12 @@ export function learnSpell<TCharacter extends Character>(
   options: LearnSpellOptions = {},
   config: RulesConfig = DEFAULT_RULES_CONFIG
 ): TCharacter {
-  if (!isMagician(character)) {
+  if (!isMagicianOrientation(character.orientation, config)) {
     throw new ProgressionError('only magician characters can learn spells');
   }
 
   assertNarrativeAccess(options.hasNarrativeAccess);
-  assertMinimumLevel(character, options.minimumLevel);
+  assertMinimumLevel(character, options.minimumLevel, config);
 
   const currentSpell = character.spells.find((spell) => spell.id === spellId);
   const cost = spellImprovementCost(currentSpell?.points ?? 0, config);
@@ -277,26 +278,22 @@ function assertNarrativeAccess(hasNarrativeAccess = true): void {
   }
 }
 
-function assertMinimumLevel(character: Character, minimumLevel?: number): void {
+function assertMinimumLevel(
+  character: Character,
+  minimumLevel?: number,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): void {
   if (minimumLevel === undefined) {
     return;
   }
 
   assertPositiveInteger('minimumLevel', minimumLevel);
 
-  const level = calculateLevelProgression(character).level ?? 0;
+  const level = calculateLevelProgression(character, config).level ?? 0;
 
   if (level < minimumLevel) {
     throw new ProgressionError(`level ${minimumLevel} required, current level is ${level}`);
   }
-}
-
-function isMagician(character: Character): boolean {
-  return (
-    character.orientation.isMagical === true ||
-    character.orientation.id === '1' ||
-    character.orientation.id === 'magicien'
-  );
 }
 
 function learningFloor(kind: LearningKind, config: RulesConfig = DEFAULT_RULES_CONFIG): number {

--- a/packages/rules-core/src/rules-config.test.ts
+++ b/packages/rules-core/src/rules-config.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
-import { addCombatant, createCombatState, resolveStaminaDamage } from './combat.js';
+import {
+  addCombatant,
+  applyDamage,
+  createCombatState,
+  getCyclicDT,
+  resolveStaminaDamage
+} from './combat.js';
+import {
+  ATTRIBUTE_KEYS,
+  calculateLevelProgression,
+  createPlayerCharacter,
+  type RaceProfile
+} from './character.js';
 import {
   calculateLearningPlan,
   skillImprovementCost,
@@ -34,6 +46,16 @@ function withCombat(overrides: Partial<RulesConfig['combat']>): RulesConfig {
   };
 }
 
+function withCreation(overrides: Partial<RulesConfig['creation']>): RulesConfig {
+  return {
+    ...DEFAULT_RULES_CONFIG,
+    creation: {
+      ...DEFAULT_RULES_CONFIG.creation,
+      ...overrides
+    }
+  };
+}
+
 function scriptedRolls(values: number[]) {
   let index = 0;
 
@@ -49,9 +71,113 @@ function scriptedRolls(values: number[]) {
   };
 }
 
+function targetCombatant() {
+  return {
+    id: 'target',
+    name: 'Target',
+    speedFactor: 5,
+    nextActionAt: 12,
+    reflexes: 3,
+    vitality: { current: 10, max: 10 },
+    attributes: { strength: 5, dexterity: 5, stamina: 3 },
+    baseAttributes: { strength: 5, dexterity: 5, stamina: 3 },
+    skills: {},
+    statuses: []
+  };
+}
+
+function humanRace(id = 'humain'): RaceProfile {
+  return {
+    id,
+    name: 'Human',
+    category: 20,
+    vitality: 24,
+    speedFactor: 8,
+    willFactor: 10,
+    attributeMax: Object.fromEntries(
+      ATTRIBUTE_KEYS.map((key) => [key, 6])
+    ) as RaceProfile['attributeMax']
+  };
+}
+
+function validAttributes() {
+  return {
+    strength: 3,
+    dexterity: 3,
+    stamina: 3,
+    reflexes: 2,
+    perception: 2,
+    intelligence: 2,
+    charisma: 2,
+    empathy: 2,
+    aestheticism: 1
+  };
+}
+
+function validSkills() {
+  return [
+    { id: 'epee', points: 4, isMain: true },
+    { id: 'course', points: 4 },
+    { id: 'chasse', points: 4 },
+    { id: 'histoire', points: 4 },
+    { id: 'medecine', points: 4 }
+  ];
+}
+
 describe('versioned rules-config', () => {
   it('exposes the canonical default ruleset version', () => {
     expect(DEFAULT_RULES_CONFIG.version).toBe(1);
+  });
+
+  it('drives combat round length from config.roundLengthDT', () => {
+    const custom = withCombat({ roundLengthDT: 12 });
+
+    expect(getCyclicDT(12, '+', custom)).toBe(1);
+    expect(getCyclicDT(1, '-', custom)).toBe(12);
+    expect(createCombatState(13, custom).round).toBe(2);
+  });
+
+  it('drives damage unconscious and vitality-malus thresholds from config ratios', () => {
+    const custom = withCombat({ unconsciousDamageRatio: 0.3, vitalityMalusRatio: 0.8 });
+    const state = addCombatant(createCombatState(1, custom), targetCombatant(), custom);
+
+    const result = applyDamage(state, 'target', 4, custom);
+    const target = result.timeline[0];
+
+    expect(target.vitality.current).toBe(6);
+    expect(target.statuses).toContainEqual({ id: 'unconscious', appliedAtDT: 1 });
+    expect(target.attributes).toMatchObject({ strength: 3, dexterity: 3, stamina: 1 });
+  });
+
+  it('drives magician and familiar identity from configured ids', () => {
+    const custom = withCreation({
+      magicianOrientationIds: ['custom-mage'],
+      familiarRaceIds: ['custom-familiar']
+    });
+
+    const mage = createPlayerCharacter(
+      {
+        id: 'pc-custom-mage',
+        name: 'Custom Mage',
+        race: humanRace(),
+        orientation: { id: 'custom-mage', name: 'Custom Mage' },
+        classProfile: { id: 'custom-class', name: 'Custom Class', orientationId: 'custom-mage' },
+        attributes: validAttributes(),
+        skills: validSkills(),
+        spells: [{ id: 'custom-spell', points: 2 }]
+      },
+      custom
+    );
+
+    expect(mage.energy).toEqual({ current: 60, max: 60 });
+
+    const familiar = { ...mage, race: humanRace('custom-familiar') };
+    expect(calculateLevelProgression(familiar, custom)).toEqual({
+      level: null,
+      levelPoints: null,
+      levelUpAt: null,
+      primarySkillIds: []
+    });
   });
 
   it('drives skill improvement cost from config.skillImprovementBaseCost', () => {
@@ -106,19 +232,7 @@ describe('versioned rules-config', () => {
   });
 
   it('drives the stamina endurance roll difficulty from config.staminaRollDifficulty', () => {
-    const makeState = () =>
-      addCombatant(createCombatState(1), {
-        id: 'target',
-        name: 'Target',
-        speedFactor: 5,
-        nextActionAt: 12,
-        reflexes: 3,
-        vitality: { current: 10, max: 10 },
-        attributes: { strength: 5, dexterity: 5, stamina: 3 },
-        baseAttributes: { strength: 5, dexterity: 5, stamina: 3 },
-        skills: {},
-        statuses: []
-      });
+    const makeState = () => addCombatant(createCombatState(1), targetCombatant());
 
     // Default difficulty 7: three dice showing 8 (>= 7) -> 3 successes -> 3 prevented.
     const defaultResult = resolveStaminaDamage(makeState(), 'target', 5, {

--- a/packages/rules-core/src/rules-config.ts
+++ b/packages/rules-core/src/rules-config.ts
@@ -30,6 +30,10 @@ export interface CreationRulesConfig {
   skillPointsPerSpellPoint: number;
   /** Starting energy (current and max) for a magician character. */
   magicianStartingEnergy: number;
+  /** Orientation ids treated as magician when source data does not expose isMagical. */
+  magicianOrientationIds: string[];
+  /** Race ids treated as familiars for level progression. */
+  familiarRaceIds: string[];
 }
 
 export interface ProgressionRulesConfig {
@@ -85,7 +89,9 @@ export const DEFAULT_RULES_CONFIG: RulesConfig = {
     maxSpellPointsAtCreation: 2,
     magicianBaseSpellPoints: 2,
     skillPointsPerSpellPoint: 10,
-    magicianStartingEnergy: 60
+    magicianStartingEnergy: 60,
+    magicianOrientationIds: ['1', 'magicien'],
+    familiarRaceIds: ['32', 'familiar']
   },
   progression: {
     skillImprovementBaseCost: 3,


### PR DESCRIPTION
## Summary
- finish the follow-ups deferred by PR #75 for #73
- drive combat round length, unconscious threshold and vitality malus from `RulesConfig.combat`
- drive magician/familiar identity from configured ids instead of literal checks in rules logic
- keep legacy defaults in `DEFAULT_RULES_CONFIG` and add tests proving custom IDs/ratios change behavior

Closes #73.

## Checks
- `pnpm --filter @knightandwizard/rules-core test`
- `pnpm --filter @knightandwizard/rules-core build`
- `pnpm --filter @knightandwizard/catalogs build`
- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm canonical:check`
- `pnpm canonical:check:strict`
- `pnpm build`
- `git diff --check`
