### PR TITLE
feat(cms): wire canonical catalog import

### DIFF
--- a/apps/cms/src/collections/Users.ts
+++ b/apps/cms/src/collections/Users.ts
@@ -11,6 +11,17 @@ export const Users: CollectionConfig = {
     {
       name: 'name',
       type: 'text'
+    },
+    {
+      name: 'roles',
+      type: 'select',
+      defaultValue: ['catalog_reviewer'],
+      hasMany: true,
+      options: [
+        { label: 'Admin', value: 'admin' },
+        { label: 'Catalog Editor', value: 'catalog_editor' },
+        { label: 'Catalog Reviewer', value: 'catalog_reviewer' }
+      ]
     }
   ]
 };

--- a/apps/cms/src/collections/catalogCollections.test.ts
+++ b/apps/cms/src/collections/catalogCollections.test.ts
@@ -1,6 +1,7 @@
 import type { CollectionConfig, Field } from 'payload';
 import { describe, expect, it } from 'vitest';
 
+import { Users } from './Users.js';
 import { CatalogCollections } from './catalogCollections.js';
 
 const requiredCatalogSlugs = [
@@ -8,6 +9,7 @@ const requiredCatalogSlugs = [
   'protections',
   'bestiary',
   'potions',
+  'magic-schools',
   'spells',
   'nations',
   'organisations',
@@ -37,7 +39,7 @@ const legacySupportSlugs = [
 const expectedSlugs = [...requiredCatalogSlugs, ...yamlBacklogSlugs, ...legacySupportSlugs];
 
 describe('Payload catalog collections', () => {
-  it('registers the complete CMS catalog surface for issue 3C-02', () => {
+  it('registers the complete CMS catalog surface for issue 56', () => {
     expect(CatalogCollections.map((collection) => collection.slug)).toEqual(expectedSlugs);
   });
 
@@ -53,9 +55,42 @@ describe('Payload catalog collections', () => {
         unique: true
       });
 
+      expect(collection.fields.some(fieldByName('status'))).toBe(true);
       expect(collection.fields.some(fieldByName('sourceRefs'))).toBe(true);
       expect(collection.fields.some(fieldByName('metadata'))).toBe(true);
     }
+  });
+
+  it('preserves canonical status and source hashes on every catalog collection', () => {
+    for (const collection of CatalogCollections) {
+      expect(field(collection.slug, 'status')).toMatchObject({
+        defaultValue: 'active',
+        index: true,
+        type: 'select'
+      });
+      expect(childFieldNames(field(collection.slug, 'sourceRefs'))).toEqual([
+        'kind',
+        'path',
+        'ref',
+        'sha256',
+        'note'
+      ]);
+    }
+  });
+
+  it('defines catalog editor and reviewer permissions', () => {
+    for (const collection of CatalogCollections) {
+      expect(collection.access).toBeDefined();
+      expect(runAccess(collection, 'read', { roles: ['catalog_reviewer'] })).toBe(true);
+      expect(runAccess(collection, 'create', { roles: ['catalog_editor'] })).toBe(true);
+      expect(runAccess(collection, 'update', { roles: ['catalog_editor'] })).toBe(true);
+      expect(runAccess(collection, 'delete', { roles: ['catalog_reviewer'] })).toBe(false);
+    }
+
+    expect(fieldFromFields(Users.fields, 'roles')).toMatchObject({
+      hasMany: true,
+      type: 'select'
+    });
   });
 
   it('keeps collection slugs unique', () => {
@@ -64,30 +99,72 @@ describe('Payload catalog collections', () => {
   });
 
   it('models critical relationships between catalogs', () => {
-    expect(field(CatalogCollections, 'weapons', 'originNation')).toMatchObject({
+    expect(field('weapons', 'originNation')).toMatchObject({
       relationTo: 'nations',
       type: 'relationship'
     });
-    expect(field(CatalogCollections, 'level-assets', 'characterClass')).toMatchObject({
+    expect(field('level-assets', 'characterClass')).toMatchObject({
       relationTo: 'character-classes',
       type: 'relationship'
     });
-    expect(field(CatalogCollections, 'places', 'parentPlace')).toMatchObject({
+    expect(field('places', 'parentPlace')).toMatchObject({
       relationTo: 'places',
       type: 'relationship'
     });
-    expect(field(CatalogCollections, 'character-classes', 'primarySkills')).toMatchObject({
+    expect(field('character-classes', 'primarySkills')).toMatchObject({
       hasMany: true,
       relationTo: 'skills',
+      type: 'relationship'
+    });
+    expect(field('magic-schools', 'specialistClass')).toMatchObject({
+      relationTo: 'character-classes',
+      type: 'relationship'
+    });
+    expect(field('spells', 'magicSchool')).toMatchObject({
+      relationTo: 'magic-schools',
       type: 'relationship'
     });
   });
 });
 
-function field(collections: CollectionConfig[], slug: string, name: string): Field | undefined {
-  return collections.find((collection) => collection.slug === slug)?.fields.find(fieldByName(name));
+function field(slug: string, name: string): Field | undefined {
+  return CatalogCollections.find((collection) => collection.slug === slug)?.fields.find(
+    fieldByName(name)
+  );
+}
+
+function fieldFromFields(fields: Field[], name: string): Field | undefined {
+  return fields.find(fieldByName(name));
 }
 
 function fieldByName(name: string): (field: Field) => boolean {
   return (field) => 'name' in field && field.name === name;
+}
+
+function childFieldNames(field: Field | undefined): string[] {
+  if (!field || !('fields' in field) || !Array.isArray(field.fields)) {
+    return [];
+  }
+
+  return field.fields.filter(hasName).map((childField) => String(childField.name));
+}
+
+function hasName(field: Field): field is Field & { name: string } {
+  return 'name' in field && typeof field.name === 'string';
+}
+
+type AccessName = 'create' | 'delete' | 'read' | 'update';
+
+function runAccess(
+  collection: CollectionConfig,
+  accessName: AccessName,
+  user: { roles: string[] }
+): boolean {
+  const access = collection.access?.[accessName];
+
+  if (typeof access !== 'function') {
+    return false;
+  }
+
+  return Boolean(access({ req: { user } } as unknown as Parameters<typeof access>[0]));
 }

--- a/apps/cms/src/collections/catalogCollections.ts
+++ b/apps/cms/src/collections/catalogCollections.ts
@@ -16,7 +16,43 @@ const CATALOG_GROUP = 'Catalogues canoniques';
 const LEGACY_GROUP = 'Referentiels PHP';
 const RULES_GROUP = 'Regles vivantes';
 
+const catalogEntryStatuses = ['active', 'ambiguous', 'deprecated', 'raw_reference_only'] as const;
+const catalogEditorRoles = ['admin', 'catalog_editor'] as const;
+const catalogReviewerRoles = ['admin', 'catalog_editor', 'catalog_reviewer'] as const;
+
 const canonicalIdPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+type CatalogUser = {
+  role?: string | null;
+  roles?: string[] | string | null;
+};
+
+const catalogAccess: CollectionConfig['access'] = {
+  read: ({ req }) => hasCatalogRole(req.user, catalogReviewerRoles),
+  create: ({ req }) => hasCatalogRole(req.user, catalogEditorRoles),
+  update: ({ req }) => hasCatalogRole(req.user, catalogEditorRoles),
+  delete: ({ req }) => hasCatalogRole(req.user, catalogEditorRoles)
+};
+
+function hasCatalogRole(
+  user: unknown,
+  allowedRoles: readonly (typeof catalogReviewerRoles)[number][]
+): boolean {
+  if (!isCatalogUser(user)) {
+    return false;
+  }
+
+  const roles = [
+    ...(Array.isArray(user.roles) ? user.roles : user.roles ? [user.roles] : []),
+    ...(user.role ? [user.role] : [])
+  ];
+
+  return roles.some((role) => allowedRoles.includes(role as (typeof catalogReviewerRoles)[number]));
+}
+
+function isCatalogUser(user: unknown): user is CatalogUser {
+  return typeof user === 'object' && user !== null;
+}
 
 const normalizeCanonicalId: CollectionBeforeValidateHook = ({ data }) => {
   if (!data) {
@@ -63,6 +99,14 @@ const nameField: Field = {
   required: true
 };
 
+const statusField: Field = selectField('status', catalogEntryStatuses, false, {
+  admin: {
+    description: 'Canonical review status preserved from YAML imports.'
+  },
+  defaultValue: 'active',
+  index: true
+});
+
 const migrationNotesField: Field = {
   name: 'migrationNotes',
   type: 'textarea',
@@ -87,8 +131,14 @@ const sourceRefsField: Field = {
     description: 'Source files, legacy tables or rules documents used to create this entry.'
   },
   fields: [
-    selectField('kind', ['yaml', 'legacy_php', 'rules_markdown', 'map_asset', 'manual'], true),
+    selectField(
+      'kind',
+      ['yaml', 'legacy_source', 'legacy_php', 'rules_markdown', 'map_asset', 'manual'],
+      true
+    ),
     textField('path', true),
+    textField('ref'),
+    textField('sha256'),
     textField('note')
   ]
 };
@@ -193,14 +243,29 @@ export const Potions = catalogCollection({
   slug: 'potions'
 });
 
-export const Spells = catalogCollection({
-  defaultColumns: ['canonicalId', 'name', 'magicType', 'energyCost', 'difficulty'],
+export const MagicSchools = catalogCollection({
+  defaultColumns: ['canonicalId', 'name', 'color', 'specialistClassCanonicalId', 'status'],
   fields: [
-    selectField('magicType', magicTypes, true),
-    textareaField('effect'),
-    numberField('energyCost'),
-    numberField('castingTimeDT'),
-    numberField('difficulty'),
+    textField('sourceLabel'),
+    textField('color', true),
+    textareaField('domain', true),
+    textField('specialistClassCanonicalId', true),
+    relationshipField('specialistClass', 'character-classes')
+  ],
+  labels: { singular: 'Magic School', plural: 'Magic Schools' },
+  slug: 'magic-schools'
+});
+
+export const Spells = catalogCollection({
+  defaultColumns: ['canonicalId', 'name', 'magicSchoolCanonicalId', 'energyCost', 'difficulty'],
+  fields: [
+    textField('magicSchoolCanonicalId', true),
+    relationshipField('magicSchool', 'magic-schools'),
+    selectField('magicType', magicTypes),
+    textareaField('effect', true),
+    numberField('energyCost', true),
+    numberField('castingTimeDT', true),
+    numberField('difficulty', true),
     numberField('value'),
     checkboxField('directMagic'),
     textField('legacyTypeId')
@@ -374,8 +439,8 @@ export const MapCities = catalogCollection({
 
 export const Orientations = catalogCollection({
   adminGroup: LEGACY_GROUP,
-  defaultColumns: ['canonicalId', 'name'],
-  fields: [relationshipField('asset', 'assets')],
+  defaultColumns: ['canonicalId', 'name', 'isMagical', 'status'],
+  fields: [checkboxField('isMagical'), relationshipField('asset', 'assets')],
   labels: { singular: 'Orientation', plural: 'Orientations' },
   slug: 'orientations'
 });
@@ -398,7 +463,7 @@ export const Races = catalogCollection({
 
 export const SkillFamilies = catalogCollection({
   adminGroup: LEGACY_GROUP,
-  defaultColumns: ['canonicalId', 'name'],
+  defaultColumns: ['canonicalId', 'name', 'status'],
   fields: [textareaField('description')],
   labels: { singular: 'Skill Family', plural: 'Skill Families' },
   slug: 'skill-families'
@@ -406,8 +471,10 @@ export const SkillFamilies = catalogCollection({
 
 export const Skills = catalogCollection({
   adminGroup: LEGACY_GROUP,
-  defaultColumns: ['canonicalId', 'name', 'family', 'parentSkill'],
+  defaultColumns: ['canonicalId', 'name', 'familyCanonicalId', 'parentSkillCanonicalId'],
   fields: [
+    textField('familyCanonicalId', true),
+    textField('parentSkillCanonicalId'),
     relationshipField('family', 'skill-families'),
     relationshipField('parentSkill', 'skills'),
     checkboxField('isPrimaryCandidate')
@@ -418,8 +485,11 @@ export const Skills = catalogCollection({
 
 export const CharacterClasses = catalogCollection({
   adminGroup: LEGACY_GROUP,
-  defaultColumns: ['canonicalId', 'name', 'orientation', 'classAsset'],
+  defaultColumns: ['canonicalId', 'name', 'orientationCanonicalId', 'primarySkillChoice'],
   fields: [
+    textField('orientationCanonicalId', true),
+    textField('primarySkillCanonicalId'),
+    selectField('primarySkillChoice', ['fixed', 'player_choice', 'magician_no_primary'], true),
     relationshipField('orientation', 'orientations'),
     relationshipField('classAsset', 'assets'),
     relationshipField('primarySkills', 'skills', { hasMany: true })
@@ -451,11 +521,15 @@ export const Assets = catalogCollection({
 
 export const LevelAssets = catalogCollection({
   adminGroup: LEGACY_GROUP,
-  defaultColumns: ['canonicalId', 'name', 'asset', 'level', 'points'],
+  defaultColumns: ['canonicalId', 'name', 'assetCanonicalId', 'level', 'points'],
   fields: [
+    textField('assetCanonicalId', true),
     relationshipField('asset', 'assets'),
     numberField('level', true),
     numberField('points'),
+    textField('raceName'),
+    textField('orientationName'),
+    textField('characterClassName'),
     relationshipField('race', 'races'),
     relationshipField('orientation', 'orientations'),
     relationshipField('characterClass', 'character-classes'),
@@ -467,11 +541,11 @@ export const LevelAssets = catalogCollection({
 
 export const Places = catalogCollection({
   adminGroup: LEGACY_GROUP,
-  defaultColumns: ['canonicalId', 'name', 'status', 'nation', 'isCapital'],
+  defaultColumns: ['canonicalId', 'name', 'placeStatus', 'nation', 'isCapital'],
   fields: [
     relationshipField('parentPlace', 'places'),
     relationshipField('nation', 'nations'),
-    textField('status'),
+    textField('placeStatus'),
     checkboxField('isCapital'),
     selectField('mapRole', ['forum_place', 'city', 'town', 'region', 'landmark', 'unknown'])
   ],
@@ -484,6 +558,7 @@ export const CatalogCollections = [
   Protections,
   Bestiary,
   Potions,
+  MagicSchools,
   Spells,
   Nations,
   Organisations,
@@ -519,6 +594,7 @@ function catalogCollection({
       useAsTitle: 'name'
     },
     labels,
+    access: catalogAccess,
     versions: true,
     hooks: {
       beforeValidate: [normalizeCanonicalId]
@@ -526,6 +602,7 @@ function catalogCollection({
     fields: [
       canonicalIdField,
       nameField,
+      statusField,
       ...fields,
       sourceRefsField,
       migrationNotesField,

--- a/packages/catalogs/src/payload-types.ts
+++ b/packages/catalogs/src/payload-types.ts
@@ -72,6 +72,7 @@ export interface Config {
     protections: Protection;
     bestiary: Bestiary;
     potions: Potion;
+    'magic-schools': MagicSchool;
     spells: Spell;
     nations: Nation;
     organisations: Organisation;
@@ -102,6 +103,7 @@ export interface Config {
     protections: ProtectionsSelect<false> | ProtectionsSelect<true>;
     bestiary: BestiarySelect<false> | BestiarySelect<true>;
     potions: PotionsSelect<false> | PotionsSelect<true>;
+    'magic-schools': MagicSchoolsSelect<false> | MagicSchoolsSelect<true>;
     spells: SpellsSelect<false> | SpellsSelect<true>;
     nations: NationsSelect<false> | NationsSelect<true>;
     organisations: OrganisationsSelect<false> | OrganisationsSelect<true>;
@@ -168,6 +170,7 @@ export interface UserAuthOperations {
 export interface User {
   id: number;
   name?: string | null;
+  roles?: ('admin' | 'catalog_editor' | 'catalog_reviewer')[] | null;
   updatedAt: string;
   createdAt: string;
   email: string;
@@ -198,6 +201,10 @@ export interface Weapon {
    */
   canonicalId: string;
   name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
   category: string;
   damageTypes?: ('P' | 'E' | 'C' | 'T' | 'special')[] | null;
   damageFormula: string;
@@ -211,8 +218,10 @@ export interface Weapon {
    */
   sourceRefs?:
     | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
         path: string;
+        ref?: string | null;
+        sha256?: string | null;
         note?: string | null;
         id?: string | null;
       }[]
@@ -247,6 +256,10 @@ export interface Nation {
    */
   canonicalId: string;
   name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
   category: string;
   capital?: string | null;
   officialLanguage?: string | null;
@@ -278,8 +291,10 @@ export interface Nation {
    */
   sourceRefs?:
     | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
         path: string;
+        ref?: string | null;
+        sha256?: string | null;
         note?: string | null;
         id?: string | null;
       }[]
@@ -314,6 +329,10 @@ export interface Protection {
    */
   canonicalId: string;
   name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
   kind: 'armor_piece' | 'shield';
   layer?: string | null;
   category: string;
@@ -347,8 +366,10 @@ export interface Protection {
    */
   sourceRefs?:
     | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
         path: string;
+        ref?: string | null;
+        sha256?: string | null;
         note?: string | null;
         id?: string | null;
       }[]
@@ -383,6 +404,10 @@ export interface Bestiary {
    */
   canonicalId: string;
   name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
   category: string;
   sizeM?: number | null;
   lifeExpectancy?: number | null;
@@ -408,8 +433,10 @@ export interface Bestiary {
    */
   sourceRefs?:
     | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
         path: string;
+        ref?: string | null;
+        sha256?: string | null;
         note?: string | null;
         id?: string | null;
       }[]
@@ -444,6 +471,10 @@ export interface Potion {
    */
   canonicalId: string;
   name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
   category: string;
   outputType: string;
   effect: string;
@@ -481,8 +512,10 @@ export interface Potion {
    */
   sourceRefs?:
     | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
         path: string;
+        ref?: string | null;
+        sha256?: string | null;
         note?: string | null;
         id?: string | null;
       }[]
@@ -508,712 +541,33 @@ export interface Potion {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "spells".
+ * via the `definition` "magic-schools".
  */
-export interface Spell {
+export interface MagicSchool {
   id: number;
   /**
    * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
    */
   canonicalId: string;
   name: string;
-  magicType:
-    | 'abjuration'
-    | 'alteration'
-    | 'white_magic'
-    | 'divination'
-    | 'enchantment'
-    | 'elemental'
-    | 'illusion'
-    | 'invocation'
-    | 'natural_magic'
-    | 'black_magic'
-    | 'necromancy'
-    | 'legacy_type';
-  effect?: string | null;
-  energyCost?: number | null;
-  castingTimeDT?: number | null;
-  difficulty?: number | null;
-  value?: number | null;
-  directMagic?: boolean | null;
-  legacyTypeId?: string | null;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  sourceLabel?: string | null;
+  color: string;
+  domain: string;
+  specialistClassCanonicalId: string;
+  specialistClass?: (number | null) | CharacterClass;
   /**
    * Source files, legacy tables or rules documents used to create this entry.
    */
   sourceRefs?:
     | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
         path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "organisations".
- */
-export interface Organisation {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  category: string;
-  description?: string | null;
-  homeNation?: (number | null) | Nation;
-  relatedReligion?: (number | null) | Religion;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "religions".
- */
-export interface Religion {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  category: string;
-  primaryRace?: (number | null) | Race;
-  doctrine?: string | null;
-  deities?:
-    | {
-        name: string;
-        title?: string | null;
-        domain?: string | null;
-        notes?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "races".
- */
-export interface Race {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  category?: number | null;
-  vitalityBase?: number | null;
-  speedFactorBase?: number | null;
-  willFactorBase?: number | null;
-  attributeMax?: {
-    strength?: number | null;
-    dexterity?: number | null;
-    stamina?: number | null;
-    reflexes?: number | null;
-    perception?: number | null;
-    intelligence?: number | null;
-    charisma?: number | null;
-    empathy?: number | null;
-    aestheticism?: number | null;
-  };
-  raceAssets?: (number | Asset)[] | null;
-  playable?: boolean | null;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "assets".
- */
-export interface Asset {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  type: 'neutral' | 'race' | 'orientation' | 'class' | 'level' | 'handicap' | 'familiar';
-  activation?: ('permanent' | 'ephemeral' | 'manual' | 'legacy_unknown') | null;
-  effect: string;
-  value?: number | null;
-  familiarCostPoints?: number | null;
-  familiarGrantPoints?: number | null;
-  isHandicap?: boolean | null;
-  sourceLine?: number | null;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "rules".
- */
-export interface Rule {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  section:
-    | 'resolution'
-    | 'attributes'
-    | 'races'
-    | 'classes'
-    | 'skills'
-    | 'character_creation'
-    | 'progression'
-    | 'magic'
-    | 'combat'
-    | 'equipment'
-    | 'npc_control'
-    | 'world'
-    | 'roles';
-  sourcePath: string;
-  order?: number | null;
-  content: string;
-  tags?:
-    | {
-        tag: string;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "mushrooms".
- */
-export interface Mushroom {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  syndrome?: string | null;
-  toxicity?: string | null;
-  symptoms?: string | null;
-  treatment?: string | null;
-  species?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "images".
- */
-export interface Image {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  assetType: 'world_map' | 'regional_map' | 'coat_of_arms' | 'web_asset';
-  sourcePath: string;
-  altText?: string | null;
-  width?: number | null;
-  height?: number | null;
-  relatedNation?: (number | null) | Nation;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "lore-entries".
- */
-export interface LoreEntry {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  topic: string;
-  sourcePath: string;
-  summary?: string | null;
-  content?: string | null;
-  tags?:
-    | {
-        tag: string;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "world-map-regions".
- */
-export interface WorldMapRegion {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  kind: 'region' | 'nation' | 'zone' | 'landmark';
-  parentRegion?: (number | null) | WorldMapRegion;
-  nation?: (number | null) | Nation;
-  sourceMap?: string | null;
-  borders?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  geometry?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "map-cities".
- */
-export interface MapCity {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  parentRegion?: (number | null) | WorldMapRegion;
-  nation?: (number | null) | Nation;
-  role:
-    | 'capital'
-    | 'capital_centre'
-    | 'major_city'
-    | 'town'
-    | 'border_town'
-    | 'village'
-    | 'landmark'
-    | 'gate'
-    | 'island'
-    | 'island_group'
-    | 'tribal_capital';
-  domain?: string | null;
-  sourceMap?: string | null;
-  webId?: number | null;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "orientations".
- */
-export interface Orientation {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  asset?: (number | null) | Asset;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "skill-families".
- */
-export interface SkillFamily {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  description?: string | null;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
-        note?: string | null;
-        id?: string | null;
-      }[]
-    | null;
-  /**
-   * Internal notes for source ambiguity, author validation or migration decisions.
-   */
-  migrationNotes?: string | null;
-  /**
-   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
-   */
-  metadata?:
-    | {
-        [k: string]: unknown;
-      }
-    | unknown[]
-    | string
-    | number
-    | boolean
-    | null;
-  updatedAt: string;
-  createdAt: string;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "skills".
- */
-export interface Skill {
-  id: number;
-  /**
-   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
-   */
-  canonicalId: string;
-  name: string;
-  family?: (number | null) | SkillFamily;
-  parentSkill?: (number | null) | Skill;
-  isPrimaryCandidate?: boolean | null;
-  /**
-   * Source files, legacy tables or rules documents used to create this entry.
-   */
-  sourceRefs?:
-    | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
-        path: string;
+        ref?: string | null;
+        sha256?: string | null;
         note?: string | null;
         id?: string | null;
       }[]
@@ -1248,6 +602,13 @@ export interface CharacterClass {
    */
   canonicalId: string;
   name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  orientationCanonicalId: string;
+  primarySkillCanonicalId?: string | null;
+  primarySkillChoice: 'fixed' | 'player_choice' | 'magician_no_primary';
   orientation?: (number | null) | Orientation;
   classAsset?: (number | null) | Asset;
   primarySkills?: (number | Skill)[] | null;
@@ -1256,8 +617,833 @@ export interface CharacterClass {
    */
   sourceRefs?:
     | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
         path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "orientations".
+ */
+export interface Orientation {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  isMagical?: boolean | null;
+  asset?: (number | null) | Asset;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "assets".
+ */
+export interface Asset {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  type: 'neutral' | 'race' | 'orientation' | 'class' | 'level' | 'handicap' | 'familiar';
+  activation?: ('permanent' | 'ephemeral' | 'manual' | 'legacy_unknown') | null;
+  effect: string;
+  value?: number | null;
+  familiarCostPoints?: number | null;
+  familiarGrantPoints?: number | null;
+  isHandicap?: boolean | null;
+  sourceLine?: number | null;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "skills".
+ */
+export interface Skill {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  familyCanonicalId: string;
+  parentSkillCanonicalId?: string | null;
+  family?: (number | null) | SkillFamily;
+  parentSkill?: (number | null) | Skill;
+  isPrimaryCandidate?: boolean | null;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "skill-families".
+ */
+export interface SkillFamily {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  description?: string | null;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "spells".
+ */
+export interface Spell {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  magicSchoolCanonicalId: string;
+  magicSchool?: (number | null) | MagicSchool;
+  magicType?:
+    | (
+        | 'abjuration'
+        | 'alteration'
+        | 'white_magic'
+        | 'divination'
+        | 'enchantment'
+        | 'elemental'
+        | 'illusion'
+        | 'invocation'
+        | 'natural_magic'
+        | 'black_magic'
+        | 'necromancy'
+        | 'legacy_type'
+      )
+    | null;
+  effect: string;
+  energyCost: number;
+  castingTimeDT: number;
+  difficulty: number;
+  value?: number | null;
+  directMagic?: boolean | null;
+  legacyTypeId?: string | null;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "organisations".
+ */
+export interface Organisation {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  category: string;
+  description?: string | null;
+  homeNation?: (number | null) | Nation;
+  relatedReligion?: (number | null) | Religion;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "religions".
+ */
+export interface Religion {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  category: string;
+  primaryRace?: (number | null) | Race;
+  doctrine?: string | null;
+  deities?:
+    | {
+        name: string;
+        title?: string | null;
+        domain?: string | null;
+        notes?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "races".
+ */
+export interface Race {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  category?: number | null;
+  vitalityBase?: number | null;
+  speedFactorBase?: number | null;
+  willFactorBase?: number | null;
+  attributeMax?: {
+    strength?: number | null;
+    dexterity?: number | null;
+    stamina?: number | null;
+    reflexes?: number | null;
+    perception?: number | null;
+    intelligence?: number | null;
+    charisma?: number | null;
+    empathy?: number | null;
+    aestheticism?: number | null;
+  };
+  raceAssets?: (number | Asset)[] | null;
+  playable?: boolean | null;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "rules".
+ */
+export interface Rule {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  section:
+    | 'resolution'
+    | 'attributes'
+    | 'races'
+    | 'classes'
+    | 'skills'
+    | 'character_creation'
+    | 'progression'
+    | 'magic'
+    | 'combat'
+    | 'equipment'
+    | 'npc_control'
+    | 'world'
+    | 'roles';
+  sourcePath: string;
+  order?: number | null;
+  content: string;
+  tags?:
+    | {
+        tag: string;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "mushrooms".
+ */
+export interface Mushroom {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  syndrome?: string | null;
+  toxicity?: string | null;
+  symptoms?: string | null;
+  treatment?: string | null;
+  species?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "images".
+ */
+export interface Image {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  assetType: 'world_map' | 'regional_map' | 'coat_of_arms' | 'web_asset';
+  sourcePath: string;
+  altText?: string | null;
+  width?: number | null;
+  height?: number | null;
+  relatedNation?: (number | null) | Nation;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "lore-entries".
+ */
+export interface LoreEntry {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  topic: string;
+  sourcePath: string;
+  summary?: string | null;
+  content?: string | null;
+  tags?:
+    | {
+        tag: string;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "world-map-regions".
+ */
+export interface WorldMapRegion {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  kind: 'region' | 'nation' | 'zone' | 'landmark';
+  parentRegion?: (number | null) | WorldMapRegion;
+  nation?: (number | null) | Nation;
+  sourceMap?: string | null;
+  borders?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  geometry?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
+        note?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  /**
+   * Internal notes for source ambiguity, author validation or migration decisions.
+   */
+  migrationNotes?: string | null;
+  /**
+   * Raw catalog metadata preserved from YAML/PHP until importer-specific fields stabilize.
+   */
+  metadata?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "map-cities".
+ */
+export interface MapCity {
+  id: number;
+  /**
+   * Stable source id used by YAML imports, legacy PHP mapping and rules-core references.
+   */
+  canonicalId: string;
+  name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  parentRegion?: (number | null) | WorldMapRegion;
+  nation?: (number | null) | Nation;
+  role:
+    | 'capital'
+    | 'capital_centre'
+    | 'major_city'
+    | 'town'
+    | 'border_town'
+    | 'village'
+    | 'landmark'
+    | 'gate'
+    | 'island'
+    | 'island_group'
+    | 'tribal_capital';
+  domain?: string | null;
+  sourceMap?: string | null;
+  webId?: number | null;
+  /**
+   * Source files, legacy tables or rules documents used to create this entry.
+   */
+  sourceRefs?:
+    | {
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        path: string;
+        ref?: string | null;
+        sha256?: string | null;
         note?: string | null;
         id?: string | null;
       }[]
@@ -1292,9 +1478,17 @@ export interface LevelAsset {
    */
   canonicalId: string;
   name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
+  assetCanonicalId: string;
   asset?: (number | null) | Asset;
   level: number;
   points?: number | null;
+  raceName?: string | null;
+  orientationName?: string | null;
+  characterClassName?: string | null;
   race?: (number | null) | Race;
   orientation?: (number | null) | Orientation;
   characterClass?: (number | null) | CharacterClass;
@@ -1304,8 +1498,10 @@ export interface LevelAsset {
    */
   sourceRefs?:
     | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
         path: string;
+        ref?: string | null;
+        sha256?: string | null;
         note?: string | null;
         id?: string | null;
       }[]
@@ -1340,9 +1536,13 @@ export interface Place {
    */
   canonicalId: string;
   name: string;
+  /**
+   * Canonical review status preserved from YAML imports.
+   */
+  status?: ('active' | 'ambiguous' | 'deprecated' | 'raw_reference_only') | null;
   parentPlace?: (number | null) | Place;
   nation?: (number | null) | Nation;
-  status?: string | null;
+  placeStatus?: string | null;
   isCapital?: boolean | null;
   mapRole?: ('forum_place' | 'city' | 'town' | 'region' | 'landmark' | 'unknown') | null;
   /**
@@ -1350,8 +1550,10 @@ export interface Place {
    */
   sourceRefs?:
     | {
-        kind: 'yaml' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
+        kind: 'yaml' | 'legacy_source' | 'legacy_php' | 'rules_markdown' | 'map_asset' | 'manual';
         path: string;
+        ref?: string | null;
+        sha256?: string | null;
         note?: string | null;
         id?: string | null;
       }[]
@@ -1418,6 +1620,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'potions';
         value: number | Potion;
+      } | null)
+    | ({
+        relationTo: 'magic-schools';
+        value: number | MagicSchool;
       } | null)
     | ({
         relationTo: 'spells';
@@ -1539,6 +1745,7 @@ export interface PayloadMigration {
  */
 export interface UsersSelect<T extends boolean = true> {
   name?: T;
+  roles?: T;
   updatedAt?: T;
   createdAt?: T;
   email?: T;
@@ -1563,6 +1770,7 @@ export interface UsersSelect<T extends boolean = true> {
 export interface WeaponsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   category?: T;
   damageTypes?: T;
   damageFormula?: T;
@@ -1576,6 +1784,8 @@ export interface WeaponsSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1591,6 +1801,7 @@ export interface WeaponsSelect<T extends boolean = true> {
 export interface ProtectionsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   kind?: T;
   layer?: T;
   category?: T;
@@ -1618,6 +1829,8 @@ export interface ProtectionsSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1633,6 +1846,7 @@ export interface ProtectionsSelect<T extends boolean = true> {
 export interface BestiarySelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   category?: T;
   sizeM?: T;
   lifeExpectancy?: T;
@@ -1660,6 +1874,8 @@ export interface BestiarySelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1675,6 +1891,7 @@ export interface BestiarySelect<T extends boolean = true> {
 export interface PotionsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   category?: T;
   outputType?: T;
   effect?: T;
@@ -1696,6 +1913,36 @@ export interface PotionsSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
+        note?: T;
+        id?: T;
+      };
+  migrationNotes?: T;
+  metadata?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "magic-schools_select".
+ */
+export interface MagicSchoolsSelect<T extends boolean = true> {
+  canonicalId?: T;
+  name?: T;
+  status?: T;
+  sourceLabel?: T;
+  color?: T;
+  domain?: T;
+  specialistClassCanonicalId?: T;
+  specialistClass?: T;
+  sourceRefs?:
+    | T
+    | {
+        kind?: T;
+        path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1711,6 +1958,9 @@ export interface PotionsSelect<T extends boolean = true> {
 export interface SpellsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
+  magicSchoolCanonicalId?: T;
+  magicSchool?: T;
   magicType?: T;
   effect?: T;
   energyCost?: T;
@@ -1724,6 +1974,8 @@ export interface SpellsSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1739,6 +1991,7 @@ export interface SpellsSelect<T extends boolean = true> {
 export interface NationsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   category?: T;
   capital?: T;
   officialLanguage?: T;
@@ -1754,6 +2007,8 @@ export interface NationsSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1769,6 +2024,7 @@ export interface NationsSelect<T extends boolean = true> {
 export interface OrganisationsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   category?: T;
   description?: T;
   homeNation?: T;
@@ -1778,6 +2034,8 @@ export interface OrganisationsSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1793,6 +2051,7 @@ export interface OrganisationsSelect<T extends boolean = true> {
 export interface ReligionsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   category?: T;
   primaryRace?: T;
   doctrine?: T;
@@ -1810,6 +2069,8 @@ export interface ReligionsSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1825,6 +2086,7 @@ export interface ReligionsSelect<T extends boolean = true> {
 export interface RulesSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   section?: T;
   sourcePath?: T;
   order?: T;
@@ -1840,6 +2102,8 @@ export interface RulesSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1855,6 +2119,7 @@ export interface RulesSelect<T extends boolean = true> {
 export interface MushroomsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   syndrome?: T;
   toxicity?: T;
   symptoms?: T;
@@ -1865,6 +2130,8 @@ export interface MushroomsSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1880,6 +2147,7 @@ export interface MushroomsSelect<T extends boolean = true> {
 export interface ImagesSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   assetType?: T;
   sourcePath?: T;
   altText?: T;
@@ -1891,6 +2159,8 @@ export interface ImagesSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1906,6 +2176,7 @@ export interface ImagesSelect<T extends boolean = true> {
 export interface LoreEntriesSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   topic?: T;
   sourcePath?: T;
   summary?: T;
@@ -1921,6 +2192,8 @@ export interface LoreEntriesSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1936,6 +2209,7 @@ export interface LoreEntriesSelect<T extends boolean = true> {
 export interface WorldMapRegionsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   kind?: T;
   parentRegion?: T;
   nation?: T;
@@ -1947,6 +2221,8 @@ export interface WorldMapRegionsSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1962,6 +2238,7 @@ export interface WorldMapRegionsSelect<T extends boolean = true> {
 export interface MapCitiesSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   parentRegion?: T;
   nation?: T;
   role?: T;
@@ -1973,6 +2250,8 @@ export interface MapCitiesSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -1988,12 +2267,16 @@ export interface MapCitiesSelect<T extends boolean = true> {
 export interface OrientationsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
+  isMagical?: T;
   asset?: T;
   sourceRefs?:
     | T
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -2009,6 +2292,7 @@ export interface OrientationsSelect<T extends boolean = true> {
 export interface RacesSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   category?: T;
   vitalityBase?: T;
   speedFactorBase?: T;
@@ -2033,6 +2317,8 @@ export interface RacesSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -2048,12 +2334,15 @@ export interface RacesSelect<T extends boolean = true> {
 export interface SkillFamiliesSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   description?: T;
   sourceRefs?:
     | T
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -2069,6 +2358,9 @@ export interface SkillFamiliesSelect<T extends boolean = true> {
 export interface SkillsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
+  familyCanonicalId?: T;
+  parentSkillCanonicalId?: T;
   family?: T;
   parentSkill?: T;
   isPrimaryCandidate?: T;
@@ -2077,6 +2369,8 @@ export interface SkillsSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -2092,6 +2386,10 @@ export interface SkillsSelect<T extends boolean = true> {
 export interface CharacterClassesSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
+  orientationCanonicalId?: T;
+  primarySkillCanonicalId?: T;
+  primarySkillChoice?: T;
   orientation?: T;
   classAsset?: T;
   primarySkills?: T;
@@ -2100,6 +2398,8 @@ export interface CharacterClassesSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -2115,6 +2415,7 @@ export interface CharacterClassesSelect<T extends boolean = true> {
 export interface AssetsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   type?: T;
   activation?: T;
   effect?: T;
@@ -2128,6 +2429,8 @@ export interface AssetsSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -2143,9 +2446,14 @@ export interface AssetsSelect<T extends boolean = true> {
 export interface LevelAssetsSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
+  assetCanonicalId?: T;
   asset?: T;
   level?: T;
   points?: T;
+  raceName?: T;
+  orientationName?: T;
+  characterClassName?: T;
   race?: T;
   orientation?: T;
   characterClass?: T;
@@ -2155,6 +2463,8 @@ export interface LevelAssetsSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };
@@ -2170,9 +2480,10 @@ export interface LevelAssetsSelect<T extends boolean = true> {
 export interface PlacesSelect<T extends boolean = true> {
   canonicalId?: T;
   name?: T;
+  status?: T;
   parentPlace?: T;
   nation?: T;
-  status?: T;
+  placeStatus?: T;
   isCapital?: T;
   mapRole?: T;
   sourceRefs?:
@@ -2180,6 +2491,8 @@ export interface PlacesSelect<T extends boolean = true> {
     | {
         kind?: T;
         path?: T;
+        ref?: T;
+        sha256?: T;
         note?: T;
         id?: T;
       };

--- a/tools/README.md
+++ b/tools/README.md
@@ -20,6 +20,21 @@ pnpm canonical:check:strict
 
 `canonical:check` est inclus dans `pnpm validate`. Les artefacts `docs/canonical/*` sont générés et comparés par ce gate ; ils ne doivent pas être édités à la main.
 
+### `import-catalogs.ts`
+
+Construit le plan d'import Payload depuis les catalogues canoniques P0 et les sources YAML et Markdown. Les documents importes conservent `status`, `source_refs.path`, `source_refs.ref` et `source_refs.sha256`, avec les donnees brutes en `metadata.raw` pour permettre un export round-trip controlable. Le plan couvre notamment races, orientations, classes, competences, ecoles de magie, sorts, atouts et atouts de niveau.
+
+Commandes :
+
+```bash
+pnpm cms:import:catalogs:dry-run
+pnpm cms:import:catalogs
+pnpm cms:verify:catalogs
+pnpm exec tsx tools/import-catalogs.ts --export-yaml-dir /tmp/kw-catalog-roundtrip
+```
+
+L'edition CMS passe par les roles Payload `catalog_editor` et `catalog_reviewer`; les imports automatises utilisent `overrideAccess` mais n'effacent pas la tracabilite YAML.
+
 ### `build-races-catalog.ts`
 
 Génère `data/catalogs/races.yaml` depuis `data/catalogs/bestiaire.yaml`, en conservant les `source_refs` web/paper de chaque entrée. Le catalogue contient les 31 races connues du domaine D3, avec `playable: true` pour les 25 races disponibles au wizard PJ et `playable: false` pour les races non proposées à la création.

--- a/tools/import-catalogs.test.ts
+++ b/tools/import-catalogs.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildCatalogImportPlan,
+  buildCatalogYamlRoundTripDocuments,
+  exportCatalogRoundTripYaml,
   importCatalogs,
   summarizePlan,
   verifyCatalogImport
@@ -21,12 +23,73 @@ describe('catalog import plan', () => {
     expect(summary.nations).toBe(29);
     expect(summary.organisations).toBe(7);
     expect(summary.religions).toBe(15);
-    expect(summary.assets).toBeGreaterThan(400);
+    expect(summary.orientations).toBe(13);
+    expect(summary['skill-families']).toBe(10);
+    expect(summary.skills).toBe(368);
+    expect(summary['character-classes']).toBe(91);
+    expect(summary['magic-schools']).toBe(11);
+    expect(summary.spells).toBe(324);
+    expect(summary.assets).toBe(802);
+    expect(summary['level-assets']).toBe(300);
     expect(summary.rules).toBe(13);
     expect(plan.ambiguityFiles).toContain('armes-ambiguites.md');
 
-    const keys = plan.entries.map((entry) => `${entry.collection}:${entry.data.canonicalId}`);
+    const keys = plan.entries.map((entry) => entry.collection + ':' + entry.data.canonicalId);
     expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('preserves catalog status and exact source refs for editable CMS documents', async () => {
+    const plan = await buildCatalogImportPlan();
+    const spell = findEntry(plan, 'spells', 'annihilation');
+    const school = findEntry(plan, 'magic-schools', 'abjuration');
+    const levelAsset = findEntry(plan, 'level-assets', 'niveau-2-agitateur-voyageur-berzerker');
+
+    expect(spell?.data).toMatchObject({
+      energyCost: 169,
+      magicSchoolCanonicalId: 'abjuration',
+      status: 'active'
+    });
+    expect(spell?.data.sourceRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'legacy_source',
+          path: 'data/legacy/web-scraped/documents/grimoire/index.md',
+          ref: 'entry:annihilation',
+          sha256: expect.stringMatching(/^[0-9a-f]{64}$/)
+        })
+      ])
+    );
+    expect(school?.data).toMatchObject({
+      color: 'jaune',
+      specialistClassCanonicalId: 'abjurateur',
+      status: 'active'
+    });
+    expect(levelAsset?.data).toMatchObject({
+      assetCanonicalId: 'niveau-2-agitateur-voyageur-berzerker',
+      characterClassName: 'Berzerker',
+      level: 2,
+      orientationName: 'Voyageur',
+      status: 'active'
+    });
+  });
+
+  it('exports a YAML round-trip document with raw source status and refs intact', async () => {
+    const plan = await buildCatalogImportPlan();
+    const documents = buildCatalogYamlRoundTripDocuments(plan);
+    const spells = documents.find((document) => document.catalogName === 'spells.yaml');
+    const yamlByCatalog = exportCatalogRoundTripYaml(plan);
+
+    expect(spells?.entries).toHaveLength(324);
+    expect(spells?.entries[0]).toMatchObject({
+      canonicalId: 'annihilation',
+      collection: 'spells',
+      status: 'active'
+    });
+    expect(yamlByCatalog['spells.yaml']).toContain('ref: entry:annihilation');
+    expect(yamlByCatalog['spells.yaml']).toContain('status: active');
+    expect(yamlByCatalog['spells.yaml']).toContain(
+      'sha256: 46e9ee82c1f468eb68efabe8030828b9784fad4cda6cc3664a4564667e10a200'
+    );
   });
 
   it('upserts documents by canonicalId without creating duplicates', async () => {
@@ -101,6 +164,14 @@ describe('catalog import plan', () => {
     await expect(verifyCatalogImport(payload, plan)).rejects.toThrow('potions:mana');
   });
 });
+
+type TestPlan = Awaited<ReturnType<typeof buildCatalogImportPlan>>;
+
+function findEntry(plan: TestPlan, collection: string, canonicalId: string) {
+  return plan.entries.find(
+    (entry) => entry.collection === collection && entry.data.canonicalId === canonicalId
+  );
+}
 
 function mockPayload(overrides: Partial<Payload> = {}): Payload {
   return {

--- a/tools/import-catalogs.ts
+++ b/tools/import-catalogs.ts
@@ -1,40 +1,60 @@
 import { parse as parsePath, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { readdir, readFile } from 'node:fs/promises';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 
+import yaml from 'js-yaml';
 import type { Payload } from 'payload';
 import {
   DEFAULT_CATALOGS_DIR,
   loadCatalog,
   loadValidatedCatalogs,
+  type Atout,
   type BestiaryEntry,
+  type ClassEntry,
+  type MagicSchool,
   type Nation,
   type Organisation,
+  type Orientation,
   type Potion,
   type Protection,
   type Race,
   type Religion,
+  type Skill,
+  type Spell,
   type Weapon
 } from '../packages/catalogs/src/index.js';
 
 type ImportCollection =
   | 'assets'
   | 'bestiary'
+  | 'character-classes'
   | 'images'
+  | 'level-assets'
   | 'lore-entries'
+  | 'magic-schools'
   | 'map-cities'
   | 'mushrooms'
   | 'nations'
   | 'organisations'
+  | 'orientations'
   | 'potions'
   | 'protections'
   | 'races'
   | 'religions'
   | 'rules'
+  | 'skill-families'
+  | 'skills'
+  | 'spells'
   | 'weapons'
   | 'world-map-regions';
 
-type SourceRefKind = 'legacy_php' | 'manual' | 'map_asset' | 'rules_markdown' | 'yaml';
+type SourceRefKind =
+  | 'legacy_php'
+  | 'legacy_source'
+  | 'manual'
+  | 'map_asset'
+  | 'rules_markdown'
+  | 'yaml';
 
 type ImportDocument = {
   canonicalId: string;
@@ -53,11 +73,27 @@ type SourceRef = {
   kind: SourceRefKind;
   note?: string;
   path: string;
+  ref?: string;
+  sha256?: string;
 };
 
 type ImportPlan = {
   ambiguityFiles: string[];
   entries: ImportEntry[];
+};
+
+type CatalogRoundTripEntry = {
+  canonicalId: string;
+  collection: ImportCollection;
+  name: string;
+  raw: Record<string, unknown>;
+  sourceRefs: SourceRef[];
+  status?: string;
+};
+
+type CatalogRoundTripDocument = {
+  catalogName: string;
+  entries: CatalogRoundTripEntry[];
 };
 
 type ImportStats = {
@@ -76,7 +112,6 @@ type ExistingDocumentsByCollection = Map<ImportCollection, Map<string, ExistingC
 const PAYLOAD_LOOKUP_CHUNK_SIZE = 50;
 const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const defaultRulesDir = resolve(repoRoot, 'docs/rules');
-const defaultAtoutsCsv = resolve(DEFAULT_CATALOGS_DIR, 'atouts-values.csv');
 
 export async function buildCatalogImportPlan(
   catalogsDir = DEFAULT_CATALOGS_DIR,
@@ -113,11 +148,33 @@ export async function buildCatalogImportPlan(
     ),
     ...priorityCatalogs['religions.yaml'].religions.map((religion) =>
       religionEntry(religion, priorityCatalogs['religions.yaml'].metadata)
+    ),
+    ...priorityCatalogs['orientations.yaml'].orientations.map((orientation) =>
+      orientationEntry(orientation, priorityCatalogs['orientations.yaml'].metadata)
+    ),
+    ...skillFamilyEntries(
+      priorityCatalogs['competences.yaml'].skills,
+      priorityCatalogs['competences.yaml'].metadata
+    ),
+    ...priorityCatalogs['competences.yaml'].skills.map((skill) =>
+      skillEntry(skill, priorityCatalogs['competences.yaml'].metadata)
+    ),
+    ...priorityCatalogs['classes.yaml'].classes.map((characterClass) =>
+      characterClassEntry(characterClass, priorityCatalogs['classes.yaml'].metadata)
+    ),
+    ...priorityCatalogs['magic-schools.yaml'].schools.map((school) =>
+      magicSchoolEntry(school, priorityCatalogs['magic-schools.yaml'].metadata)
+    ),
+    ...priorityCatalogs['spells.yaml'].spells.map((spell) =>
+      spellEntry(spell, priorityCatalogs['spells.yaml'].metadata)
+    ),
+    ...atoutsEntries(
+      priorityCatalogs['atouts.yaml'].atouts,
+      priorityCatalogs['atouts.yaml'].metadata
     )
   );
 
   entries.push(...(await extendedYamlEntries(catalogsDir)));
-  entries.push(...(await atoutsEntries(defaultAtoutsCsv)));
   entries.push(...(await ruleEntries(rulesDir)));
 
   return {
@@ -187,15 +244,76 @@ export function summarizePlan(plan: ImportPlan): Record<string, number> {
   }, {});
 }
 
+export function buildCatalogYamlRoundTripDocuments(plan: ImportPlan): CatalogRoundTripDocument[] {
+  const byCatalog = new Map<string, CatalogRoundTripEntry[]>();
+
+  for (const importEntry of plan.entries) {
+    const metadata = importEntry.data.metadata;
+    const catalogName =
+      isRecord(metadata) && typeof metadata.catalog === 'string'
+        ? metadata.catalog
+        : importEntry.collection;
+    const raw = isRecord(metadata) && isRecord(metadata.raw) ? metadata.raw : {};
+    const sourceRefs = toArray<SourceRef>(importEntry.data.sourceRefs);
+    const entries = byCatalog.get(catalogName) ?? [];
+
+    entries.push({
+      canonicalId: importEntry.data.canonicalId,
+      collection: importEntry.collection,
+      name: importEntry.data.name,
+      raw,
+      sourceRefs,
+      status: typeof importEntry.data.status === 'string' ? importEntry.data.status : undefined
+    });
+    byCatalog.set(catalogName, entries);
+  }
+
+  return [...byCatalog.entries()]
+    .map(([catalogName, entries]) => ({ catalogName, entries }))
+    .sort((left, right) => left.catalogName.localeCompare(right.catalogName));
+}
+
+export function exportCatalogRoundTripYaml(plan: ImportPlan): Record<string, string> {
+  return Object.fromEntries(
+    buildCatalogYamlRoundTripDocuments(plan).map((document) => [
+      document.catalogName,
+      yaml.dump(
+        {
+          entries: document.entries
+        },
+        { lineWidth: 100, noRefs: true, sortKeys: true }
+      )
+    ])
+  );
+}
+
+async function writeRoundTripYaml(plan: ImportPlan, outputDir: string): Promise<void> {
+  await mkdir(outputDir, { recursive: true });
+
+  for (const [catalogName, content] of Object.entries(exportCatalogRoundTripYaml(plan))) {
+    await writeFile(resolve(outputDir, safeExportFileName(catalogName)), content, 'utf8');
+  }
+}
+
+function safeExportFileName(catalogName: string): string {
+  return catalogName.replace(/[^a-zA-Z0-9._-]+/g, '_');
+}
+
 async function main(): Promise<void> {
   const args = new Set(process.argv.slice(2));
   const dryRun = args.has('--dry-run');
   const verifyOnly = args.has('--verify-only');
+  const exportYamlDir = argValue('--export-yaml-dir');
   const catalogsDir = argValue('--catalogs-dir') ?? DEFAULT_CATALOGS_DIR;
   const rulesDir = argValue('--rules-dir') ?? defaultRulesDir;
   const plan = await buildCatalogImportPlan(catalogsDir, rulesDir);
 
   printPlan(plan);
+
+  if (exportYamlDir) {
+    await writeRoundTripYaml(plan, resolve(exportYamlDir));
+    return;
+  }
 
   if (dryRun) {
     return;
@@ -397,6 +515,119 @@ function religionEntry(religion: Religion, catalogMetadata: Record<string, unkno
   );
 }
 
+function orientationEntry(
+  orientation: Orientation,
+  catalogMetadata: Record<string, unknown>
+): ImportEntry {
+  return entry(
+    'orientations',
+    orientation,
+    {
+      isMagical: orientation.is_magical
+    },
+    catalogMetadata,
+    'orientations.yaml'
+  );
+}
+
+function skillFamilyEntries(
+  skills: Skill[],
+  catalogMetadata: Record<string, unknown>
+): ImportEntry[] {
+  const families = new Map<string, Skill>();
+
+  for (const skill of skills) {
+    if (!families.has(skill.family)) {
+      families.set(skill.family, skill);
+    }
+  }
+
+  return [...families.values()].map((skill) =>
+    entry(
+      'skill-families',
+      {
+        id: skill.family,
+        name: skill.family_name ?? labelFromId(skill.family),
+        source_refs: skill.source_refs,
+        status: skill.status
+      },
+      {
+        description: 'Canonical skill family imported from competences.yaml.'
+      },
+      catalogMetadata,
+      'competences.yaml'
+    )
+  );
+}
+
+function skillEntry(skill: Skill, catalogMetadata: Record<string, unknown>): ImportEntry {
+  return entry(
+    'skills',
+    skill,
+    {
+      familyCanonicalId: skill.family,
+      isPrimaryCandidate: !skill.parent_id,
+      parentSkillCanonicalId: skill.parent_id ?? undefined
+    },
+    catalogMetadata,
+    'competences.yaml'
+  );
+}
+
+function characterClassEntry(
+  characterClass: ClassEntry,
+  catalogMetadata: Record<string, unknown>
+): ImportEntry {
+  return entry(
+    'character-classes',
+    characterClass,
+    {
+      orientationCanonicalId: characterClass.orientation_id,
+      primarySkillCanonicalId: characterClass.primary_skill_id ?? undefined,
+      primarySkillChoice: characterClass.primary_skill_choice
+    },
+    catalogMetadata,
+    'classes.yaml'
+  );
+}
+
+function magicSchoolEntry(
+  school: MagicSchool,
+  catalogMetadata: Record<string, unknown>
+): ImportEntry {
+  return entry(
+    'magic-schools',
+    school,
+    {
+      color: school.color,
+      domain: school.domain,
+      sourceLabel: school.source_label,
+      specialistClassCanonicalId: school.specialist_class_id
+    },
+    catalogMetadata,
+    'magic-schools.yaml'
+  );
+}
+
+function spellEntry(spell: Spell, catalogMetadata: Record<string, unknown>): ImportEntry {
+  return entry(
+    'spells',
+    spell,
+    {
+      castingTimeDT: spell.incantation_time,
+      difficulty: spell.difficulty,
+      effect: spell.effect,
+      energyCost: spell.energy,
+      legacyTypeId: spell.school_id,
+      magicSchoolCanonicalId: spell.school_id,
+      magicType: magicTypeValue(spell.school_id),
+      value: spell.value
+    },
+    catalogMetadata,
+    'spells.yaml'
+  );
+}
+
 async function extendedYamlEntries(catalogsDir: string): Promise<ImportEntry[]> {
   const entries: ImportEntry[] = [];
   const mushrooms = await loadCatalog<Record<string, unknown>>('champignons.yaml', catalogsDir);
@@ -573,27 +804,48 @@ function regionalMapCityEntries(regionalCities: Record<string, unknown>): Import
   return entries;
 }
 
-async function atoutsEntries(csvFile = defaultAtoutsCsv): Promise<ImportEntry[]> {
-  const csv = await readFile(csvFile, 'utf8');
-  const rows = parseCsv(csv);
+function atoutsEntries(atouts: Atout[], catalogMetadata: Record<string, unknown>): ImportEntry[] {
+  return [
+    ...atouts.map((atout) => atoutEntry(atout, catalogMetadata)),
+    ...atouts
+      .filter((atout) => atout.scope === 'niveau')
+      .map((atout) => levelAssetEntry(atout, catalogMetadata))
+  ];
+}
 
-  return rows.map((row) =>
-    entry(
-      'assets',
-      { id: row.id, name: row.name, ...row },
-      {
-        activation: activationValue(row.activation),
-        effect: row.effect,
-        familiarCostPoints: numberOrUndefined(row.familiar_cost_points),
-        familiarGrantPoints: numberOrUndefined(row.familiar_grant_points),
-        isHandicap: row.is_handicap === 'True',
-        sourceLine: numberOrUndefined(row.source_line),
-        type: row.is_handicap === 'True' ? 'handicap' : assetTypeValue(row.type),
-        value: numberOrUndefined(row.value)
-      },
-      { source: 'atouts-values.csv' },
-      'atouts-values.csv'
-    )
+function atoutEntry(atout: Atout, catalogMetadata: Record<string, unknown>): ImportEntry {
+  return entry(
+    'assets',
+    atout,
+    {
+      activation: activationValue(atout.activation),
+      effect: atout.effect,
+      isHandicap: typeof atout.value === 'number' && atout.value < 0,
+      type: assetTypeValue(atout),
+      value: atout.value ?? undefined
+    },
+    catalogMetadata,
+    'atouts.yaml'
+  );
+}
+
+function levelAssetEntry(atout: Atout, catalogMetadata: Record<string, unknown>): ImportEntry {
+  const metadata = isRecord(atout.metadata) ? atout.metadata : {};
+
+  return entry(
+    'level-assets',
+    atout,
+    {
+      assetCanonicalId: atout.id,
+      characterClassName: stringOrUndefined(metadata.class),
+      orientationName: stringOrUndefined(metadata.orientation),
+      points: atout.value ?? undefined,
+      raceName: stringOrUndefined(metadata.race),
+      specialCondition: atout.effect,
+      level: numberOrUndefined(metadata.minimum_level)
+    },
+    catalogMetadata,
+    'atouts.yaml'
   );
 }
 
@@ -648,9 +900,10 @@ function entry(
         catalogMetadata,
         raw
       }),
-      migrationNotes: data.migrationNotes,
+      migrationNotes: typeof data.migrationNotes === 'string' ? data.migrationNotes : undefined,
       name: String(raw.name ?? raw.title ?? canonicalId),
-      sourceRefs: data.sourceRefs ?? sourceRefs(sourcePath, undefined, sourceKind)
+      sourceRefs: normalizeSourceRefs(data.sourceRefs ?? raw.source_refs, sourcePath, sourceKind),
+      status: typeof raw.status === 'string' ? raw.status : undefined
     })
   };
 }
@@ -789,6 +1042,77 @@ function sourceRefs(
   ];
 }
 
+function normalizeSourceRefs(
+  value: unknown,
+  sourcePath: string,
+  sourceKind: SourceRefKind
+): SourceRef[] {
+  const refs = toArray(value)
+    .map((refValue) => normalizeSourceRef(refValue, sourcePath, sourceKind))
+    .filter((ref): ref is SourceRef => ref !== undefined);
+
+  return refs.length > 0 ? refs : sourceRefs(sourcePath, undefined, sourceKind);
+}
+
+function normalizeSourceRef(
+  value: unknown,
+  sourcePath: string,
+  sourceKind: SourceRefKind
+): SourceRef | undefined {
+  if (typeof value === 'string') {
+    return { kind: kindFromSourcePath(value, sourceKind), path: value };
+  }
+
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const path = stringOrUndefined(value.path) ?? sourcePath;
+
+  return compactObject({
+    kind: sourceRefKindOrDefault(value.kind, path, sourceKind),
+    note: stringOrUndefined(value.note),
+    path,
+    ref: stringOrUndefined(value.ref),
+    sha256: stringOrUndefined(value.sha256)
+  });
+}
+
+function sourceRefKindOrDefault(
+  value: unknown,
+  path: string,
+  fallback: SourceRefKind
+): SourceRefKind {
+  if (
+    value === 'legacy_php' ||
+    value === 'legacy_source' ||
+    value === 'manual' ||
+    value === 'map_asset' ||
+    value === 'rules_markdown' ||
+    value === 'yaml'
+  ) {
+    return value;
+  }
+
+  return kindFromSourcePath(path, fallback);
+}
+
+function kindFromSourcePath(path: string, fallback: SourceRefKind): SourceRefKind {
+  if (path.startsWith('data/legacy/') || path.includes('/legacy/')) {
+    return 'legacy_source';
+  }
+
+  if (path.startsWith('docs/rules/') || path.endsWith('.md')) {
+    return 'rules_markdown';
+  }
+
+  if (path.endsWith('.yaml') || path.endsWith('.yml')) {
+    return 'yaml';
+  }
+
+  return fallback;
+}
+
 async function findAmbiguityFiles(catalogsDir: string): Promise<string[]> {
   const files = await readdir(catalogsDir);
   return files.filter((file) => file.endsWith('-ambiguites.md')).sort();
@@ -816,70 +1140,48 @@ function sectionFromRuleFile(file: string): string {
   return sectionMap[section] ?? section;
 }
 
-function parseCsv(csv: string): Record<string, string>[] {
-  const lines = csv.trim().split(/\r?\n/);
-  const headers = parseCsvLine(lines[0] ?? '');
+function assetTypeValue(atout: Atout): string {
+  if (typeof atout.value === 'number' && atout.value < 0) {
+    return 'handicap';
+  }
 
-  return lines.slice(1).map((line) => {
-    const values = parseCsvLine(line);
-    return Object.fromEntries(headers.map((header, index) => [header, values[index] ?? '']));
-  });
+  const scopeMap: Record<Atout['scope'], string> = {
+    classe: 'class',
+    neutre: 'neutral',
+    niveau: 'level',
+    orientation: 'orientation',
+    race: 'race'
+  };
+
+  return scopeMap[atout.scope];
 }
 
-function parseCsvLine(line: string): string[] {
-  const values: string[] = [];
-  let current = '';
-  let quoted = false;
-
-  for (let index = 0; index < line.length; index += 1) {
-    const char = line[index];
-    const next = line[index + 1];
-
-    if (char === '"' && quoted && next === '"') {
-      current += '"';
-      index += 1;
-      continue;
-    }
-
-    if (char === '"') {
-      quoted = !quoted;
-      continue;
-    }
-
-    if (char === ',' && !quoted) {
-      values.push(current);
-      current = '';
-      continue;
-    }
-
-    current += char;
-  }
-
-  values.push(current);
-  return values;
-}
-
-function assetTypeValue(type: string | undefined): string {
-  if (type === 'Classe') {
-    return 'class';
-  }
-  if (type === 'Race') {
-    return 'race';
-  }
-  if (type === 'Orientation') {
-    return 'orientation';
-  }
-  return 'neutral';
-}
-
-function activationValue(activation: string | undefined): string {
-  if (activation === 'Permanent') {
+function activationValue(activation: Atout['activation']): string {
+  if (activation === 'permanent') {
     return 'permanent';
   }
-  if (activation === 'Ephémère') {
+  if (activation === 'ephemere') {
     return 'ephemeral';
   }
   return 'legacy_unknown';
+}
+
+function magicTypeValue(schoolId: string): string {
+  const magicTypesBySchool: Record<string, string> = {
+    abjuration: 'abjuration',
+    alteration: 'alteration',
+    divination: 'divination',
+    elementaire: 'elemental',
+    enchantement: 'enchantment',
+    illusion: 'illusion',
+    invocation: 'invocation',
+    'magie-blanche': 'white_magic',
+    'magie-naturelle': 'natural_magic',
+    'magie-noire': 'black_magic',
+    necromancie: 'necromancy'
+  };
+
+  return magicTypesBySchool[schoolId] ?? 'legacy_type';
 }
 
 function compactObject<T extends Record<string, unknown>>(object: T): T {
@@ -896,6 +1198,14 @@ function toArray<T = Record<string, unknown>>(value: unknown): T[] {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringOrUndefined(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined;
+  }
+
+  return value;
 }
 
 function numberOrUndefined(value: unknown): number | undefined {


### PR DESCRIPTION
## Summary
- Adds Payload roles for catalog review/edit and applies access to canonical catalog collections.
- Adds CMS coverage for magic schools and richer P0 catalog fields while preserving `status`, `source_refs.ref`, and `source_refs.sha256`.
- Extends the catalog importer to load orientations, skill families, skills, classes, magic schools, spells, canonical atouts, and level assets from YAML, with round-trip YAML export support.
- Regenerates Payload types and documents the import/export workflow.

Closes #56

## Verification
- `pnpm exec vitest run apps/cms/src/collections/catalogCollections.test.ts tools/import-catalogs.test.ts --pool=forks`
- `pnpm --filter @knightandwizard/cms typecheck`
- `pnpm cms:import:catalogs:dry-run`
- `pnpm exec tsx tools/import-catalogs.ts --export-yaml-dir /tmp/kw-catalog-roundtrip`
- `pnpm canonical:check && pnpm canonical:check:strict`
- `pnpm nomos:export`
- `pnpm lint`
- `pnpm format:check`
- `pnpm --filter @knightandwizard/rules-core build && pnpm --filter @knightandwizard/catalogs build && pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm validate:geojson`
- `git diff --check`