### PR TITLE
feat(server): trace session entity links

### DIFF
--- a/apps/server/src/routes/sessions.test.ts
+++ b/apps/server/src/routes/sessions.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { buildApp } from '../app.js';
+import { createSqlClient } from '../db/client.js';
 
 const app = buildApp({ logger: false });
 
@@ -230,6 +231,99 @@ describe('session routes', () => {
       'gm_decision_resolved',
       'rollback_requested'
     ]);
+  });
+
+  it('records canonical entity links on events, decisions and rollback markers', async () => {
+    const slug = `linked-session-${randomUUID()}`;
+    const links = {
+      characters: ['aveline'],
+      objects: ['relique-brisee'],
+      places: ['brumeval-gate'],
+      rules: [{ ref: 'R-13.9', sourcePath: 'docs/rules/13-roles-passation.md' }]
+    };
+
+    await app.inject({
+      method: 'POST',
+      payload: { slug, title: 'Linked API' },
+      url: '/sessions'
+    });
+
+    const eventResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        eventType: 'scene_opened',
+        links,
+        payload: { text: 'La relique apparait dans la brume.' }
+      },
+      url: `/sessions/${slug}/events`
+    });
+    const decisionResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        assignedTo: 'human_gm',
+        links,
+        payload: { options: ['examiner', 'ignorer'] },
+        requestedBy: 'llm',
+        title: 'Tracer la relique dans le journal'
+      },
+      url: `/sessions/${slug}/decisions`
+    });
+    const decisionId = decisionResponse.json().decision.id;
+    const resolveResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        links,
+        resolution: { ruling: 'examiner' },
+        status: 'approved'
+      },
+      url: `/sessions/${slug}/decisions/${decisionId}/resolve`
+    });
+    const rollbackResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        links,
+        reason: 'Retour avant decision',
+        targetSequence: 1
+      },
+      url: `/sessions/${slug}/rollback`
+    });
+    const readResponse = await app.inject({ method: 'GET', url: `/sessions/${slug}` });
+    const readBody = readResponse.json();
+    const sql = createSqlClient();
+    let auditRows: { action: string; payload: { links?: unknown } }[];
+
+    try {
+      auditRows = await sql<{ action: string; payload: { links?: unknown } }[]>`
+        SELECT action, payload
+        FROM audit_events
+        WHERE payload->>'sessionId' = ${readBody.id}
+        ORDER BY created_at ASC
+      `;
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+
+    expect(eventResponse.statusCode).toBe(201);
+    expect(decisionResponse.statusCode).toBe(201);
+    expect(resolveResponse.statusCode).toBe(200);
+    expect(rollbackResponse.statusCode).toBe(201);
+    expect(eventResponse.json().event.payload.links).toEqual(links);
+    expect(decisionResponse.json().decision.payload.links).toEqual(links);
+    expect(resolveResponse.json().decision.resolution.links).toEqual(links);
+    expect(rollbackResponse.json().event.payload.links).toEqual(links);
+    expect(
+      readBody.events.map((event: { payload: { links?: unknown } }) => event.payload.links)
+    ).toEqual([links, links, links, links]);
+    expect(auditRows.map((row) => row.action)).toEqual([
+      'session.event.appended',
+      'session.decision.queued',
+      'session.decision.resolved',
+      'session.rollback.requested'
+    ]);
+    expect(auditRows.map((row) => row.payload.links)).toEqual([links, links, links, links]);
   });
 
   it('rejects invalid session payloads', async () => {

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -25,11 +25,13 @@ interface CreateSessionRequestBody {
 interface AppendEventRequestBody {
   actorId?: unknown;
   eventType?: unknown;
+  links?: unknown;
   payload?: unknown;
 }
 
 interface QueueDecisionRequestBody {
   assignedTo?: unknown;
+  links?: unknown;
   payload?: unknown;
   priority?: unknown;
   requestedBy?: unknown;
@@ -38,12 +40,14 @@ interface QueueDecisionRequestBody {
 
 interface ResolveDecisionRequestBody {
   actorId?: unknown;
+  links?: unknown;
   resolution?: unknown;
   status?: unknown;
 }
 
 interface RollbackRequestBody {
   actorId?: unknown;
+  links?: unknown;
   reason?: unknown;
   targetSequence?: unknown;
 }
@@ -54,6 +58,19 @@ interface SessionParams {
 
 interface DecisionParams extends SessionParams {
   decisionId: string;
+}
+
+interface SessionRuleLink {
+  ref?: string;
+  sourcePath: string;
+  title?: string;
+}
+
+interface SessionEntityLinks {
+  characters?: string[];
+  objects?: string[];
+  places?: string[];
+  rules?: SessionRuleLink[];
 }
 
 // Validation vocabularies are derived from the canonical rules-core unions so
@@ -228,7 +245,11 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
       }
 
       const sql = createSqlClient();
-      const payload = body.payload === undefined ? {} : (body.payload as Record<string, unknown>);
+      const links = normalizeSessionLinks(body.links);
+      const payload = attachLinks(
+        body.payload === undefined ? {} : (body.payload as Record<string, unknown>),
+        links
+      );
       const actorId = typeof body.actorId === 'string' ? body.actorId : null;
       const eventType = body.eventType as string;
 
@@ -271,11 +292,16 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
               'session.event.appended',
               'session_event',
               ${eventRows[0]!.id},
-              ${tx.json({
-                eventType,
-                sequence,
-                sessionId: session.id
-              } as postgres.JSONValue)}::jsonb
+              ${tx.json(
+                attachLinks(
+                  {
+                    eventType,
+                    sequence,
+                    sessionId: session.id
+                  },
+                  links
+                ) as postgres.JSONValue
+              )}::jsonb
             )
           `;
           await tx`
@@ -315,7 +341,11 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
       }
 
       const sql = createSqlClient();
-      const payload = body.payload === undefined ? {} : (body.payload as Record<string, unknown>);
+      const links = normalizeSessionLinks(body.links);
+      const payload = attachLinks(
+        body.payload === undefined ? {} : (body.payload as Record<string, unknown>),
+        links
+      );
       const priority = typeof body.priority === 'string' ? body.priority : 'normal';
       const assignedTo = typeof body.assignedTo === 'string' ? body.assignedTo : 'human_gm';
       const requestedBy = body.requestedBy as string;
@@ -380,13 +410,18 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
               ${sequence},
               'gm_decision_requested',
               ${requestedBy},
-              ${tx.json({
-                assignedTo,
-                decisionId: decision.id,
-                priority,
-                requestedBy,
-                title
-              } as postgres.JSONValue)}::jsonb
+              ${tx.json(
+                attachLinks(
+                  {
+                    assignedTo,
+                    decisionId: decision.id,
+                    priority,
+                    requestedBy,
+                    title
+                  },
+                  links
+                ) as postgres.JSONValue
+              )}::jsonb
             )
             RETURNING id, session_id, sequence, event_type, actor_id, payload, created_at
           `;
@@ -398,11 +433,16 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
               'session.decision.queued',
               'session_decision',
               ${decision.id},
-              ${tx.json({
-                eventId: eventRows[0]!.id,
-                priority,
-                sessionId: session.id
-              } as postgres.JSONValue)}::jsonb
+              ${tx.json(
+                attachLinks(
+                  {
+                    eventId: eventRows[0]!.id,
+                    priority,
+                    sessionId: session.id
+                  },
+                  links
+                ) as postgres.JSONValue
+              )}::jsonb
             )
           `;
           await tx`
@@ -443,8 +483,11 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
       }
 
       const sql = createSqlClient();
-      const resolution =
-        body.resolution === undefined ? {} : (body.resolution as Record<string, unknown>);
+      const links = normalizeSessionLinks(body.links);
+      const resolution = attachLinks(
+        body.resolution === undefined ? {} : (body.resolution as Record<string, unknown>),
+        links
+      );
       const actorId = body.actorId as string;
       const decisionStatus = body.status as string;
 
@@ -505,11 +548,16 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
               ${sequence},
               'gm_decision_resolved',
               ${actorId},
-              ${tx.json({
-                decisionId: decision.id,
-                resolution,
-                status: decisionStatus
-              } as postgres.JSONValue)}::jsonb
+              ${tx.json(
+                attachLinks(
+                  {
+                    decisionId: decision.id,
+                    resolution,
+                    status: decisionStatus
+                  },
+                  links
+                ) as postgres.JSONValue
+              )}::jsonb
             )
             RETURNING id, session_id, sequence, event_type, actor_id, payload, created_at
           `;
@@ -521,11 +569,16 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
               'session.decision.resolved',
               'session_decision',
               ${decision.id},
-              ${tx.json({
-                eventId: eventRows[0]!.id,
-                sessionId: session.id,
-                status: decisionStatus
-              } as postgres.JSONValue)}::jsonb
+              ${tx.json(
+                attachLinks(
+                  {
+                    eventId: eventRows[0]!.id,
+                    sessionId: session.id,
+                    status: decisionStatus
+                  },
+                  links
+                ) as postgres.JSONValue
+              )}::jsonb
             )
           `;
           await tx`
@@ -556,12 +609,8 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
     }
   );
 
