### PR TITLE
feat(ui): add surface components

### DIFF
--- a/apps/game/src/app/design-proto/ui/page.tsx
+++ b/apps/game/src/app/design-proto/ui/page.tsx
@@ -1,0 +1,5 @@
+import { UiSurfaceBench } from './ui-surface-bench';
+
+export default function UiPrototypePage() {
+  return <UiSurfaceBench />;
+}

--- a/apps/game/src/app/design-proto/ui/ui-surface-bench.tsx
+++ b/apps/game/src/app/design-proto/ui/ui-surface-bench.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useState } from 'react';
+
+import {
+  Badge,
+  Button,
+  Card,
+  DiceCluster,
+  Dialog,
+  Field,
+  Label,
+  ProgressBar,
+  SelectField,
+  Table,
+  Tabs,
+  TimelineDT,
+  Toast
+} from '@knightandwizard/ui';
+
+const rows = [
+  { actor: 'Aveline', dt: 6, state: 'Prete' },
+  { actor: 'Brigand', dt: 8, state: 'Saignement' },
+  { actor: 'Mire', dt: 12, state: 'Incantation' }
+] as const;
+
+export function UiSurfaceBench() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState('ordre');
+
+  return (
+    <div className="kw-surface-page">
+      <Card>
+        <Label>UI</Label>
+        <h1>Composants de surface</h1>
+        <Badge tone="info">Skin moderne</Badge>
+      </Card>
+
+      <section className="kw-surface-grid" aria-label="Composants de formulaire et feedback">
+        <Card className="kw-ui-demo-stack">
+          <Field defaultValue="Aveline" hint="Nom consigne" label="Champ texte" />
+          <SelectField
+            defaultValue="registre"
+            label="Select"
+            options={[
+              { label: 'Registre', value: 'registre' },
+              { label: 'Armorial', value: 'armorial' },
+              { label: 'Grimoire', value: 'grimoire' }
+            ]}
+          />
+        </Card>
+
+        <Card className="kw-ui-demo-stack">
+          <ProgressBar label="Vitalite" max={24} tone="success" value={16} />
+          <ProgressBar label="Fatigue" max={10} tone="warn" value={7} />
+        </Card>
+
+        <Card className="kw-ui-demo-stack">
+          <DiceCluster
+            dice={[
+              { value: 10, kind: 'success' },
+              { value: 7, kind: 'critical' },
+              { value: 1, kind: 'one' }
+            ]}
+            label="Jet de reference"
+          />
+          <Toast title="Jet consigne" tone="success">
+            2 succes, une remarque du destin.
+          </Toast>
+          <Button onClick={() => setDialogOpen(true)} variant="secondary">
+            Ouvrir modal
+          </Button>
+        </Card>
+      </section>
+
+      <Tabs
+        activeId={activeTab}
+        items={[
+          {
+            id: 'ordre',
+            label: 'Ordre',
+            panel: (
+              <TimelineDT
+                items={rows.map((row) => ({
+                  id: row.actor,
+                  current: row.actor === 'Aveline',
+                  description: row.state,
+                  dt: row.dt,
+                  label: row.actor
+                }))}
+              />
+            )
+          },
+          {
+            id: 'table',
+            label: 'Table',
+            panel: (
+              <Table
+                caption="Ordre de bataille"
+                columns={[
+                  { id: 'actor', header: 'Acteur', cell: (row) => row.actor },
+                  { id: 'dt', header: 'DT', align: 'right', cell: (row) => row.dt },
+                  { id: 'state', header: 'Etat', cell: (row) => row.state }
+                ]}
+                getRowKey={(row) => row.actor}
+                rows={rows}
+              />
+            )
+          }
+        ]}
+        label="Banc UI"
+        onTabChange={setActiveTab}
+      />
+
+      <Card className="kw-ui-demo-stack">
+        <Label>Modal</Label>
+        <p className="kw-ui-demo-copy">
+          La modale reste declenchee par action pour garder le banc lisible.
+        </p>
+        <Button onClick={() => setDialogOpen(true)}>Ouvrir minute</Button>
+      </Card>
+
+      <Dialog
+        description="Fenetre modale sans portail pour le banc UI."
+        id="ui-bench-dialog"
+        onClose={() => setDialogOpen(false)}
+        open={dialogOpen}
+        title="Minute du greffe"
+      >
+        <Toast title="Audience ouverte" tone="info">
+          Le greffier consigne, le moteur tranche.
+        </Toast>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/game/src/app/globals.css
+++ b/apps/game/src/app/globals.css
@@ -264,3 +264,13 @@ a {
     white-space: nowrap;
   }
 }
