### PR TITLE
feat(server): expose equipment catalog read model

### DIFF
--- a/apps/server/src/catalogs/equipment.ts
+++ b/apps/server/src/catalogs/equipment.ts
@@ -1,0 +1,222 @@
+import type {
+  CatalogEntryStatus,
+  Potion,
+  PotionsCatalog,
+  Protection,
+  ProtectionsCatalog,
+  SourceRef,
+  Weapon,
+  WeaponsCatalog
+} from '@knightandwizard/catalogs';
+
+export const EQUIPMENT_CATALOG_NAMES = ['armes.yaml', 'protections.yaml', 'potions.yaml'] as const;
+
+export type EquipmentCatalogName = (typeof EQUIPMENT_CATALOG_NAMES)[number];
+export type EquipmentInventoryCategory = 'armor' | 'consumable' | 'shield' | 'weapon';
+
+export interface EquipmentProtectionProfile {
+  C: number;
+  E: number;
+  P: number;
+  T: number;
+}
+
+export interface EquipmentReadModelEntry {
+  catalogStatus?: CatalogEntryStatus;
+  category: EquipmentInventoryCategory;
+  craftDifficulty?: number;
+  craftSkill?: string;
+  damageFormula?: string;
+  damageType?: string | string[];
+  difficulty?: number;
+  effect?: string;
+  handsRequired?: number;
+  id: string;
+  name: string;
+  passChancePct?: number;
+  pricePc?: number;
+  protection?: EquipmentProtectionProfile;
+  rawCategory?: string;
+  sourceCatalog: EquipmentCatalogName;
+  sourceRefs?: SourceRef[];
+  weightKg?: number;
+  zonesCovered?: string[];
+}
+
+export interface EquipmentInventoryReadModelInput {
+  potions: PotionsCatalog;
+  protections: ProtectionsCatalog;
+  weapons: WeaponsCatalog;
+}
+
+export interface EquipmentInventoryTotals {
+  armor: number;
+  consumables: number;
+  shields: number;
+  total: number;
+  weapons: number;
+}
+
+export function buildEquipmentInventoryReadModel(
+  input: EquipmentInventoryReadModelInput
+): EquipmentReadModelEntry[] {
+  return [
+    ...input.weapons.weapons.map(toWeaponEntry),
+    ...input.protections.shields.map((entry) => toProtectionEntry(entry, 'shield')),
+    ...input.protections.armor_pieces.map((entry) => toProtectionEntry(entry, 'armor')),
+    ...input.potions.potions.map(toPotionEntry)
+  ].filter((entry): entry is EquipmentReadModelEntry => entry !== undefined);
+}
+
+export function summarizeEquipmentInventory(
+  entries: EquipmentReadModelEntry[]
+): EquipmentInventoryTotals {
+  const totals: EquipmentInventoryTotals = {
+    armor: 0,
+    consumables: 0,
+    shields: 0,
+    total: entries.length,
+    weapons: 0
+  };
+
+  for (const entry of entries) {
+    if (entry.category === 'armor') {
+      totals.armor += 1;
+    } else if (entry.category === 'consumable') {
+      totals.consumables += 1;
+    } else if (entry.category === 'shield') {
+      totals.shields += 1;
+    } else if (entry.category === 'weapon') {
+      totals.weapons += 1;
+    }
+  }
+
+  return totals;
+}
+
+function toWeaponEntry(entry: Weapon): EquipmentReadModelEntry | undefined {
+  if (!isInventoryVisible(entry.status)) {
+    return undefined;
+  }
+
+  return compactEntry({
+    catalogStatus: entry.status,
+    category: 'weapon',
+    damageFormula: entry.damage_formula,
+    damageType: entry.damage_type,
+    difficulty: entry.difficulty,
+    handsRequired: entry.hands_required,
+    id: entry.id,
+    name: entry.name,
+    pricePc: readNumberField(entry, 'price_pc'),
+    rawCategory: entry.category,
+    sourceCatalog: 'armes.yaml',
+    sourceRefs: entry.source_refs,
+    weightKg: readWeightKg(entry)
+  });
+}
+
+function toProtectionEntry(
+  entry: Protection,
+  category: Extract<EquipmentInventoryCategory, 'armor' | 'shield'>
+): EquipmentReadModelEntry | undefined {
+  if (!isInventoryVisible(entry.status)) {
+    return undefined;
+  }
+
+  return compactEntry({
+    catalogStatus: entry.status,
+    category,
+    id: entry.id,
+    name: entry.name,
+    passChancePct: readNumberField(entry, 'pass_chance_pct'),
+    pricePc: readNumberField(entry, 'price_pc') ?? readNumberField(entry, 'price_pc_pair'),
+    protection: entry.protection,
+    rawCategory: entry.category,
+    sourceCatalog: 'protections.yaml',
+    sourceRefs: entry.source_refs,
+    weightKg: entry.weight_kg_human,
+    zonesCovered: readStringArrayField(entry, 'zones_covered')
+  });
+}
+
+function toPotionEntry(entry: Potion): EquipmentReadModelEntry | undefined {
+  if (!isInventoryVisible(entry.status)) {
+    return undefined;
+  }
+
+  return compactEntry({
+    catalogStatus: entry.status,
+    category: 'consumable',
+    craftDifficulty: readNestedNumberField(entry, 'craft_check', 'difficulty'),
+    craftSkill: readNestedStringField(entry, 'craft_check', 'skill'),
+    effect: entry.effect,
+    id: entry.id,
+    name: entry.name,
+    pricePc: readNestedNumberField(entry, 'price', 'market_value_pc'),
+    rawCategory: entry.category,
+    sourceCatalog: 'potions.yaml',
+    sourceRefs: entry.source_refs,
+    weightKg: readWeightKg(entry)
+  });
+}
+
+function isInventoryVisible(status: CatalogEntryStatus | undefined): boolean {
+  return status === undefined || status === 'active';
+}
+
+function readWeightKg(entry: Record<string, unknown>): number | undefined {
+  const weight = entry.weight_kg ?? entry.weight_kg_human;
+  return typeof weight === 'number' ? weight : undefined;
+}
+
+function readNumberField(entry: Record<string, unknown>, key: string): number | undefined {
+  const value = entry[key];
+  return typeof value === 'number' ? value : undefined;
+}
+
+function readStringArrayField(entry: Record<string, unknown>, key: string): string[] | undefined {
+  const value = entry[key];
+  return Array.isArray(value) && value.every((item) => typeof item === 'string')
+    ? value
+    : undefined;
+}
+
+function readNestedNumberField(
+  entry: Record<string, unknown>,
+  parentKey: string,
+  key: string
+): number | undefined {
+  const parent = entry[parentKey];
+
+  if (!isRecord(parent)) {
+    return undefined;
+  }
+
+  return readNumberField(parent, key);
+}
+
+function readNestedStringField(
+  entry: Record<string, unknown>,
+  parentKey: string,
+  key: string
+): string | undefined {
+  const parent = entry[parentKey];
+
+  if (!isRecord(parent)) {
+    return undefined;
+  }
+
+  const value = parent[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function compactEntry(entry: EquipmentReadModelEntry): EquipmentReadModelEntry {
+  return Object.fromEntries(
+    Object.entries(entry).filter(([, value]) => value !== undefined)
+  ) as unknown as EquipmentReadModelEntry;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/server/src/routes/catalogs.test.ts
+++ b/apps/server/src/routes/catalogs.test.ts
@@ -39,6 +39,53 @@ describe('catalog routes', () => {
     expect(body.catalogs[0]?.importedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
+  it('returns inventory-ready equipment entries from canonical equipment catalogs', async () => {
+    const response = await app.inject({ method: 'GET', url: '/catalogs/equipment' });
+    const body = response.json() as EquipmentCatalogResponse;
+
+    expect(response.statusCode).toBe(200);
+    expect(body.status).toBe('ok');
+    expect(body.sourceCatalogs.map((catalog) => catalog.catalogName).sort()).toEqual([
+      'armes.yaml',
+      'potions.yaml',
+      'protections.yaml'
+    ]);
+    expect(body.totals).toEqual({
+      armor: 59,
+      consumables: 5,
+      shields: 12,
+      total: 183,
+      weapons: 107
+    });
+    expect(body.equipment.find((entry) => entry.id === 'epee_batarde')).toMatchObject({
+      category: 'weapon',
+      damageFormula: 'F+6',
+      difficulty: 8,
+      id: 'epee_batarde',
+      name: 'Épée bâtarde',
+      sourceCatalog: 'armes.yaml',
+      weightKg: 2.2
+    });
+    expect(body.equipment.find((entry) => entry.id === 'bouclier_bois')).toMatchObject({
+      category: 'shield',
+      id: 'bouclier_bois',
+      name: 'Bouclier (bois)',
+      passChancePct: 40,
+      protection: { C: 1, E: 2, P: 2, T: 3 },
+      sourceCatalog: 'protections.yaml',
+      weightKg: 3
+    });
+    expect(body.equipment.find((entry) => entry.id === 'soin')).toMatchObject({
+      category: 'consumable',
+      craftDifficulty: 9,
+      effect:
+        'Restaure autant de points de vitalité que de réussites obtenues lors de la fabrication',
+      id: 'soin',
+      name: 'Potion de Soin',
+      sourceCatalog: 'potions.yaml'
+    });
+  });
+
   it('returns a catalog document with canonical status and source refs intact', async () => {
     const response = await app.inject({ method: 'GET', url: '/catalogs/spells.yaml' });
     const body = response.json() as CatalogDocumentResponse<{ spells: CatalogEntry[] }>;
@@ -109,4 +156,31 @@ interface CatalogSummary {
 interface CatalogEntry {
   source_refs?: Array<{ path?: string }>;
   status?: string;
+}
+
+interface EquipmentCatalogResponse {
+  equipment: EquipmentEntry[];
+  sourceCatalogs: CatalogSummary[];
+  status: 'ok';
+  totals: {
+    armor: number;
+    consumables: number;
+    shields: number;
+    total: number;
+    weapons: number;
+  };
+}
+
+interface EquipmentEntry {
+  category: 'armor' | 'consumable' | 'shield' | 'weapon';
+  craftDifficulty?: number;
+  damageFormula?: string;
+  difficulty?: number;
+  effect?: string;
+  id: string;
+  name: string;
+  passChancePct?: number;
+  protection?: Record<string, number>;
+  sourceCatalog: string;
+  weightKg?: number;
 }

--- a/apps/server/src/routes/catalogs.ts
+++ b/apps/server/src/routes/catalogs.ts
@@ -1,6 +1,17 @@
-import { PRIORITY_CATALOG_NAMES, type PriorityCatalogName } from '@knightandwizard/catalogs';
+import {
+  PRIORITY_CATALOG_NAMES,
+  type PotionsCatalog,
+  type PriorityCatalogName,
+  type ProtectionsCatalog,
+  type WeaponsCatalog
+} from '@knightandwizard/catalogs';
 import type { FastifyInstance } from 'fastify';
 
+import {
+  EQUIPMENT_CATALOG_NAMES,
+  buildEquipmentInventoryReadModel,
+  summarizeEquipmentInventory
+} from '../catalogs/equipment.js';
 import { createSqlClient, type SqlClient } from '../db/client.js';
 
 const catalogNamePattern = /^[a-z0-9-]+\.yaml$/;
@@ -33,6 +44,7 @@ interface CatalogDocumentRow {
 
 export async function registerCatalogRoutes(app: FastifyInstance): Promise<void> {
   app.options('/catalogs', async (_request, reply) => reply.code(204).send());
+  app.options('/catalogs/equipment', async (_request, reply) => reply.code(204).send());
   app.options('/catalogs/:catalogName', async (_request, reply) => reply.code(204).send());
 
   app.get('/catalogs', async () => {
@@ -46,6 +58,51 @@ export async function registerCatalogRoutes(app: FastifyInstance): Promise<void>
           .filter((row) => isPriorityCatalogName(row.catalog_name))
           .map(toCatalogSummary),
         status: 'ok' as const
+      };
+    } finally {
+      await sql.end({ timeout: 5 });
+    }
+  });
+
+  app.get('/catalogs/equipment', async (_request, reply) => {
+    const sql = createSqlClient();
+
+    try {
+      const rows = await sql<CatalogDocumentRow[]>`
+        SELECT catalog_name, source_path, content_hash, document, imported_at, updated_at
+        FROM catalog_documents
+        WHERE catalog_name IN ('armes.yaml', 'protections.yaml', 'potions.yaml')
+        ORDER BY catalog_name ASC
+      `;
+      const rowByName = new Map(rows.map((row) => [row.catalog_name, row]));
+      const missingCatalogs = EQUIPMENT_CATALOG_NAMES.filter(
+        (catalogName) => !rowByName.has(catalogName)
+      );
+
+      if (missingCatalogs.length > 0) {
+        return reply.code(404).send({
+          error: {
+            catalogNames: missingCatalogs,
+            code: 'equipment_catalogs_not_imported',
+            message: 'Equipment catalog read models are not imported.'
+          },
+          status: 'not_found'
+        });
+      }
+
+      const equipment = buildEquipmentInventoryReadModel({
+        potions: rowByName.get('potions.yaml')!.document as PotionsCatalog,
+        protections: rowByName.get('protections.yaml')!.document as ProtectionsCatalog,
+        weapons: rowByName.get('armes.yaml')!.document as WeaponsCatalog
+      });
+
+      return {
+        equipment,
+        sourceCatalogs: EQUIPMENT_CATALOG_NAMES.map((catalogName) =>
+          toCatalogSummary(rowByName.get(catalogName)!)
+        ),
+        status: 'ok' as const,
+        totals: summarizeEquipmentInventory(equipment)
       };
     } finally {
       await sql.end({ timeout: 5 });

--- a/tests/e2e/backend-gm.spec.ts
+++ b/tests/e2e/backend-gm.spec.ts
@@ -36,6 +36,26 @@ test.describe('K&W backend, RAG and GM runtime flows', () => {
       expect(body.pgvector).toBe(true);
     });
 
+    await expectJson(request, 'GET', '/catalogs/equipment', 200, (body) => {
+      const totals = asRecord(body.totals);
+      const equipment = records(body.equipment);
+
+      expect(body.status).toBe('ok');
+      expect(totals.total).toBe(183);
+      expect(equipment.find((entry) => entry.id === 'epee_batarde')).toMatchObject({
+        category: 'weapon',
+        sourceCatalog: 'armes.yaml'
+      });
+      expect(equipment.find((entry) => entry.id === 'bouclier_bois')).toMatchObject({
+        category: 'shield',
+        sourceCatalog: 'protections.yaml'
+      });
+      expect(equipment.find((entry) => entry.id === 'soin')).toMatchObject({
+        category: 'consumable',
+        sourceCatalog: 'potions.yaml'
+      });
+    });
+
     await expectJson(
       request,
       'PUT',

--- a/tests/e2e/fixtures/canonical.ts
+++ b/tests/e2e/fixtures/canonical.ts
@@ -50,7 +50,10 @@ export const canonicalE2EFixtures = {
       sourceRefs: [
         { path: 'docs/product/llm-tool-calling-contract.md', ref: 'tool calling MJ' },
         { path: 'docs/product/rag-citation-evaluation-contract.md', ref: 'citations RAG' },
-        { path: 'docs/product/episodic-memory-contract.md', ref: 'memoire episodique' }
+        { path: 'docs/product/episodic-memory-contract.md', ref: 'memoire episodique' },
+        { path: 'data/catalogs/armes.yaml', ref: 'inventaire armes' },
+        { path: 'data/catalogs/protections.yaml', ref: 'inventaire protections' },
+        { path: 'data/catalogs/potions.yaml', ref: 'inventaire potions' }
       ]
     }
   }


### PR DESCRIPTION
## Summary

- Adds a server-side equipment inventory read model derived only from `armes.yaml`, `protections.yaml` and `potions.yaml`.
- Exposes `GET /catalogs/equipment` with normalized inventory categories, weights, combat/craft fields, source catalog summaries and totals.
- Extends backend route tests and Playwright API E2E coverage with canonical source annotations for the equipment catalogs.

Closes #74

## Validation

- `pnpm build:shared && pnpm exec vitest run apps/server/src/routes/catalogs.test.ts` (red first: route returned 400 before implementation)
- `pnpm exec vitest run apps/server/src/routes/catalogs.test.ts tools/e2e-fixtures.test.ts`
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e`
- `pnpm validate`
- `pnpm canonical:check:strict`
- `git diff --check`