-  // TODO(#54): the reverted projection is now computed by rules-core and
-  // returned to the caller, but the canonical journal still keeps every event
-  // (history-preserving markers). Deferred follow-ups: (a) event->entity links
-  // (characters/places/objects/cited rules) so reconstruction can re-project
-  // those relations, (b) frontend session-manager persistence of the reverted
-  // state, and (c) an e2e covering a multi-actor rollback round-trip.
+  // The journal is history-preserving: rollback records an auditable marker
+  // and returns a pure rules-core projection at the requested sequence.
   app.post<{ Body: RollbackRequestBody; Params: SessionParams }>(
     '/sessions/:slug/rollback',
     async (request, reply) => {
@@ -579,6 +628,7 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
       const actorId = body.actorId as string;
       const reason = body.reason as string;
       const targetSequence = body.targetSequence as number;
+      const links = normalizeSessionLinks(body.links);
 
       try {
         const result = await sql.begin(async (tx) => {
@@ -619,11 +669,16 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
               ${sequence},
               'rollback_requested',
               ${actorId},
-              ${tx.json({
-                reason,
-                targetEventId: target.id,
-                targetSequence: target.sequence
-              } as postgres.JSONValue)}::jsonb
+              ${tx.json(
+                attachLinks(
+                  {
+                    reason,
+                    targetEventId: target.id,
+                    targetSequence: target.sequence
+                  },
+                  links
+                ) as postgres.JSONValue
+              )}::jsonb
             )
             RETURNING id, session_id, sequence, event_type, actor_id, payload, created_at
           `;
@@ -635,11 +690,17 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
               'session.rollback.requested',
               'session',
               ${session.id},
-              ${tx.json({
-                eventId: eventRows[0]!.id,
-                reason,
-                targetSequence: target.sequence
-              } as postgres.JSONValue)}::jsonb
+              ${tx.json(
+                attachLinks(
+                  {
+                    eventId: eventRows[0]!.id,
+                    reason,
+                    sessionId: session.id,
+                    targetSequence: target.sequence
+                  },
+                  links
+                ) as postgres.JSONValue
+              )}::jsonb
             )
           `;
           await tx`
@@ -805,6 +866,8 @@ function validateEventBody(body: AppendEventRequestBody): ValidationResult {
     errors.push('payload must be an object');
   }
 
+  validateSessionLinks(body.links, errors);
+
   return { errors, valid: errors.length === 0 };
 }
 
@@ -837,6 +900,8 @@ function validateDecisionBody(body: QueueDecisionRequestBody): ValidationResult 
     errors.push('payload must be an object');
   }
 
+  validateSessionLinks(body.links, errors);
+
   return { errors, valid: errors.length === 0 };
 }
 
@@ -854,6 +919,8 @@ function validateResolveDecisionBody(body: ResolveDecisionRequestBody): Validati
   if (body.resolution !== undefined && !isRecord(body.resolution)) {
     errors.push('resolution must be an object');
   }
+
+  validateSessionLinks(body.links, errors);
 
   return { errors, valid: errors.length === 0 };
 }
@@ -873,7 +940,124 @@ function validateRollbackBody(body: RollbackRequestBody): ValidationResult {
     errors.push('targetSequence must be a positive integer');
   }
 
+  validateSessionLinks(body.links, errors);
+
   return { errors, valid: errors.length === 0 };
+}
+
+const linkCollectionKeys = ['characters', 'objects', 'places'] as const;
+
+function validateSessionLinks(value: unknown, errors: string[]): void {
+  if (value === undefined) {
+    return;
+  }
+
+  if (!isRecord(value)) {
+    errors.push('links must be an object');
+    return;
+  }
+
+  for (const key of linkCollectionKeys) {
+    const entries = value[key];
+
+    if (entries === undefined) {
+      continue;
+    }
+
+    if (!Array.isArray(entries) || entries.some((entry) => !isNonEmptyString(entry))) {
+      errors.push(`links.${key} must be an array of non-empty strings`);
+    }
+  }
+
+  const rules = value.rules;
+
+  if (rules === undefined) {
+    return;
+  }
+
+  if (!Array.isArray(rules)) {
+    errors.push('links.rules must be an array of rule links');
+    return;
+  }
+
+  rules.forEach((rule, index) => {
+    if (!isRecord(rule)) {
+      errors.push(`links.rules[${index}] must be an object`);
+      return;
+    }
+
+    if (!isNonEmptyString(rule.sourcePath)) {
+      errors.push(`links.rules[${index}].sourcePath is required`);
+    }
+
+    for (const key of ['ref', 'title'] as const) {
+      if (rule[key] !== undefined && !isNonEmptyString(rule[key])) {
+        errors.push(`links.rules[${index}].${key} must be a non-empty string`);
+      }
+    }
+  });
+}
+
+function normalizeSessionLinks(value: unknown): SessionEntityLinks | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const links: SessionEntityLinks = {};
+
+  for (const key of linkCollectionKeys) {
+    const entries = value[key];
+
+    if (!Array.isArray(entries)) {
+      continue;
+    }
+
+    const normalizedEntries = entries.filter(isNonEmptyString).map((entry) => entry.trim());
+
+    if (normalizedEntries.length > 0) {
+      links[key] = normalizedEntries;
+    }
+  }
+
+  if (Array.isArray(value.rules)) {
+    const rules = value.rules
+      .filter(isRecord)
+      .map((rule) => {
+        if (!isNonEmptyString(rule.sourcePath)) {
+          return undefined;
+        }
+
+        const normalizedRule: SessionRuleLink = { sourcePath: rule.sourcePath.trim() };
+
+        if (isNonEmptyString(rule.ref)) {
+          normalizedRule.ref = rule.ref.trim();
+        }
+
+        if (isNonEmptyString(rule.title)) {
+          normalizedRule.title = rule.title.trim();
+        }
+
+        return normalizedRule;
+      })
+      .filter((rule): rule is SessionRuleLink => rule !== undefined);
+
+    if (rules.length > 0) {
+      links.rules = rules;
+    }
+  }
+
+  return Object.keys(links).length > 0 ? links : undefined;
+}
+
+function attachLinks(
+  payload: Record<string, unknown>,
+  links: SessionEntityLinks | undefined
+): Record<string, unknown> {
+  return links === undefined ? payload : { ...payload, links };
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
 }
 
 function toSessionResponse(

--- a/tests/e2e/backend-gm.spec.ts
+++ b/tests/e2e/backend-gm.spec.ts
@@ -19,6 +19,12 @@ test.describe('K&W backend, RAG and GM runtime flows', () => {
     const draftId = `e2e-draft-${suffix}`;
     const sessionSlug = `e2e-session-${suffix}`;
     const gmSessionId = `e2e-gm-${suffix}`;
+    const canonicalLinks = {
+      characters: ['aveline'],
+      objects: ['relique-brisee'],
+      places: ['porte-nord'],
+      rules: [{ ref: 'D13 arbitrage et rollback', sourcePath: 'docs/rules/13-roles-passation.md' }]
+    };
 
     await expectJson(request, 'GET', '/health', 200, (body) => {
       expect(body.status).toBe('ok');
@@ -85,10 +91,12 @@ test.describe('K&W backend, RAG and GM runtime flows', () => {
         expect(body.status).toBe('created');
         expect(event.sequence).toBe(1);
         expect(event.eventType).toBe('scene_opened');
+        expect(asRecord(event.payload).links).toEqual(canonicalLinks);
       },
       {
         actorId: 'gm',
         eventType: 'scene_opened',
+        links: canonicalLinks,
         payload: { location: 'Porte nord' }
       }
     );
@@ -105,9 +113,12 @@ test.describe('K&W backend, RAG and GM runtime flows', () => {
         expect(body.status).toBe('created');
         expect(decisionBody.status).toBe('pending');
         expect(event.eventType).toBe('gm_decision_requested');
+        expect(asRecord(decisionBody.payload).links).toEqual(canonicalLinks);
+        expect(asRecord(event.payload).links).toEqual(canonicalLinks);
       },
       {
         assignedTo: 'human_gm',
+        links: canonicalLinks,
         payload: { options: ['negocier', 'combattre'] },
         priority: 'high',
         requestedBy: 'llm',
@@ -129,9 +140,12 @@ test.describe('K&W backend, RAG and GM runtime flows', () => {
         expect(body.status).toBe('resolved');
         expect(decisionBody.status).toBe('approved');
         expect(event.eventType).toBe('gm_decision_resolved');
+        expect(asRecord(decisionBody.resolution).links).toEqual(canonicalLinks);
+        expect(asRecord(event.payload).links).toEqual(canonicalLinks);
       },
       {
         actorId: 'gm',
+        links: canonicalLinks,
         resolution: { ruling: 'Reaction validee' },
         status: 'approved'
       }
@@ -147,20 +161,30 @@ test.describe('K&W backend, RAG and GM runtime flows', () => {
 
         expect(body.status).toBe('created');
         expect(event.eventType).toBe('rollback_requested');
+        expect(asRecord(event.payload).links).toEqual(canonicalLinks);
       },
       {
         actorId: 'gm',
+        links: canonicalLinks,
         reason: 'Correction E2E',
         targetSequence: 1
       }
     );
 
     await expectJson(request, 'GET', `/sessions/${sessionSlug}`, 200, (body) => {
-      expect(records(body.events).map((event) => event.eventType)).toEqual([
+      const events = records(body.events);
+
+      expect(events.map((event) => event.eventType)).toEqual([
         'scene_opened',
         'gm_decision_requested',
         'gm_decision_resolved',
         'rollback_requested'
+      ]);
+      expect(events.map((event) => asRecord(event.payload).links)).toEqual([
+        canonicalLinks,
+        canonicalLinks,
+        canonicalLinks,
+        canonicalLinks
       ]);
       expect(asRecord(records(body.decisions)[0]).status).toBe('approved');
     });


### PR DESCRIPTION
## Summary

- Adds validated canonical `links` metadata to session events, queued GM decisions, decision resolutions and rollback markers.
- Carries those links into `audit_events` so event, decision and rollback provenance can be reconstructed by character/place/object/rule references.
- Extends the backend GM Playwright API flow to assert the links survive the full session journal round-trip.

Closes #54

## Validation

- `pnpm build:shared && pnpm exec vitest run apps/server/src/routes/sessions.test.ts`
- `pnpm exec vitest run apps/server/src/routes/sessions.test.ts apps/server/src/db/schema.test.ts`
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm validate`
- `pnpm canonical:check:strict`
- `git diff --check`
