### PR TITLE
test: trace canonical e2e scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,17 @@ jobs:
       - name: Validate repository
         run: pnpm validate
 
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            playwright-report
+            test-results/e2e
+          if-no-files-found: ignore
+          retention-days: 14
+
       - name: Show devlab logs on failure
         if: failure()
         run: docker compose logs --no-color

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "knowledge:index": "tsx tools/index-knowledge-base.ts",
     "knowledge:index:dry-run": "tsx tools/index-knowledge-base.ts --dry-run",
     "rag:evaluate": "tsx tools/evaluate-rag.ts",
-    "test:e2e": "pnpm db:migrate && pnpm db:import:catalogs && pnpm knowledge:index && playwright test",
+    "test:e2e": "pnpm build:shared && pnpm db:migrate && pnpm db:import:catalogs && pnpm knowledge:index && playwright test",
     "test:e2e:ui": "playwright test --ui",
     "canonical:write": "tsx tools/canonical.ts --write",
     "canonical:check": "tsx tools/canonical.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig, devices, type ReporterDescription } from '@playwright/test';
 
 const gamePort = Number.parseInt(process.env.E2E_GAME_PORT ?? '3100', 10);
 const apiPort = Number.parseInt(process.env.E2E_API_PORT ?? '3102', 10);
@@ -8,18 +8,27 @@ const databaseUrl =
   process.env.DATABASE_URL ??
   'postgres://knightandwizard:knightandwizard@127.0.0.1:55432/knightandwizard';
 const payloadSecret = process.env.PAYLOAD_SECRET ?? 'local-dev-only-secret';
