### PR TITLE
feat(character): expose creation ambiguities

### DIFF
--- a/apps/game/src/features/character-creation/CharacterCreationWizard.tsx
+++ b/apps/game/src/features/character-creation/CharacterCreationWizard.tsx
@@ -213,6 +213,25 @@ export function CharacterCreationWizard({
         </div>
       </section>
 
+      {view.ambiguityNotices.length > 0 && (
+        <section
+          aria-label="Ambiguïtés catalogues"
+          className="rounded-md border border-gold/35 bg-gold/15 p-4 text-ink"
+        >
+          <h2 className="text-lg font-semibold text-ink">Ambiguïtés catalogues</h2>
+          <p className="mt-1 text-sm text-ink/68">
+            Ces valeurs proviennent des imports canoniques et restent à trancher en règle vivante.
+          </p>
+          <ul className="mt-3 grid gap-1 text-sm font-semibold text-ink">
+            {view.ambiguityNotices.map((notice) => (
+              <li key={`${notice.catalogName}-${notice.sourcePath}`}>
+                {notice.catalogName}: {notice.count} ambiguïtés · {notice.sourcePath}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
       <div className="grid gap-5 xl:grid-cols-[1.12fr_0.88fr]">
         <section className="rounded-md border border-ink/10 bg-white/78 p-5 shadow-sm">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">

--- a/apps/game/src/features/character-creation/model.test.ts
+++ b/apps/game/src/features/character-creation/model.test.ts
@@ -37,6 +37,29 @@ describe('character creation wizard model', () => {
     ]);
   });
 
+  it('keeps catalog ambiguity notices visible in the creation view', () => {
+    const sourceCatalog = {
+      ...catalog(),
+      ambiguityNotices: [
+        {
+          catalogName: 'Armes',
+          count: 8,
+          sourcePath: 'data/catalogs/armes-ambiguites.md'
+        }
+      ]
+    } as CharacterCreationCatalog;
+    const view = buildCreationView(createCreationDraft(sourceCatalog), sourceCatalog);
+
+    expect(view.ambiguityNotices).toEqual([
+      {
+        catalogName: 'Armes',
+        count: 8,
+        sourcePath: 'data/catalogs/armes-ambiguites.md'
+      }
+    ]);
+    expect(view.canSubmit).toBe(false);
+  });
+
   it('validates magician spell conversion against the skill and spell budgets', () => {
     const draft = withAttributes(
       setSpellPoints(
@@ -272,6 +295,7 @@ function catalog(): CharacterCreationCatalog {
   const humanMax = Object.fromEntries(ATTRIBUTE_KEYS.map((key) => [key, 6])) as CharacterAttributes;
 
   return {
+    ambiguityNotices: [],
     assets: [
       {
         id: 'human-adaptability',

--- a/apps/game/src/features/character-creation/model.ts
+++ b/apps/game/src/features/character-creation/model.ts
@@ -57,7 +57,14 @@ export interface CharacterCreationEquipmentOption {
   name: string;
 }
 
+export interface CharacterCreationAmbiguityNotice {
+  catalogName: string;
+  count: number;
+  sourcePath: string;
+}
+
 export interface CharacterCreationCatalog {
+  ambiguityNotices: CharacterCreationAmbiguityNotice[];
   assets: CharacterCreationAsset[];
   classes: CharacterClassProfile[];
   equipment: CharacterCreationEquipmentOption[];
@@ -119,6 +126,7 @@ export interface StepValidation {
 }
 
 export interface CharacterCreationView {
+  ambiguityNotices: CharacterCreationAmbiguityNotice[];
   attributeBudget: AttributeCreationBudget;
   availableClasses: CharacterClassProfile[];
   canSubmit: boolean;
@@ -207,6 +215,7 @@ export function buildCreationView(
   );
 
   return {
+    ambiguityNotices: [...catalog.ambiguityNotices],
     attributeBudget,
     availableClasses,
     canSubmit,

--- a/apps/game/src/features/character-creation/read-models.test.ts
+++ b/apps/game/src/features/character-creation/read-models.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/catalogs', () => ({ getCatalogDocument: vi.fn() }));
+
+import { buildCharacterCreationCatalogFromReadModels } from './read-models.js';
+
+describe('character creation read-models', () => {
+  it('exposes catalog ambiguity counts instead of silently resolving them', () => {
+    const catalog = buildCharacterCreationCatalogFromReadModels({
+      classes: { classes: [] },
+      orientations: { orientations: [] },
+      potions: { potions: [] },
+      protections: { metadata: { ambiguities_count: 4 }, armor_pieces: [], shields: [] },
+      races: { races: [] },
+      skills: { skills: [] },
+      spells: { spells: [] },
+      weapons: { metadata: { ambiguities_count: 8 }, weapons: [] }
+    });
+
+    expect(catalog.ambiguityNotices).toEqual([
+      {
+        catalogName: 'Armes',
+        count: 8,
+        sourcePath: 'data/catalogs/armes-ambiguites.md'
+      },
+      {
+        catalogName: 'Protections',
+        count: 4,
+        sourcePath: 'data/catalogs/protections.yaml'
+      }
+    ]);
+  });
+});

--- a/apps/game/src/features/character-creation/read-models.ts
+++ b/apps/game/src/features/character-creation/read-models.ts
@@ -11,6 +11,7 @@ import { getCatalogDocument } from '@/lib/catalogs';
 
 import {
   createCreationDraft,
+  type CharacterCreationAmbiguityNotice,
   type CharacterCreationCatalog,
   type CharacterCreationDraft
 } from './model';
@@ -93,6 +94,10 @@ export interface SpellEntry {
   status?: string;
 }
 
+export interface CatalogMetadata {
+  ambiguities_count?: number;
+}
+
 export interface EquipmentCatalogEntryDocument {
   id?: string;
   name?: string;
@@ -102,15 +107,18 @@ export interface EquipmentCatalogEntryDocument {
 }
 
 export interface WeaponsCatalogDocument {
+  metadata?: CatalogMetadata;
   weapons?: EquipmentCatalogEntryDocument[];
 }
 
 export interface ProtectionsCatalogDocument {
   armor_pieces?: EquipmentCatalogEntryDocument[];
+  metadata?: CatalogMetadata;
   shields?: EquipmentCatalogEntryDocument[];
 }
 
 export interface PotionsCatalogDocument {
+  metadata?: CatalogMetadata;
   potions?: EquipmentCatalogEntryDocument[];
 }
 
@@ -155,6 +163,23 @@ export function buildCharacterCreationCatalogFromReadModels(input: {
   const races = toRaceProfiles(input.races);
 
   return {
+    ambiguityNotices: toAmbiguityNotices([
+      {
+        catalogName: 'Armes',
+        metadata: input.weapons.metadata,
+        sourcePath: 'data/catalogs/armes-ambiguites.md'
+      },
+      {
+        catalogName: 'Protections',
+        metadata: input.protections.metadata,
+        sourcePath: 'data/catalogs/protections.yaml'
+      },
+      {
+        catalogName: 'Potions',
+        metadata: input.potions.metadata,
+        sourcePath: 'data/catalogs/potions.yaml'
+      }
+    ]),
     assets: toRaceAssets(input.races),
     classes: toClassProfiles(input.classes),
     equipment: toEquipmentOptions(input.weapons, input.protections, input.potions),
@@ -247,6 +272,18 @@ export function toEquipmentOptions(
     ...(protections.armor_pieces ?? []).map((entry) => toEquipmentOption(entry)),
     ...(potions.potions ?? []).map((entry) => toEquipmentOption(entry))
   ].filter((entry): entry is { id: string; name: string } => entry !== null);
+}
+
+function toAmbiguityNotices(
+  sources: Array<{ catalogName: string; metadata?: CatalogMetadata; sourcePath: string }>
+): CharacterCreationAmbiguityNotice[] {
+  return sources.flatMap((source) => {
+    const count = source.metadata?.ambiguities_count ?? 0;
+
+    return count > 0
+      ? [{ catalogName: source.catalogName, count, sourcePath: source.sourcePath }]
+      : [];
+  });
 }
 
 function toRaceAssets(catalog: RacesCatalogDocument) {

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -115,6 +115,10 @@ test.describe('K&W player and GM application flows', () => {
 
     await page.goto('/character/create');
 
+    await expect(page.getByRole('heading', { name: 'Ambiguïtés catalogues' })).toBeVisible();
+    await expect(page.getByText('Armes: 8 ambiguïtés')).toBeVisible();
+    await expect(page.getByText('Protections: 4 ambiguïtés')).toBeVisible();
+
     await page.getByLabel('Nom').fill(canonicalE2EFixtures.actors.avelineDraftName);
     await openCreationStep(page, 'Aptitudes');
     await increaseStepper(page, 'Force', 4);


### PR DESCRIPTION
## Summary
- Surfaces catalog import ambiguities in the character creation wizard instead of hiding inferred equipment values.
- Carries `ambiguityNotices` through the character creation read-model and view model from catalog metadata.
- Extends unit and E2E coverage for visible armes/protections ambiguity counts while preserving existing DB autosave and fighter/magician flows.

Closes #51

## Validation
- TDD red/green: `pnpm exec vitest run apps/game/src/features/character-creation/model.test.ts apps/game/src/features/character-creation/read-models.test.ts`
- TDD red/green: `E2E_GAME_PORT=3138 E2E_API_PORT=3144 pnpm exec playwright test tests/e2e/app-features.spec.ts -g "character creation"`
- `pnpm build:game`
- `pnpm lint && pnpm format:check && git diff --check`
- Browser smoke on `/character/create` desktop/mobile + Jour/Veillee, screenshots nonblank
- `pnpm validate`
- `pnpm canonical:check:strict`
