### PR TITLE
feat(frontend): shell skins and persistent veillee

### DIFF
--- a/apps/game/src/app/bibliotheque/page.tsx
+++ b/apps/game/src/app/bibliotheque/page.tsx
@@ -1,0 +1,23 @@
+import { Badge, Card, Label } from '@knightandwizard/ui';
+
+const ledgers = ['Sources', 'Catalogues', 'Amendements', 'Historique'] as const;
+
+export default function BibliothequePage() {
+  return (
+    <div className="kw-surface-page">
+      <Card>
+        <Label>Bibliotheque</Label>
+        <h1>La chancellerie classe avant de contredire.</h1>
+        <Badge tone="neutral">Skin bibliotheque</Badge>
+      </Card>
+
+      <section className="kw-surface-grid" aria-label="Registres de chancellerie">
+        {ledgers.map((ledger) => (
+          <div className="kw-swatch-row" key={ledger}>
+            <span className="kw-label">{ledger}</span>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/apps/game/src/app/dice/page.tsx
+++ b/apps/game/src/app/dice/page.tsx
@@ -1,0 +1,27 @@
+import { Badge, Card, Die, Label } from '@knightandwizard/ui';
+
+const dice = [
+  { value: 10, kind: 'success' },
+  { value: 7, kind: 'critical' },
+  { value: 1, kind: 'one' }
+] as const;
+
+export default function DicePage() {
+  return (
+    <div className="kw-surface-page">
+      <Card>
+        <Label>Tripot</Label>
+        <h1>Le destin tire au cent.</h1>
+        <Badge tone="warn">Skin tripot</Badge>
+      </Card>
+
+      <Card>
+        <div className="flex flex-wrap gap-2" aria-label="Des de reference">
+          {dice.map((die) => (
+            <Die key={die.value} kind={die.kind} value={die.value} />
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/apps/game/src/app/globals.css
+++ b/apps/game/src/app/globals.css
@@ -33,3 +33,234 @@ button,
 a {
   -webkit-tap-highlight-color: transparent;
 }
+
+.app-shell {
+  width: min(100%, 1280px);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: 16px;
+}
+
+.app-shell__header {
+  position: sticky;
+  top: 12px;
+  z-index: 20;
+  border: var(--border-hairline) solid var(--color-border-rule);
+  background: color-mix(in oklab, var(--color-bg-surface) 94%, transparent);
+  box-shadow: var(--shadow-card) color-mix(in oklab, var(--color-text-ink) 16%, transparent);
+  backdrop-filter: blur(10px);
+}
+
+.app-shell__bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px;
+  border-bottom: var(--border-hairline) solid var(--color-border-hairline);
+}
+
+.app-shell__brand {
+  display: inline-flex;
+  min-height: 48px;
+  align-items: center;
+  gap: 12px;
+}
+
+.app-shell__brand:focus-visible,
+.app-shell__nav-link:focus-visible,
+.app-shell__theme-button:focus-visible {
+  outline: var(--border-strong) solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.app-shell__brand-mark {
+  display: grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  border: var(--border-hairline) solid var(--color-border-rule);
+  background: var(--color-accent);
+  color: var(--color-bg-canvas);
+  font-family: var(--font-label);
+  font-size: var(--text-label-sm);
+  font-weight: 700;
+  letter-spacing: var(--tracking-label);
+}
+
+.app-shell__brand-title {
+  display: block;
+  color: var(--color-text-ink);
+  font-family: var(--font-display);
+  font-size: var(--text-body-l);
+  font-weight: 700;
+  line-height: var(--leading-tight);
+}
+
+.app-shell__brand-subtitle {
+  display: block;
+  color: var(--color-text-muted);
+  font-family: var(--font-label);
+  font-size: var(--text-label-sm);
+  letter-spacing: var(--tracking-label);
+  line-height: var(--leading-normal);
+  text-transform: uppercase;
+}
+
+.app-shell__theme-button {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: var(--border-hairline) solid var(--color-border-rule);
+  border-radius: var(--radius-rect);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-ink);
+  box-shadow: var(--shadow-button) var(--color-border-rule);
+  cursor: pointer;
+  font-family: var(--font-label);
+  font-size: var(--text-label-sm);
+  letter-spacing: var(--tracking-label);
+  padding: 8px 12px;
+  text-transform: uppercase;
+}
+
+.app-shell__theme-button:active {
+  transform: translateY(2px);
+  box-shadow: none;
+}
+
+.app-shell__theme-icon,
+.app-shell__nav-icon {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+}
+
+.app-shell__nav {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(86px, 1fr));
+  gap: 6px;
+  padding: 8px;
+}
+
+.app-shell__nav-link {
+  display: flex;
+  min-width: 0;
+  min-height: 44px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border: var(--border-hairline) solid transparent;
+  color: var(--color-text-muted);
+  font-family: var(--font-label);
+  font-size: var(--text-label-sm);
+  letter-spacing: var(--tracking-label);
+  padding: 8px 10px;
+  text-transform: uppercase;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease;
+}
+
+.app-shell__nav-link:hover {
+  border-color: var(--color-border-hairline);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-ink);
+}
+
+.app-shell__nav-link[aria-current='page'] {
+  border-color: var(--color-border-rule);
+  background: var(--color-text-ink);
+  color: var(--color-bg-canvas);
+}
+
+.app-shell__nav-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-shell__nav-short {
+  display: none;
+}
+
+.app-shell__main {
+  padding: 24px 0 32px;
+}
+
+.kw-surface-page {
+  display: grid;
+  gap: 16px;
+}
+
+.kw-surface-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.kw-swatch-row {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  gap: 10px;
+  border: var(--border-hairline) solid var(--color-border-hairline);
+  background: var(--color-bg-elevated);
+  padding: 8px 10px;
+}
+
+.kw-swatch {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  border: var(--border-hairline) solid var(--color-border-rule);
+  background: var(--swatch-color, var(--color-accent));
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    padding: 10px;
+  }
+
+  .app-shell__header {
+    top: 8px;
+  }
+
+  .app-shell__bar {
+    align-items: stretch;
+  }
+
+  .app-shell__brand,
+  .app-shell__theme-button {
+    width: 100%;
+  }
+
+  .app-shell__theme-button {
+    justify-content: center;
+  }
+
+  .app-shell__nav {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .app-shell__nav-link {
+    gap: 4px;
+    padding: 6px 4px;
+  }
+
+  .app-shell__nav-label {
+    display: none;
+  }
+
+  .app-shell__nav-short {
+    display: inline;
+    overflow: hidden;
+    max-width: 100%;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}

--- a/apps/game/src/app/grimoire/page.tsx
+++ b/apps/game/src/app/grimoire/page.tsx
@@ -1,0 +1,42 @@
+import type { CSSProperties } from 'react';
+
+import { Badge, Card, Label } from '@knightandwizard/ui';
+
+const schools = [
+  ['Abjuration', 'abjuration'],
+  ['Alteration', 'alteration'],
+  ['Blanche', 'blanche'],
+  ['Divination', 'divination'],
+  ['Enchantement', 'enchantement'],
+  ['Elementaire', 'elementaire'],
+  ['Illusion', 'illusion'],
+  ['Invocation', 'invocation'],
+  ['Naturelle', 'naturelle'],
+  ['Noire', 'noire'],
+  ['Necromancie', 'necromancie']
+] as const;
+
+export default function GrimoirePage() {
+  return (
+    <div className="kw-surface-page">
+      <Card>
+        <Label>Grimoire</Label>
+        <h1>Onze ecoles, une roue peu charitable.</h1>
+        <Badge tone="info">Skin grimoire</Badge>
+      </Card>
+
+      <section className="kw-surface-grid" aria-label="Ecoles de magie">
+        {schools.map(([label, token]) => (
+          <div className="kw-swatch-row" key={token}>
+            <span
+              aria-hidden="true"
+              className="kw-swatch"
+              style={{ '--swatch-color': 'var(--school-' + token + ')' } as CSSProperties}
+            />
+            <span>{label}</span>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/apps/game/src/app/layout.tsx
+++ b/apps/game/src/app/layout.tsx
@@ -1,7 +1,14 @@
 import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
 import type { ReactNode } from 'react';
 
 import { AppShell } from '@/components/app-shell';
+import {
+  KW_THEME_COOKIE,
+  SKIN_BOOTSTRAP_SCRIPT,
+  resolveSkinForPath,
+  resolveThemePreference
+} from '@/lib/surface-theme';
 import './globals.css';
 import '@knightandwizard/ui/styles.css';
 
@@ -10,20 +17,32 @@ export const metadata: Metadata = {
   description: 'Compagnon de table digital pour les joueurs et le MJ Knight & Wizard.'
 };
 
-// Polices des skins du design system (pack Terres Oubliées + pack moderne).
+// Polices des skins du design system (pack Terres Oubliees + pack moderne).
 const FONTS_HREF =
   'https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700;900&family=Bitter:ital,wght@0,400;0,700&family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Cormorant+SC:wght@400;600&family=Courier+Prime&family=EB+Garamond:ital,wght@0,400;0,500;1,400&family=IBM+Plex+Mono&family=Inter:wght@400;500;600;700&family=Libre+Caslon+Display&family=Playfair+Display:wght@400;700;900&family=PT+Serif:ital,wght@0,400;0,700;1,400&family=Source+Serif+4:wght@400;600&family=Special+Elite&display=swap';
 
-export default function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
+export default async function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
+  const cookieStore = await cookies();
+  const initialTheme = resolveThemePreference(cookieStore.get(KW_THEME_COOKIE)?.value);
+  const initialSkin = resolveSkinForPath('/');
+
   return (
-    <html lang="fr">
+    <html
+      data-skin={initialSkin}
+      data-theme={initialTheme === 'night' ? 'night' : undefined}
+      lang="fr"
+      suppressHydrationWarning
+    >
       <head>
+        <script dangerouslySetInnerHTML={{ __html: SKIN_BOOTSTRAP_SCRIPT }} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href={FONTS_HREF} rel="stylesheet" />
       </head>
       <body>
-        <AppShell>{children}</AppShell>
+        <AppShell initialSkin={initialSkin} initialTheme={initialTheme}>
+          {children}
+        </AppShell>
       </body>
     </html>
   );

--- a/apps/game/src/app/rules/page.tsx
+++ b/apps/game/src/app/rules/page.tsx
@@ -1,0 +1,24 @@
+import { Badge, Card, Label } from '@knightandwizard/ui';
+
+const ruleCodes = Array.from({ length: 13 }, (_, index) => 'D' + String(index + 1));
+
+export default function RulesPage() {
+  return (
+    <div className="kw-surface-page">
+      <Card>
+        <Label>Archives</Label>
+        <h1>D1-D13, et autant de raisons de relire.</h1>
+        <Badge tone="danger">Skin archives</Badge>
+      </Card>
+
+      <section className="kw-surface-grid" aria-label="Sections de regles">
+        {ruleCodes.map((code) => (
+          <div className="kw-swatch-row" key={code}>
+            <span className="kw-label">{code}</span>
+            <span>Article canonique</span>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/apps/game/src/components/app-shell.tsx
+++ b/apps/game/src/components/app-shell.tsx
@@ -1,63 +1,143 @@
 'use client';
 
-import { BookUser, LayoutDashboard, ScrollText, Swords } from 'lucide-react';
+import {
+  BookOpen,
+  BookUser,
+  Dices,
+  FileArchive,
+  LayoutDashboard,
+  LibraryBig,
+  Moon,
+  PenLine,
+  ScrollText,
+  Sun,
+  Swords,
+  WandSparkles,
+  type LucideIcon
+} from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import type { ReactNode } from 'react';
+import { useLayoutEffect, useState, type ReactNode } from 'react';
 
-const navItems = [
-  { href: '/', label: 'Dashboard', icon: LayoutDashboard },
-  { href: '/character', label: 'Personnage', icon: BookUser },
-  { href: '/combat', label: 'Combat', icon: Swords },
-  { href: '/session', label: 'Session', icon: ScrollText }
-];
+import {
+  KW_THEME_COOKIE,
+  KW_THEME_STORAGE_KEY,
+  resolveSkinForPath,
+  surfaceNavItems,
+  type KwSkin,
+  type KwThemePreference
+} from '@/lib/surface-theme';
 
-export function AppShell({ children }: Readonly<{ children: ReactNode }>) {
+const THEME_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+const navIcons: Record<string, LucideIcon> = {
+  '/': LayoutDashboard,
+  '/character': BookUser,
+  '/character/create': PenLine,
+  '/combat': Swords,
+  '/session': ScrollText,
+  '/grimoire': WandSparkles,
+  '/dice': Dices,
+  '/rules': FileArchive,
+  '/bibliotheque': LibraryBig,
+  '/design-proto': BookOpen
+};
+
+export function AppShell({
+  children,
+  initialSkin,
+  initialTheme
+}: Readonly<{
+  children: ReactNode;
+  initialSkin: KwSkin;
+  initialTheme: KwThemePreference;
+}>) {
   const pathname = usePathname();
+  const activeHref = resolveActiveHref(pathname);
+  const skin = resolveSkinForPath(pathname);
+  const [theme, setTheme] = useState<KwThemePreference>(initialTheme);
+
+  useLayoutEffect(() => {
+    document.documentElement.dataset.skin = skin;
+  }, [skin]);
+
+  useLayoutEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  const nextTheme = theme === 'night' ? 'day' : 'night';
+  const ThemeIcon = theme === 'night' ? Moon : Sun;
 
   return (
-    <div className="mx-auto flex min-h-screen w-full max-w-7xl flex-col px-4 py-4 sm:px-6 lg:px-8">
-      <header className="sticky top-3 z-20 rounded-md border border-ink/10 bg-paper/92 p-2 shadow-sm backdrop-blur">
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <Link className="flex items-center gap-3 px-2 py-1" href="/">
-            <span className="grid size-10 place-items-center rounded-md bg-forest font-serif text-lg font-bold text-paper">
+    <div className="app-shell" data-shell-skin={initialSkin}>
+      <header className="app-shell__header">
+        <div className="app-shell__bar">
+          <Link className="app-shell__brand" href="/">
+            <span aria-hidden="true" className="app-shell__brand-mark">
               K&W
             </span>
             <span>
-              <span className="block text-base font-semibold text-ink">Knight & Wizard</span>
-              <span className="block text-xs font-medium uppercase tracking-[0.16em] text-ink/54">
-                Table Companion
-              </span>
+              <span className="app-shell__brand-title">Knight & Wizard</span>
+              <span className="app-shell__brand-subtitle">Table Companion</span>
             </span>
           </Link>
 
-          <nav aria-label="Navigation principale" className="grid grid-cols-4 gap-1 md:flex">
-            {navItems.map((item) => {
-              const Icon = item.icon;
-              const active = item.href === '/' ? pathname === '/' : pathname.startsWith(item.href);
-
-              return (
-                <Link
-                  aria-current={active ? 'page' : undefined}
-                  className={[
-                    'flex min-h-11 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition',
-                    active
-                      ? 'bg-ink text-paper shadow-sm'
-                      : 'text-ink/68 hover:bg-vellum hover:text-ink'
-                  ].join(' ')}
-                  href={item.href}
-                  key={item.href}
-                >
-                  <Icon aria-hidden="true" className="size-4 shrink-0" />
-                  <span className="hidden sm:inline">{item.label}</span>
-                </Link>
-              );
-            })}
-          </nav>
+          <button
+            aria-label={nextTheme === 'night' ? 'Passer en mode Veillee' : 'Passer en mode Jour'}
+            className="app-shell__theme-button"
+            onClick={() => setTheme(nextTheme)}
+            title={nextTheme === 'night' ? 'Passer en mode Veillee' : 'Passer en mode Jour'}
+            type="button"
+          >
+            <ThemeIcon aria-hidden="true" className="app-shell__theme-icon" />
+            <span>{theme === 'night' ? 'Veillee' : 'Jour'}</span>
+          </button>
         </div>
+
+        <nav aria-label="Navigation principale" className="app-shell__nav">
+          {surfaceNavItems.map((item) => {
+            const Icon = navIcons[item.href] ?? BookOpen;
+            const active = item.href === activeHref;
+
+            return (
+              <Link
+                aria-current={active ? 'page' : undefined}
+                className="app-shell__nav-link"
+                href={item.href}
+                key={item.href}
+                title={item.label}
+              >
+                <Icon aria-hidden="true" className="app-shell__nav-icon" />
+                <span className="app-shell__nav-label">{item.label}</span>
+                <span className="app-shell__nav-short">{item.shortLabel}</span>
+              </Link>
+            );
+          })}
+        </nav>
       </header>
 
-      <main className="flex-1 py-6 md:py-8">{children}</main>
+      <main className="app-shell__main">{children}</main>
     </div>
   );
+}
+
+function resolveActiveHref(pathname: string): string {
+  const candidates = surfaceNavItems
+    .map((item) => item.href)
+    .filter((href) => pathname === href || (href !== '/' && pathname.startsWith(href + '/')))
+    .sort((left, right) => right.length - left.length);
+
+  return candidates[0] ?? '/';
+}
+
+function applyTheme(theme: KwThemePreference): void {
+  if (theme === 'night') {
+    document.documentElement.dataset.theme = 'night';
+  } else {
+    document.documentElement.removeAttribute('data-theme');
+  }
+
+  document.cookie =
+    KW_THEME_COOKIE + '=' + theme + '; path=/; max-age=' + THEME_MAX_AGE_SECONDS + '; samesite=lax';
+  window.localStorage.setItem(KW_THEME_STORAGE_KEY, theme);
 }

--- a/apps/game/src/lib/surface-theme.test.ts
+++ b/apps/game/src/lib/surface-theme.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  KW_SKINS,
+  resolveSkinForPath,
+  resolveThemePreference,
+  surfaceNavItems
+} from './surface-theme';
+
+describe('surface theme contract', () => {
+  it('maps the product routes to their in-world skins', () => {
+    expect(resolveSkinForPath('/')).toBe('gazette');
+    expect(resolveSkinForPath('/character')).toBe('armorial');
+    expect(resolveSkinForPath('/character/create')).toBe('armorial');
+    expect(resolveSkinForPath('/combat')).toBe('registre');
+    expect(resolveSkinForPath('/session')).toBe('gazette');
+    expect(resolveSkinForPath('/grimoire')).toBe('grimoire');
+    expect(resolveSkinForPath('/dice')).toBe('tripot');
+    expect(resolveSkinForPath('/rules')).toBe('archives');
+    expect(resolveSkinForPath('/bibliotheque')).toBe('bibliotheque');
+    expect(resolveSkinForPath('/design-proto')).toBe('moderne');
+  });
+
+  it('keeps navigation coverage for every emitted skin', () => {
+    const navSkins = new Set(surfaceNavItems.map((item) => item.skin));
+
+    expect(navSkins).toEqual(new Set(KW_SKINS));
+  });
+
+  it('normalizes the persisted Jour/Veillee preference', () => {
+    expect(resolveThemePreference('night')).toBe('night');
+    expect(resolveThemePreference('day')).toBe('day');
+    expect(resolveThemePreference(undefined)).toBe('day');
+    expect(resolveThemePreference('bogus')).toBe('day');
+  });
+});

--- a/apps/game/src/lib/surface-theme.ts
+++ b/apps/game/src/lib/surface-theme.ts
@@ -1,0 +1,87 @@
+export const KW_THEME_COOKIE = 'kw-theme';
+export const KW_THEME_STORAGE_KEY = 'kw-theme';
+
+export const KW_SKINS = [
+  'grimoire',
+  'registre',
+  'tripot',
+  'archives',
+  'bibliotheque',
+  'gazette',
+  'armorial',
+  'moderne'
+] as const;
+
+export type KwSkin = (typeof KW_SKINS)[number];
+export type KwThemePreference = 'day' | 'night';
+
+export type SurfaceNavItem = {
+  href: string;
+  label: string;
+  skin: KwSkin;
+  shortLabel: string;
+};
+
+export const surfaceNavItems: readonly SurfaceNavItem[] = [
+  { href: '/', label: 'Dashboard', shortLabel: 'Poste', skin: 'gazette' },
+  { href: '/character', label: 'Personnage', shortLabel: 'Fiche', skin: 'armorial' },
+  { href: '/character/create', label: 'Creation', shortLabel: 'Creer', skin: 'armorial' },
+  { href: '/combat', label: 'Combat', shortLabel: 'DT', skin: 'registre' },
+  { href: '/session', label: 'Session', shortLabel: 'Journal', skin: 'gazette' },
+  { href: '/grimoire', label: 'Grimoire', shortLabel: 'Sorts', skin: 'grimoire' },
+  { href: '/dice', label: 'Des', shortLabel: 'D10', skin: 'tripot' },
+  { href: '/rules', label: 'Archives', shortLabel: 'D1-D13', skin: 'archives' },
+  { href: '/bibliotheque', label: 'Bibliotheque', shortLabel: 'CMS', skin: 'bibliotheque' },
+  { href: '/design-proto', label: 'Lab', shortLabel: 'Skin', skin: 'moderne' }
+] as const;
+
+export const routeSkins: readonly [prefix: string, skin: KwSkin][] = [
+  ['/design-proto/registre', 'registre'],
+  ['/design-proto/fiche', 'armorial'],
+  ['/character/create', 'armorial'],
+  ['/character', 'armorial'],
+  ['/combat', 'registre'],
+  ['/session', 'gazette'],
+  ['/grimoire', 'grimoire'],
+  ['/dice', 'tripot'],
+  ['/rules', 'archives'],
+  ['/bibliotheque', 'bibliotheque'],
+  ['/design-proto', 'moderne']
+] as const;
+
+export function resolveSkinForPath(pathname: string | null | undefined): KwSkin {
+  const normalizedPathname = normalizePathname(pathname);
+
+  if (normalizedPathname === '/') return 'gazette';
+
+  const match = routeSkins.find(
+    ([prefix]) => normalizedPathname === prefix || normalizedPathname.startsWith(prefix + '/')
+  );
+
+  return match?.[1] ?? 'gazette';
+}
+
+export function resolveThemePreference(value: string | null | undefined): KwThemePreference {
+  return value === 'night' ? 'night' : 'day';
+}
+
+function normalizePathname(pathname: string | null | undefined): string {
+  if (!pathname) return '/';
+
+  const [withoutQuery] = pathname.split(/[?#]/, 1);
+  const withLeadingSlash = withoutQuery.startsWith('/') ? withoutQuery : '/' + withoutQuery;
+  return withLeadingSlash.length > 1 ? withLeadingSlash.replace(/\/$/, '') : withLeadingSlash;
+}
+
+export const SKIN_BOOTSTRAP_SCRIPT =
+  '(() => {' +
+  'const routeSkins=' +
+  JSON.stringify(routeSkins) +
+  ';' +
+  'const pathname=window.location.pathname || "/";' +
+  'let skin="gazette";' +
+  'for (const [prefix,value] of routeSkins) {' +
+  'if (pathname===prefix || pathname.startsWith(prefix + "/")) { skin=value; break; }' +
+  '}' +
+  'document.documentElement.dataset.skin=skin;' +
+  '})();';

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -19,6 +19,45 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByRole('link', { name: /Session/ })).toBeVisible();
   });
 
+  test('application shell applies surface skins and persists Veillee', async ({
+    page
+  }, testInfo) => {
+    annotateCanonical(testInfo, 'dashboard');
+
+    const serverRenderedCombat = await page.request.get('/combat', {
+      headers: { Cookie: 'kw-theme=night' }
+    });
+    const serverHtml = await serverRenderedCombat.text();
+    expect(serverHtml).toContain('data-theme="night"');
+
+    const routeSkins = [
+      ['/', 'gazette'],
+      ['/character', 'armorial'],
+      ['/combat', 'registre'],
+      ['/session', 'gazette'],
+      ['/grimoire', 'grimoire'],
+      ['/dice', 'tripot'],
+      ['/rules', 'archives'],
+      ['/bibliotheque', 'bibliotheque'],
+      ['/design-proto', 'moderne']
+    ] as const;
+
+    for (const [route, skin] of routeSkins) {
+      await page.goto(route);
+      await expect(page.locator('html')).toHaveAttribute('data-skin', skin);
+    }
+
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Passer en mode Veillee' }).click();
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
+    await page.reload();
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
+
+    await page.getByRole('link', { name: /^Combat/ }).click();
+    await expect(page.locator('html')).toHaveAttribute('data-skin', 'registre');
+    await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
+  });
+
   test('character sheet exposes canonical attributes, nested skills and level budget', async ({
     page
   }, testInfo) => {


### PR DESCRIPTION
## Summary

- Adds the app shell skin/theme contract for the 8 emitted K&W skins.
- Applies `data-skin` on `<html>` during navigation and bootstraps it before hydration.
- Persists Jour/Veillee in cookie + localStorage; SSR restores `data-theme="night"` from the cookie.
- Adds shell routes for grimoire, dice/tripot, archives, and bibliotheque so all skins have reachable surfaces.
- Adds unit and E2E coverage for route skins, theme persistence, and shell navigation.

Closes #92.

## Verification

- `pnpm exec vitest run apps/game/src/lib/surface-theme.test.ts`
- `E2E_GAME_PORT=3130 E2E_API_PORT=3132 pnpm exec playwright test tests/e2e/app-features.spec.ts -g "application shell"`
- `pnpm build:game` + CSS grep for `--school-necromancie`, `--shadow-card`, `--emaux-gueules`, `[data-skin]`
- `pnpm validate`
- `pnpm canonical:check:strict`
- Playwright smoke screenshots desktop/mobile for dashboard, registre proto, grimoire, dice, rules, bibliotheque, design-proto