+const htmlReporter: ReporterDescription = [
+  'html',
+  { open: 'never', outputFolder: 'playwright-report' }
+];
+const reporter: ReporterDescription[] = process.env.CI
+  ? [['github'], ['list'], htmlReporter]
+  : [['list'], htmlReporter];
 
 export default defineConfig({
   expect: {
     timeout: 10_000
   },
   fullyParallel: false,
-  reporter: process.env.CI ? [['github'], ['list']] : [['list']],
+  outputDir: 'test-results/e2e',
+  reporter,
   retries: process.env.CI ? 1 : 0,
   testDir: './tests/e2e',
   timeout: 45_000,
   use: {
     baseURL: gameBaseUrl,
+    screenshot: 'only-on-failure',
     trace: 'retain-on-failure'
   },
   webServer: [

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,12 @@
+# E2E canonical scenarios
+
+The Playwright suite proves critical player/GM flows at product level. Each scenario must stay readable as a business behavior and must call `annotateCanonical(...)` with a fixture from `fixtures/canonical.ts`.
+
+Required pattern for new scenarios:
+
+1. Use a descriptive test title that names the product behavior.
+2. Add canonical source annotations through `canonicalE2EFixtures.scenarios`.
+3. Keep test data in `fixtures/canonical.ts` when it represents a reusable canonical scenario actor, scene or source reference.
+4. Keep screenshots and traces actionable: Playwright stores traces and screenshots on failure under `test-results/e2e`, and CI uploads them with `playwright-report`.
+
+Do not add invented game facts directly in a test body. If a scenario needs a new fixture, add the source reference first.

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -1,7 +1,15 @@
-import { expect, type Page, test } from '@playwright/test';
+import { expect, type Page, test, type TestInfo } from '@playwright/test';
+
+import {
+  canonicalE2EFixtures,
+  formatCanonicalSourceRefs,
+  type CanonicalE2EScenario
+} from './fixtures/canonical';
 
 test.describe('K&W player and GM application flows', () => {
-  test('dashboard reports the API and links the main work surfaces', async ({ page }) => {
+  test('dashboard reports the API and links the main work surfaces', async ({ page }, testInfo) => {
+    annotateCanonical(testInfo, 'dashboard');
+
     await page.goto('/');
 
     await expect(page.getByRole('heading', { name: /Poste de table/ })).toBeVisible();
@@ -13,7 +21,9 @@ test.describe('K&W player and GM application flows', () => {
 
   test('character sheet exposes canonical attributes, nested skills and level budget', async ({
     page
-  }) => {
+  }, testInfo) => {
+    annotateCanonical(testInfo, 'characterSheet');
+
     await page.goto('/character');
 
     await expect(page.getByRole('heading', { name: 'Fiche active' })).toBeVisible();
@@ -59,10 +69,14 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByText(/Charge .* kg/)).toBeVisible();
   });
 
-  test('character creation validates fighter and magician creation budgets', async ({ page }) => {
+  test('character creation validates fighter and magician creation budgets', async ({
+    page
+  }, testInfo) => {
+    annotateCanonical(testInfo, 'characterCreation');
+
     await page.goto('/character/create');
 
-    await page.getByLabel('Nom').fill('E2E Aveline');
+    await page.getByLabel('Nom').fill(canonicalE2EFixtures.actors.avelineDraftName);
     await openCreationStep(page, 'Aptitudes');
     await increaseStepper(page, 'Force', 4);
     await increaseStepper(page, 'Dextérité', 4);
@@ -86,7 +100,7 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByText('API synchronisee')).toBeVisible();
 
     await page.getByRole('button', { name: /Reset/ }).click();
-    await page.getByLabel('Nom').fill('E2E Magicien');
+    await page.getByLabel('Nom').fill(canonicalE2EFixtures.actors.magicianDraftName);
     await openCreationStep(page, 'Voie');
     await page.getByRole('button', { name: /Magicien/ }).click();
     await openCreationStep(page, 'Sorts');
@@ -100,7 +114,9 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByText('Convertis')).toBeVisible();
   });
 
-  test('combat tracker resolves DT actions and roster changes', async ({ page }) => {
+  test('combat tracker resolves DT actions and roster changes', async ({ page }, testInfo) => {
+    annotateCanonical(testInfo, 'combatTracker');
+
     await page.goto('/combat');
 
     await expect(page.getByRole('heading', { name: 'Tracker DT' })).toBeVisible();
@@ -114,7 +130,11 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByRole('heading', { name: 'Squelette' }).first()).toBeVisible();
   });
 
-  test('session manager records events, GM decisions and rollback requests', async ({ page }) => {
+  test('session manager records events, GM decisions and rollback requests', async ({
+    page
+  }, testInfo) => {
+    annotateCanonical(testInfo, 'sessionManager');
+
     await page.goto('/session');
 
     await expect(page.getByRole('heading', { name: 'Brumeval' })).toBeVisible();
@@ -136,6 +156,15 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByText(/Rollback demande/).first()).toBeVisible();
   });
 });
+
+function annotateCanonical(testInfo: TestInfo, scenario: CanonicalE2EScenario): void {
+  const fixture = canonicalE2EFixtures.scenarios[scenario];
+
+  testInfo.annotations.push({
+    description: formatCanonicalSourceRefs(fixture.sourceRefs),
+    type: 'canonical-sources'
+  });
+}
 
 async function openCreationStep(page: Page, stepName: string): Promise<void> {
   await page.getByRole('button', { name: new RegExp(stepName) }).click();

--- a/tests/e2e/backend-gm.spec.ts
+++ b/tests/e2e/backend-gm.spec.ts
@@ -1,4 +1,10 @@
-import { expect, type APIRequestContext, test } from '@playwright/test';
+import { expect, type APIRequestContext, test, type TestInfo } from '@playwright/test';
+
+import {
+  canonicalE2EFixtures,
+  formatCanonicalSourceRefs,
+  type CanonicalE2EScenario
+} from './fixtures/canonical';
 
 const apiBaseUrl = process.env.E2E_API_URL ?? 'http://127.0.0.1:3102';
 
@@ -7,7 +13,8 @@ type JsonObject = Record<string, unknown>;
 test.describe('K&W backend, RAG and GM runtime flows', () => {
   test('persists drafts, session events, GM decisions, RAG context and episodic memory', async ({
     request
-  }) => {
+  }, testInfo) => {
+    annotateCanonical(testInfo, 'backendGm');
     const suffix = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
     const draftId = `e2e-draft-${suffix}`;
     const sessionSlug = `e2e-session-${suffix}`;
@@ -36,7 +43,7 @@ test.describe('K&W backend, RAG and GM runtime flows', () => {
       {
         currentStep: 'review',
         payload: {
-          name: 'E2E Aveline',
+          name: canonicalE2EFixtures.actors.avelineDraftName,
           rules: 'character creation draft persistence'
         },
         userId: 'e2e'
@@ -45,7 +52,7 @@ test.describe('K&W backend, RAG and GM runtime flows', () => {
 
     await expectJson(request, 'GET', `/character-drafts/${draftId}`, 200, (body) => {
       expect(body.status).toBe('found');
-      expect(asRecord(body.payload).name).toBe('E2E Aveline');
+      expect(asRecord(body.payload).name).toBe(canonicalE2EFixtures.actors.avelineDraftName);
     });
 
     await expectJson(
@@ -183,7 +190,7 @@ test.describe('K&W backend, RAG and GM runtime flows', () => {
           pool: 4,
           reason: 'jet de des difficile'
         },
-        sceneDescription: 'Aveline tente un jet de des difficile a la porte nord.',
+        sceneDescription: canonicalE2EFixtures.scenes.firstDifficultRoll,
         sessionId: gmSessionId
       }
     );
@@ -201,12 +208,21 @@ test.describe('K&W backend, RAG and GM runtime flows', () => {
         expect(body.narration).toContain('Memoire');
       },
       {
-        sceneDescription: 'Aveline repense au jet de des difficile avant de parler au guetteur.',
+        sceneDescription: canonicalE2EFixtures.scenes.memoryRecall,
         sessionId: gmSessionId
       }
     );
   });
 });
+
+function annotateCanonical(testInfo: TestInfo, scenario: CanonicalE2EScenario): void {
+  const fixture = canonicalE2EFixtures.scenarios[scenario];
+
+  testInfo.annotations.push({
+    description: formatCanonicalSourceRefs(fixture.sourceRefs),
+    type: 'canonical-sources'
+  });
+}
 
 async function expectJson(
   request: APIRequestContext,

--- a/tests/e2e/fixtures/canonical.ts
+++ b/tests/e2e/fixtures/canonical.ts
@@ -1,0 +1,63 @@
+export type CanonicalE2ESourceRef = {
+  path: `docs/rules/${string}` | `docs/product/${string}` | `data/catalogs/${string}`;
+  ref: string;
+};
+
+export const canonicalE2EFixtures = {
+  actors: {
+    avelineDraftName: 'E2E Aveline',
+    magicianDraftName: 'E2E Magicien'
+  },
+  scenes: {
+    firstDifficultRoll: 'Aveline tente un jet de des difficile a la porte nord.',
+    memoryRecall: 'Aveline repense au jet de des difficile avant de parler au guetteur.'
+  },
+  scenarios: {
+    dashboard: {
+      title: 'dashboard readiness and surface links',
+      sourceRefs: [
+        { path: 'docs/product/vision-assistant-mj-joueur.md', ref: 'surfaces MJ/Joueur' }
+      ]
+    },
+    characterSheet: {
+      title: 'canonical attributes, nested skills and level budget',
+      sourceRefs: [
+        { path: 'docs/rules/02-attributs.md', ref: 'D2 aptitudes' },
+        { path: 'docs/rules/05-competences.md', ref: 'D5 competences et specialisations' },
+        { path: 'docs/rules/07-progression.md', ref: 'D7 level points' }
+      ]
+    },
+    characterCreation: {
+      title: 'fighter and magician creation budgets',
+      sourceRefs: [
+        { path: 'docs/rules/06-creation-perso.md', ref: 'D6 budgets de creation' },
+        { path: 'docs/rules/08-magie.md', ref: 'D8 points de sorts magicien' }
+      ]
+    },
+    combatTracker: {
+      title: 'combat DT action resolution',
+      sourceRefs: [{ path: 'docs/rules/09-combat.md', ref: 'D9 actions DT' }]
+    },
+    sessionManager: {
+      title: 'async session journal and GM decisions',
+      sourceRefs: [
+        { path: 'docs/rules/11-controle-pnj.md', ref: 'D11 controle PNJ' },
+        { path: 'docs/rules/13-roles-passation.md', ref: 'D13 arbitrage et rollback' }
+      ]
+    },
+    backendGm: {
+      title: 'backend RAG, GM tools and episodic memory',
+      sourceRefs: [
+        { path: 'docs/product/llm-tool-calling-contract.md', ref: 'tool calling MJ' },
+        { path: 'docs/product/rag-citation-evaluation-contract.md', ref: 'citations RAG' },
+        { path: 'docs/product/episodic-memory-contract.md', ref: 'memoire episodique' }
+      ]
+    }
+  }
+} as const;
+
+export type CanonicalE2EScenario = keyof typeof canonicalE2EFixtures.scenarios;
+
+export function formatCanonicalSourceRefs(sourceRefs: readonly CanonicalE2ESourceRef[]): string {
+  return sourceRefs.map((sourceRef) => `${sourceRef.path}#${sourceRef.ref}`).join(', ');
+}

--- a/tools/e2e-fixtures.test.ts
+++ b/tools/e2e-fixtures.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { canonicalE2EFixtures } from '../tests/e2e/fixtures/canonical.js';
+
+describe('canonical E2E fixtures', () => {
+  it('trace every business scenario to canonical sources', () => {
+    for (const scenario of Object.values(canonicalE2EFixtures.scenarios)) {
+      expect(scenario.sourceRefs.length, scenario.title).toBeGreaterThan(0);
+      for (const sourceRef of scenario.sourceRefs) {
+        expect(sourceRef.path).toMatch(/^(docs\/rules|docs\/product|data\/catalogs)\//);
+      }
+    }
+  });
+});

--- a/tools/playwright-config.test.ts
+++ b/tools/playwright-config.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+
+import yaml from 'js-yaml';
+import { describe, expect, it } from 'vitest';
+
+import config from '../playwright.config.js';
+
+describe('Playwright E2E contract', () => {
+  it('keeps actionable artifacts for CI failures', () => {
+    expect(config.outputDir).toBe('test-results/e2e');
+    expect(config.use).toMatchObject({
+      screenshot: 'only-on-failure',
+      trace: 'retain-on-failure'
+    });
+    expect(config.reporter).toEqual(
+      expect.arrayContaining([['html', { open: 'never', outputFolder: 'playwright-report' }]])
+    );
+  });
+
+  it('builds shared packages before an isolated E2E run', () => {
+    const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(packageJson.scripts['test:e2e']).toMatch(/^pnpm build:shared && pnpm db:migrate/);
+  });
+
+  it('uploads Playwright artifacts when the CI validate job fails', () => {
+    const workflow = yaml.load(readFileSync('.github/workflows/ci.yml', 'utf8')) as {
+      jobs: { validate: { steps: Array<Record<string, unknown>> } };
+    };
+
+    expect(workflow.jobs.validate.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          if: 'failure()',
+          name: 'Upload Playwright artifacts on failure',
+          uses: 'actions/upload-artifact@v4',
+          with: expect.objectContaining({
+            'if-no-files-found': 'ignore',
+            path: expect.stringContaining('playwright-report')
+          })
+        })
+      ])
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add canonical E2E fixtures and source annotations to the Playwright business scenarios
- add contract tests for Playwright artifacts, CI upload behavior and fixture source coverage
- retain traces/screenshots/HTML report on failures and upload Playwright artifacts from CI
- make isolated `pnpm test:e2e` runs build shared packages before starting the E2E runtime

Closes #55

## Verification
- pnpm exec vitest run tools/playwright-config.test.ts tools/e2e-fixtures.test.ts
- pnpm build:shared && pnpm test
- pnpm lint
- pnpm format:check
- pnpm typecheck
- pnpm test:e2e
- pnpm validate
- pnpm canonical:check:strict
- git diff --check