+
+.kw-ui-demo-stack {
+  display: grid;
+  gap: 12px;
+}
+
+.kw-ui-demo-copy {
+  margin: 0;
+  color: var(--color-text-muted);
+}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react';
+import { useId } from 'react';
+
+export type DialogProps = {
+  open: boolean;
+  title: ReactNode;
+  children: ReactNode;
+  id?: string;
+  description?: ReactNode;
+  closeLabel?: string;
+  onClose?: () => void;
+};
+
+export function Dialog({
+  open,
+  title,
+  description,
+  children,
+  id,
+  closeLabel = 'Fermer',
+  onClose
+}: DialogProps) {
+  const generatedId = useId();
+  const dialogId = id ?? generatedId;
+  const titleId = dialogId + '-title';
+  const descriptionId = description ? dialogId + '-description' : undefined;
+
+  if (!open) return null;
+
+  return (
+    <div className="kw-dialog" role="presentation">
+      <div
+        aria-describedby={descriptionId}
+        aria-labelledby={titleId}
+        aria-modal="true"
+        className="kw-dialog__panel"
+        role="dialog"
+      >
+        <div className="kw-dialog__header">
+          <h2 className="kw-dialog__title" id={titleId}>
+            {title}
+          </h2>
+          {onClose ? (
+            <button
+              aria-label={closeLabel}
+              className="kw-dialog__close"
+              onClick={onClose}
+              type="button"
+            >
+              X
+            </button>
+          ) : null}
+        </div>
+        {description ? (
+          <p className="kw-dialog__description" id={descriptionId}>
+            {description}
+          </p>
+        ) : null}
+        <div className="kw-dialog__body">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/dice-cluster.tsx
+++ b/packages/ui/src/components/dice-cluster.tsx
@@ -1,0 +1,21 @@
+import { Die, type DieKind } from './die.js';
+
+export type DiceClusterDie = {
+  value: number;
+  kind?: DieKind;
+};
+
+export type DiceClusterProps = {
+  dice: readonly DiceClusterDie[];
+  label?: string;
+};
+
+export function DiceCluster({ dice, label = 'Des' }: DiceClusterProps) {
+  return (
+    <div aria-label={label} className="kw-dice-cluster" role="group">
+      {dice.map((die, index) => (
+        <Die key={String(die.value) + '-' + index} kind={die.kind} value={die.value} />
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/field.tsx
+++ b/packages/ui/src/components/field.tsx
@@ -1,0 +1,40 @@
+import type { InputHTMLAttributes, ReactNode } from 'react';
+import { useId } from 'react';
+
+export type FieldProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'id'> & {
+  id?: string;
+  label: ReactNode;
+  hint?: ReactNode;
+  error?: ReactNode;
+};
+
+export function Field({ id, label, hint, error, className, ...props }: FieldProps) {
+  const generatedId = useId();
+  const inputId = id ?? generatedId;
+  const hintId = hint ? inputId + '-hint' : undefined;
+  const errorId = error ? inputId + '-error' : undefined;
+  const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <label className={['kw-field', className].filter(Boolean).join(' ')} htmlFor={inputId}>
+      <span className="kw-field__label">{label}</span>
+      <input
+        aria-describedby={describedBy}
+        aria-invalid={error ? true : undefined}
+        className="kw-field__control"
+        id={inputId}
+        {...props}
+      />
+      {hint ? (
+        <span className="kw-field__hint" id={hintId}>
+          {hint}
+        </span>
+      ) : null}
+      {error ? (
+        <span className="kw-field__error" id={errorId}>
+          {error}
+        </span>
+      ) : null}
+    </label>
+  );
+}

--- a/packages/ui/src/components/progress-bar.tsx
+++ b/packages/ui/src/components/progress-bar.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react';
+
+export type ProgressTone = 'neutral' | 'success' | 'warn' | 'danger' | 'info';
+
+export type ProgressBarProps = {
+  label: ReactNode;
+  value: number;
+  max?: number;
+  tone?: ProgressTone;
+  showValue?: boolean;
+};
+
+export function ProgressBar({
+  label,
+  value,
+  max = 100,
+  tone = 'neutral',
+  showValue = true
+}: ProgressBarProps) {
+  const safeMax = max > 0 ? max : 100;
+  const clampedValue = Math.min(Math.max(value, 0), safeMax);
+  const percent = Math.round((clampedValue / safeMax) * 100);
+
+  return (
+    <div className={'kw-progress kw-progress--' + tone}>
+      <div className="kw-progress__header">
+        <span className="kw-progress__label">{label}</span>
+        {showValue ? (
+          <span className="kw-progress__value">
+            {clampedValue}/{safeMax}
+          </span>
+        ) : null}
+      </div>
+      <div
+        aria-label={typeof label === 'string' ? label : undefined}
+        aria-valuemax={safeMax}
+        aria-valuemin={0}
+        aria-valuenow={clampedValue}
+        className="kw-progress__track"
+        role="progressbar"
+      >
+        <span className="kw-progress__bar" style={{ width: percent + '%' }} />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/select-field.tsx
+++ b/packages/ui/src/components/select-field.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode, SelectHTMLAttributes } from 'react';
+import { useId } from 'react';
+
+export type SelectOption = {
+  label: ReactNode;
+  value: string;
+  disabled?: boolean;
+};
+
+export type SelectFieldProps = Omit<SelectHTMLAttributes<HTMLSelectElement>, 'id'> & {
+  id?: string;
+  label: ReactNode;
+  hint?: ReactNode;
+  error?: ReactNode;
+  options: readonly SelectOption[];
+};
+
+export function SelectField({
+  id,
+  label,
+  hint,
+  error,
+  options,
+  className,
+  ...props
+}: SelectFieldProps) {
+  const generatedId = useId();
+  const selectId = id ?? generatedId;
+  const hintId = hint ? selectId + '-hint' : undefined;
+  const errorId = error ? selectId + '-error' : undefined;
+  const describedBy = [hintId, errorId].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <label className={['kw-field', className].filter(Boolean).join(' ')} htmlFor={selectId}>
+      <span className="kw-field__label">{label}</span>
+      <select
+        aria-describedby={describedBy}
+        aria-invalid={error ? true : undefined}
+        className="kw-field__control kw-field__select"
+        id={selectId}
+        {...props}
+      >
+        {options.map((option) => (
+          <option disabled={option.disabled} key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+      {hint ? (
+        <span className="kw-field__hint" id={hintId}>
+          {hint}
+        </span>
+      ) : null}
+      {error ? (
+        <span className="kw-field__error" id={errorId}>
+          {error}
+        </span>
+      ) : null}
+    </label>
+  );
+}

--- a/packages/ui/src/components/surface-components.test.ts
+++ b/packages/ui/src/components/surface-components.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DiceCluster,
+  Dialog,
+  Field,
+  ProgressBar,
+  SelectField,
+  Table,
+  Tabs,
+  TimelineDT,
+  Toast
+} from '../index';
+
+describe('surface component exports', () => {
+  it('exports all F3 surface primitives as functions', () => {
+    expect(Field).toBeTypeOf('function');
+    expect(SelectField).toBeTypeOf('function');
+    expect(Tabs).toBeTypeOf('function');
+    expect(Dialog).toBeTypeOf('function');
+    expect(Table).toBeTypeOf('function');
+    expect(Toast).toBeTypeOf('function');
+    expect(ProgressBar).toBeTypeOf('function');
+    expect(TimelineDT).toBeTypeOf('function');
+    expect(DiceCluster).toBeTypeOf('function');
+  });
+});

--- a/packages/ui/src/components/table.tsx
+++ b/packages/ui/src/components/table.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react';
+
+export type TableColumn<Row> = {
+  id: string;
+  header: ReactNode;
+  cell: (row: Row) => ReactNode;
+  align?: 'left' | 'center' | 'right';
+};
+
+export type TableProps<Row> = {
+  columns: readonly TableColumn<Row>[];
+  rows: readonly Row[];
+  getRowKey: (row: Row, index: number) => string;
+  caption?: ReactNode;
+};
+
+export function Table<Row>({ columns, rows, getRowKey, caption }: TableProps<Row>) {
+  return (
+    <div className="kw-table-wrap">
+      <table className="kw-table">
+        {caption ? <caption className="kw-table__caption">{caption}</caption> : null}
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th data-align={column.align ?? 'left'} key={column.id} scope="col">
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, rowIndex) => (
+            <tr key={getRowKey(row, rowIndex)}>
+              {columns.map((column) => (
+                <td data-align={column.align ?? 'left'} key={column.id}>
+                  {column.cell(row)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/ui/src/components/tabs.tsx
+++ b/packages/ui/src/components/tabs.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react';
+
+export type TabItem = {
+  id: string;
+  label: ReactNode;
+  panel: ReactNode;
+  disabled?: boolean;
+};
+
+export type TabsProps = {
+  items: readonly TabItem[];
+  activeId?: string;
+  label?: string;
+  onTabChange?: (id: string) => void;
+};
+
+export function Tabs({ items, activeId, label, onTabChange }: TabsProps) {
+  const selectedId = activeId ?? items.find((item) => !item.disabled)?.id ?? items[0]?.id;
+
+  return (
+    <div className="kw-tabs">
+      <div aria-label={label} className="kw-tabs__list" role="tablist">
+        {items.map((item) => {
+          const selected = item.id === selectedId;
+          const eventProps = onTabChange ? { onClick: () => onTabChange(item.id) } : undefined;
+
+          return (
+            <button
+              aria-controls={'kw-tab-panel-' + item.id}
+              aria-selected={selected}
+              className="kw-tabs__trigger"
+              disabled={item.disabled}
+              id={'kw-tab-' + item.id}
+              key={item.id}
+              role="tab"
+              tabIndex={selected ? 0 : -1}
+              type="button"
+              {...eventProps}
+            >
+              {item.label}
+            </button>
+          );
+        })}
+      </div>
+      {items.map((item) => {
+        const selected = item.id === selectedId;
+
+        return (
+          <div
+            aria-labelledby={'kw-tab-' + item.id}
+            className="kw-tabs__panel"
+            hidden={!selected}
+            id={'kw-tab-panel-' + item.id}
+            key={item.id}
+            role="tabpanel"
+            tabIndex={0}
+          >
+            {item.panel}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/ui/src/components/timeline-dt.tsx
+++ b/packages/ui/src/components/timeline-dt.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from 'react';
+
+export type TimelineDTItem = {
+  id: string;
+  dt: number;
+  label: ReactNode;
+  description?: ReactNode;
+  current?: boolean;
+  meta?: ReactNode;
+};
+
+export type TimelineDTProps = {
+  items: readonly TimelineDTItem[];
+  label?: string;
+};
+
+export function TimelineDT({ items, label = 'Timeline DT' }: TimelineDTProps) {
+  const sortedItems = [...items].sort((left, right) => left.dt - right.dt);
+
+  return (
+    <ol aria-label={label} className="kw-timeline-dt">
+      {sortedItems.map((item) => (
+        <li
+          className="kw-timeline-dt__item"
+          data-current={item.current ? true : undefined}
+          key={item.id}
+        >
+          <span className="kw-timeline-dt__dt">DT {item.dt}</span>
+          <span className="kw-timeline-dt__content">
+            <span className="kw-timeline-dt__label">{item.label}</span>
+            {item.description ? (
+              <span className="kw-timeline-dt__description">{item.description}</span>
+            ) : null}
+          </span>
+          {item.meta ? <span className="kw-timeline-dt__meta">{item.meta}</span> : null}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/packages/ui/src/components/toast.tsx
+++ b/packages/ui/src/components/toast.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+
+export type ToastTone = 'neutral' | 'success' | 'warn' | 'danger' | 'info';
+
+export type ToastProps = {
+  title: ReactNode;
+  children?: ReactNode;
+  tone?: ToastTone;
+};
+
+export function Toast({ title, children, tone = 'neutral' }: ToastProps) {
+  const role = tone === 'danger' || tone === 'warn' ? 'alert' : 'status';
+
+  return (
+    <div className={'kw-toast kw-toast--' + tone} role={role}>
+      <strong className="kw-toast__title">{title}</strong>
+      {children ? <span className="kw-toast__body">{children}</span> : null}
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,3 +5,13 @@ export * from './components/label.js';
 export * from './components/die.js';
 export * from './components/seal.js';
 export * from './components/statblock.js';
+
+export * from './components/field.js';
+export * from './components/select-field.js';
+export * from './components/tabs.js';
+export * from './components/dialog.js';
+export * from './components/table.js';
+export * from './components/toast.js';
+export * from './components/progress-bar.js';
+export * from './components/timeline-dt.js';
+export * from './components/dice-cluster.js';

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -144,3 +144,313 @@
   font-family: var(--font-display);
   font-size: 22px;
 }
+
+.kw-field {
+  display: grid;
+  gap: 6px;
+  color: var(--color-text-ink);
+}
+.kw-field__label,
+.kw-progress__label,
+.kw-table__caption,
+.kw-toast__title,
+.kw-timeline-dt__dt {
+  font-family: var(--font-label);
+  font-size: var(--text-label-sm);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+}
+.kw-field__control {
+  min-height: 42px;
+  width: 100%;
+  border: var(--border-hairline) solid var(--color-border-rule);
+  border-radius: var(--radius-rect);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-ink);
+  padding: 8px 10px;
+  font-family: var(--font-body);
+  box-shadow: var(--shadow-button) color-mix(in oklab, var(--color-text-ink) 12%, transparent);
+}
+.kw-field__control:hover {
+  border-color: var(--color-accent);
+}
+.kw-field__control:focus-visible {
+  outline: var(--border-strong) solid var(--color-accent);
+  outline-offset: 2px;
+}
+.kw-field__control[aria-invalid='true'] {
+  border-color: var(--color-fb-danger);
+}
+.kw-field__select {
+  cursor: pointer;
+}
+.kw-field__hint {
+  color: var(--color-text-muted);
+  font-size: var(--text-label-sm);
+}
+.kw-field__error {
+  color: var(--color-fb-danger);
+  font-size: var(--text-label-sm);
+  font-weight: 700;
+}
+
+.kw-tabs {
+  display: grid;
+  gap: 12px;
+}
+.kw-tabs__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  border-bottom: var(--border-hairline) solid var(--color-border-hairline);
+  padding-bottom: 6px;
+}
+.kw-tabs__trigger {
+  min-height: 40px;
+  border: var(--border-hairline) solid var(--color-border-hairline);
+  border-radius: var(--radius-rect);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  font-family: var(--font-label);
+  font-size: var(--text-label-sm);
+  letter-spacing: var(--tracking-label);
+  padding: 8px 12px;
+  text-transform: uppercase;
+}
+.kw-tabs__trigger:hover {
+  border-color: var(--color-accent);
+  color: var(--color-text-ink);
+}
+.kw-tabs__trigger:focus-visible {
+  outline: var(--border-strong) solid var(--color-accent);
+  outline-offset: 2px;
+}
+.kw-tabs__trigger[aria-selected='true'] {
+  border-color: var(--color-border-rule);
+  background: var(--color-text-ink);
+  color: var(--color-bg-canvas);
+}
+.kw-tabs__trigger:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.kw-tabs__panel {
+  border: var(--border-hairline) solid var(--color-border-hairline);
+  background: var(--color-bg-surface);
+  padding: 12px;
+}
+.kw-tabs__panel:focus-visible {
+  outline: var(--border-strong) solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.kw-dialog {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: grid;
+  place-items: center;
+  background: color-mix(in oklab, var(--color-text-ink) 42%, transparent);
+  padding: 16px;
+}
+.kw-dialog__panel {
+  width: min(100%, 560px);
+  border: var(--border-strong) solid var(--color-border-rule);
+  border-radius: var(--radius-rect);
+  background: var(--color-bg-surface);
+  color: var(--color-text-ink);
+  box-shadow: var(--shadow-card) color-mix(in oklab, var(--color-text-ink) 24%, transparent);
+  padding: 18px;
+}
+.kw-dialog__header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+}
+.kw-dialog__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--text-title-m);
+  line-height: var(--leading-tight);
+}
+.kw-dialog__description {
+  color: var(--color-text-muted);
+  margin: 8px 0 0;
+}
+.kw-dialog__body {
+  margin-top: 16px;
+}
+.kw-dialog__close {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: var(--border-hairline) solid var(--color-border-rule);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-ink);
+  cursor: pointer;
+  font-family: var(--font-label);
+}
+.kw-dialog__close:hover {
+  background: var(--color-accent);
+  color: var(--color-bg-canvas);
+}
+.kw-dialog__close:focus-visible {
+  outline: var(--border-strong) solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.kw-table-wrap {
+  overflow-x: auto;
+  border: var(--border-hairline) solid var(--color-border-rule);
+  background: var(--color-bg-surface);
+}
+.kw-table {
+  width: 100%;
+  border-collapse: collapse;
+  color: var(--color-text-ink);
+}
+.kw-table__caption {
+  color: var(--color-text-muted);
+  padding: 10px;
+  text-align: left;
+}
+.kw-table th,
+.kw-table td {
+  border-bottom: var(--border-hairline) solid var(--color-border-hairline);
+  padding: 10px;
+  vertical-align: top;
+}
+.kw-table th {
+  background: var(--color-bg-elevated);
+  color: var(--color-text-muted);
+  font-family: var(--font-label);
+  font-size: var(--text-label-sm);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+}
+.kw-table tr:last-child td {
+  border-bottom: 0;
+}
+.kw-table [data-align='center'] {
+  text-align: center;
+}
+.kw-table [data-align='right'] {
+  text-align: right;
+}
+
+.kw-toast {
+  display: grid;
+  gap: 4px;
+  border: var(--border-hairline) solid currentColor;
+  border-radius: var(--radius-rect);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-muted);
+  padding: 10px 12px;
+  box-shadow: var(--shadow-button) color-mix(in oklab, currentColor 24%, transparent);
+}
+.kw-toast--success {
+  color: var(--color-fb-success);
+}
+.kw-toast--warn {
+  color: var(--color-fb-warn);
+}
+.kw-toast--danger {
+  color: var(--color-fb-danger);
+}
+.kw-toast--info {
+  color: var(--color-fb-info);
+}
+.kw-toast__body {
+  color: var(--color-text-ink);
+}
+
+.kw-progress {
+  --kw-progress-color: var(--color-accent);
+  display: grid;
+  gap: 6px;
+}
+.kw-progress--success {
+  --kw-progress-color: var(--color-fb-success);
+}
+.kw-progress--warn {
+  --kw-progress-color: var(--color-fb-warn);
+}
+.kw-progress--danger {
+  --kw-progress-color: var(--color-fb-danger);
+}
+.kw-progress--info {
+  --kw-progress-color: var(--color-fb-info);
+}
+.kw-progress__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.kw-progress__label {
+  color: var(--color-text-muted);
+}
+.kw-progress__value {
+  color: var(--color-text-ink);
+  font-family: var(--font-mono);
+  font-size: var(--text-label-sm);
+}
+.kw-progress__track {
+  height: 10px;
+  border: var(--border-hairline) solid var(--color-border-rule);
+  background: var(--color-bg-elevated);
+  overflow: hidden;
+}
+.kw-progress__bar {
+  display: block;
+  height: 100%;
+  background: var(--kw-progress-color);
+}
+
+.kw-timeline-dt {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.kw-timeline-dt__item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 12px;
+  align-items: center;
+  border: var(--border-hairline) solid var(--color-border-hairline);
+  background: var(--color-bg-surface);
+  padding: 10px;
+}
+.kw-timeline-dt__item[data-current='true'] {
+  border-color: var(--color-border-rule);
+  background: color-mix(in oklab, var(--color-accent) 12%, var(--color-bg-surface));
+}
+.kw-timeline-dt__dt {
+  color: var(--color-accent);
+  font-family: var(--font-mono);
+  letter-spacing: 0;
+}
+.kw-timeline-dt__content {
+  display: grid;
+  gap: 2px;
+}
+.kw-timeline-dt__label {
+  font-weight: 700;
+}
+.kw-timeline-dt__description,
+.kw-timeline-dt__meta {
+  color: var(--color-text-muted);
+  font-size: var(--text-label-sm);
+}
+
+.kw-dice-cluster {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}


### PR DESCRIPTION
## Summary
- Adds the missing token-driven surface primitives to `@knightandwizard/ui`: fields/selects, tabs, dialog, table, toast, progress/vitality bar, DT timeline and dice clusters.
- Exports typed props through the UI barrel and keeps styling skin-neutral through CSS variables.
- Adds a rendered bench at `/design-proto/ui` to exercise the new components in the game shell.

Closes #95

## Validation
- `pnpm exec vitest run packages/ui/src/components/surface-components.test.ts`
- `pnpm --filter @knightandwizard/ui typecheck`
- `pnpm --filter @knightandwizard/game typecheck`
- `pnpm build:game`
- `pnpm lint && pnpm format:check && git diff --check`
- Playwright smoke on `/design-proto/ui` desktop/mobile + Jour/Veillee, modal ARIA and tab interaction
- `pnpm validate`
- `pnpm canonical:check:strict`
