### PR TITLE
feat(sheet): adopt armorial ui surface

### DIFF
--- a/apps/game/src/app/character/page.tsx
+++ b/apps/game/src/app/character/page.tsx
@@ -1,7 +1,10 @@
-import { CharacterSheet } from '@/features/character-sheet/CharacterSheet';
-import { getCharacterSheetReadModel } from '@/features/character-sheet/read-models';
 import { UserPlus } from 'lucide-react';
 import Link from 'next/link';
+
+import { Card, Label } from '@knightandwizard/ui';
+
+import { CharacterSheet } from '@/features/character-sheet/CharacterSheet';
+import { getCharacterSheetReadModel } from '@/features/character-sheet/read-models';
 
 export const dynamic = 'force-dynamic';
 
@@ -9,20 +12,20 @@ export default async function CharacterPage() {
   const sheet = await getCharacterSheetReadModel();
 
   return (
-    <div className="grid gap-5">
-      <section className="flex flex-col gap-3 rounded-md border border-ink/10 bg-white/78 p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+    <div className="kw-character-page">
+      <Card className="kw-character-page__header">
         <div>
-          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-wine">Personnage</p>
-          <h1 className="mt-1 text-2xl font-semibold text-ink">Fiche active</h1>
+          <Label>Personnage</Label>
+          <h1>Fiche active</h1>
         </div>
         <Link
-          className="inline-flex min-h-11 items-center justify-center gap-2 rounded-md bg-ink px-4 text-sm font-semibold text-paper transition hover:bg-ink/88"
+          className="kw-btn kw-btn--secondary kw-character-page__create-link"
           href="/character/create"
         >
-          <UserPlus aria-hidden="true" className="size-4" />
+          <UserPlus aria-hidden="true" className="kw-character-page__icon" />
           Créer
         </Link>
-      </section>
+      </Card>
 
       <CharacterSheet
         attributeLabels={sheet.attributeLabels}

--- a/apps/game/src/app/globals.css
+++ b/apps/game/src/app/globals.css
@@ -528,3 +528,337 @@ a {
     grid-template-columns: 1fr;
   }
 }
+
+.kw-character-page,
+.kw-sheet,
+.kw-sheet__panel-body,
+.kw-sheet__row-list {
+  display: grid;
+  gap: 16px;
+}
+
+.kw-character-page h1,
+.kw-sheet h1,
+.kw-sheet h2,
+.kw-sheet h3,
+.kw-sheet p {
+  margin: 0;
+}
+
+.kw-character-page h1,
+.kw-sheet h1,
+.kw-sheet h2,
+.kw-sheet h3 {
+  color: var(--color-text-ink);
+  font-family: var(--font-display);
+  line-height: var(--leading-tight);
+}
+
+.kw-character-page h1,
+.kw-sheet h1 {
+  font-size: var(--text-title-l);
+}
+
+.kw-sheet h2 {
+  font-size: var(--text-title-m);
+}
+
+.kw-sheet h3 {
+  font-size: var(--text-body-l);
+}
+
+.kw-sheet p {
+  color: var(--color-text-muted);
+}
+
+.kw-character-page__header,
+.kw-sheet__hero,
+.kw-sheet__hero-head,
+.kw-sheet__panel-head,
+.kw-sheet__title-lockup,
+.kw-sheet__attribute-name,
+.kw-sheet__attribute-score,
+.kw-sheet__spell-row,
+.kw-sheet__skill-row,
+.kw-sheet__inventory-row,
+.kw-sheet__info-line,
+.kw-sheet__tab-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.kw-character-page__header,
+.kw-sheet__hero-head,
+.kw-sheet__panel-head {
+  justify-content: space-between;
+}
+
+.kw-character-page__header {
+  flex-direction: row;
+  align-items: center;
+}
+
+.kw-character-page__create-link,
+.kw-sheet .kw-btn {
+  display: inline-flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  text-decoration: none;
+}
+
+.kw-character-page__icon,
+.kw-sheet__button-icon,
+.kw-sheet__tab-icon,
+.kw-sheet__attribute-icon {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+}
+
+.kw-sheet__hero,
+.kw-sheet__panel {
+  min-width: 0;
+}
+
+.kw-sheet__title-lockup {
+  min-width: 0;
+  align-items: center;
+}
+
+.kw-sheet__hero .kw-seal {
+  flex: 0 0 auto;
+}
+
+.kw-sheet__hero h1 {
+  margin-top: 4px;
+}
+
+.kw-sheet__resources {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(180px, 1fr) minmax(240px, 0.9fr);
+  gap: 12px;
+}
+
+.kw-sheet__complete-grid,
+.kw-sheet__bottom-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.kw-sheet__split-grid,
+.kw-sheet__social-grid {
+  display: grid;
+  gap: 16px;
+  align-items: start;
+}
+
+.kw-sheet__split-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.kw-sheet__social-grid {
+  grid-template-columns: minmax(260px, 0.8fr) minmax(0, 1.2fr);
+}
+
+.kw-sheet__panel-head {
+  flex-wrap: wrap;
+}
+
+.kw-sheet__panel-action {
+  max-width: min(100%, 420px);
+}
+
+.kw-sheet__muted {
+  color: var(--color-text-muted);
+}
+
+.kw-sheet__attribute-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.kw-sheet__attribute-grid--social {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.kw-sheet__attribute-card {
+  display: grid;
+  min-width: 0;
+  gap: 12px;
+  border: var(--border-hairline) solid var(--color-border-hairline);
+  border-radius: var(--radius-rect);
+  background: var(--color-bg-elevated);
+  color: var(--color-text-ink);
+  cursor: pointer;
+  padding: 12px;
+  text-align: left;
+  transition:
+    border-color 120ms ease,
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.kw-sheet__attribute-card:hover {
+  border-color: var(--color-accent);
+  background: color-mix(in oklab, var(--color-accent) 10%, var(--color-bg-elevated));
+}
+
+.kw-sheet__attribute-card:focus-visible {
+  outline: var(--border-strong) solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.kw-sheet__attribute-card:active {
+  transform: translateY(2px);
+}
+
+.kw-sheet__attribute-name,
+.kw-sheet__attribute-score {
+  justify-content: space-between;
+}
+
+.kw-sheet__attribute-name {
+  color: var(--color-text-ink);
+  font-weight: 700;
+}
+
+.kw-sheet__attribute-score {
+  align-items: flex-end;
+}
+
+.kw-sheet__attribute-score span:last-child {
+  color: var(--color-text-muted);
+  font-family: var(--font-label);
+  font-size: var(--text-label-sm);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+}
+
+.kw-sheet__roll .kw-toast__body {
+  display: grid;
+  gap: 8px;
+}
+
+.kw-sheet__dice-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.kw-sheet__roll-outcome {
+  color: var(--color-text-ink);
+  font-family: var(--font-label);
+  font-size: var(--text-label-sm);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+}
+
+.kw-sheet__skill-row,
+.kw-sheet__spell-row,
+.kw-sheet__inventory-row,
+.kw-sheet__audit-row,
+.kw-sheet__info-line {
+  border: var(--border-hairline) solid var(--color-border-hairline);
+  background: var(--color-bg-elevated);
+  padding: 10px 12px;
+}
+
+.kw-sheet__skill-row,
+.kw-sheet__inventory-row,
+.kw-sheet__spell-row {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.kw-sheet__skill-row {
+  padding-left: calc(12px + var(--kw-sheet-depth, 0) * 20px);
+}
+
+.kw-sheet__skill-row[data-implicit='true'] {
+  opacity: 0.74;
+}
+
+.kw-sheet__inventory-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+}
+
+.kw-sheet__info-line {
+  display: grid;
+  gap: 8px;
+}
+
+.kw-sheet__audit-row {
+  color: var(--color-text-ink);
+  font-weight: 700;
+}
+
+.kw-sheet__inventory-tools {
+  display: grid;
+  grid-template-columns: minmax(190px, 1fr) auto;
+  gap: 10px;
+  align-items: end;
+}
+
+.kw-sheet__add-button,
+.kw-sheet__icon-button {
+  white-space: nowrap;
+}
+
+.kw-sheet__icon-button.kw-btn {
+  width: 42px;
+  padding: 0;
+}
+
+.kw-sheet .kw-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  white-space: nowrap;
+}
+
+.kw-sheet .kw-tabs__panel {
+  min-width: 0;
+}
+
+@media (max-width: 980px) {
+  .kw-sheet__resources,
+  .kw-sheet__complete-grid,
+  .kw-sheet__bottom-grid,
+  .kw-sheet__split-grid,
+  .kw-sheet__social-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 680px) {
+  .kw-character-page__header,
+  .kw-sheet__hero-head,
+  .kw-sheet__panel-head {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .kw-character-page__create-link,
+  .kw-sheet__panel-action,
+  .kw-sheet__inventory-tools {
+    width: 100%;
+  }
+
+  .kw-sheet__attribute-grid,
+  .kw-sheet__attribute-grid--social,
+  .kw-sheet__inventory-tools {
+    grid-template-columns: 1fr;
+  }
+
+  .kw-sheet__title-lockup {
+    align-items: flex-start;
+  }
+}

--- a/apps/game/src/features/character-sheet/CharacterSheet.tsx
+++ b/apps/game/src/features/character-sheet/CharacterSheet.tsx
@@ -1,9 +1,23 @@
 'use client';
 
 import { BookOpen, Dices, Minus, PackagePlus, Shield, Sparkles, UserCog } from 'lucide-react';
-import { useMemo, useState, type ReactNode } from 'react';
+import { useMemo, useState, type CSSProperties, type ReactNode } from 'react';
 
 import { type AttributeKey, type Character } from '@knightandwizard/rules-core';
+import {
+  Badge,
+  Button,
+  Card,
+  Die,
+  Label,
+  ProgressBar,
+  Seal,
+  SelectField,
+  StatBlock,
+  Tabs,
+  Toast,
+  type ToastTone
+} from '@knightandwizard/ui';
 
 import {
   addInventoryItem,
@@ -18,6 +32,7 @@ import {
   type EquipmentCatalogEntry,
   type InventoryItem,
   type SkillCatalogEntry,
+  type SkillTreeRow,
   type SpellEntry
 } from './model';
 
@@ -97,394 +112,442 @@ export function CharacterSheet({
     );
   }
 
-  return (
-    <div className="grid gap-5">
-      <section className="rounded-md border border-ink/10 bg-white/78 p-5 shadow-sm">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <div>
-            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-wine">Fiche PJ</p>
-            <h1 className="mt-1 text-3xl font-semibold text-ink">{character.name}</h1>
-            <p className="mt-2 text-sm text-ink/62">
-              {character.race.name} · {character.orientation.name} · {character.classProfile.name}
-            </p>
-          </div>
-          <div className="grid grid-cols-4 gap-1 rounded-md bg-vellum/70 p-1">
-            {modes.map((item) => {
-              const Icon = modeIcons[item.id];
-              const active = item.id === mode;
+  const tabItems = modes.map((item) => {
+    const Icon = modeIcons[item.id];
 
-              return (
-                <button
-                  className={[
-                    'flex min-h-11 items-center justify-center gap-2 rounded-md px-3 text-sm font-semibold transition',
-                    active
-                      ? 'bg-ink text-paper shadow-sm'
-                      : 'text-ink/66 hover:bg-paper hover:text-ink'
-                  ].join(' ')}
+    return {
+      id: item.id,
+      label: (
+        <span className="kw-sheet__tab-label">
+          <Icon aria-hidden="true" className="kw-sheet__tab-icon" />
+          {item.label}
+        </span>
+      ),
+      panel: item.id === mode ? renderModePanel(item.id) : null
+    };
+  });
+
+  function renderModePanel(panelMode: CharacterSheetMode): ReactNode {
+    switch (panelMode) {
+      case 'combat':
+        return (
+          <div className="kw-sheet__split-grid">
+            <SectionCard title="Armes équipées">
+              {view.equippedWeapons.map((item) => (
+                <InventoryRow
+                  item={item}
                   key={item.id}
-                  onClick={() => setMode(item.id)}
-                  type="button"
-                >
-                  <Icon aria-hidden="true" className="size-4" />
-                  <span className="hidden sm:inline">{item.label}</span>
-                </button>
-              );
-            })}
+                  onRemove={() => setInventory((current) => removeInventoryItem(current, item.id))}
+                />
+              ))}
+            </SectionCard>
+            <SectionCard title="Sorts actifs">
+              {spells
+                .filter((spell) => spell.active)
+                .map((spell) => (
+                  <div className="kw-sheet__spell-row" key={spell.id}>
+                    <div>
+                      <h3>{spell.name}</h3>
+                      <p>{spell.points} point de sort</p>
+                    </div>
+                    <Badge tone="info">Actif</Badge>
+                  </div>
+                ))}
+            </SectionCard>
           </div>
-        </div>
-
-        <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          <Resource
-            label="Vitalité"
-            value={character.vitality.current}
-            max={character.vitality.max}
-          />
-          <Resource label="Énergie" value={character.energy.current} max={character.energy.max} />
-          <Metric label="Facteur vitesse" value={character.speedFactor} />
-          <Metric label="Facteur volonté" value={character.willFactor} />
-        </div>
-      </section>
-
-      {mode === 'complete' && (
-        <div className="grid gap-5 xl:grid-cols-[1.05fr_0.95fr]">
-          <section className="rounded-md border border-ink/10 bg-white/78 p-5 shadow-sm">
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <h2 className="text-xl font-semibold text-ink">9 aptitudes</h2>
-                <p className="text-sm text-ink/58">
-                  Total création {attributeTotal}/{character.race.category}
-                </p>
+        );
+      case 'social':
+        return (
+          <div className="kw-sheet__social-grid">
+            <SectionCard title="Attributs sociaux">
+              <div className="kw-sheet__attribute-grid kw-sheet__attribute-grid--social">
+                {socialAttributeKeys.map((attribute) => (
+                  <AttributeButton
+                    attribute={attribute}
+                    baseValue={character.attributes[attribute]}
+                    effectiveValue={view.attributes[attribute]}
+                    key={attribute}
+                    label={attributeLabels[attribute]}
+                    onRoll={() => roll(attribute)}
+                  />
+                ))}
               </div>
-              {lastRoll && (
-                <div
-                  className="rounded-md bg-forest px-3 py-2 text-right text-paper"
-                  data-testid="last-roll"
-                >
-                  <p className="text-xs font-semibold uppercase tracking-[0.14em] text-paper/70">
-                    Dernier jet
-                  </p>
-                  <p className="font-mono text-sm">
-                    {attributeLabels[lastRoll.attribute]} · {lastRoll.pool}D · DT{' '}
-                    {lastRoll.difficulty} · {lastRoll.successes} succès
-                  </p>
-                  {attributeRollOutcomeLabels(lastRoll).map((label) => (
-                    <p
-                      className="font-mono text-xs uppercase tracking-[0.14em] text-paper/85"
-                      data-testid={label.testId}
-                      key={label.id}
-                    >
-                      {label.label}
-                    </p>
-                  ))}
+            </SectionCard>
+            <SectionCard title="Réputation et relations">
+              <InfoLine label="Réputation" value={String(character.metadata.reputation)} />
+              <InfoLine label="Divinité" value={String(character.metadata.deity)} />
+              <InfoLine label="Citation" value={String(character.metadata.quote)} />
+            </SectionCard>
+          </div>
+        );
+      case 'gm':
+        return (
+          <div className="kw-sheet__split-grid">
+            <SectionCard title="Audit complet">
+              {view.sections.map((section) => (
+                <div className="kw-sheet__audit-row" key={section.id}>
+                  {section.label}
                 </div>
+              ))}
+            </SectionCard>
+            <SectionCard title="Notes privées MJ">
+              <InfoLine label="MJ" value={String(character.metadata.gmNotes)} />
+            </SectionCard>
+          </div>
+        );
+      case 'complete':
+      default:
+        return (
+          <div className="kw-sheet__complete-grid">
+            <SectionCard
+              action={
+                lastRoll ? (
+                  <RollResult attributeLabels={attributeLabels} result={lastRoll} />
+                ) : undefined
+              }
+              title="9 aptitudes"
+            >
+              <p className="kw-sheet__muted">
+                Total création {attributeTotal}/{character.race.category}
+              </p>
+              <div className="kw-sheet__attribute-grid">
+                {attributeOrder.map((attribute) => (
+                  <AttributeButton
+                    attribute={attribute}
+                    baseValue={character.attributes[attribute]}
+                    effectiveValue={view.attributes[attribute]}
+                    key={attribute}
+                    label={attributeLabels[attribute]}
+                    onRoll={() => roll(attribute)}
+                  />
+                ))}
+              </div>
+            </SectionCard>
+
+            <SectionCard
+              action={
+                <Badge tone="info">
+                  Niveau {view.levelProgression.level ?? 'NA'} ·{' '}
+                  {view.levelProgression.levelPoints ?? 'NA'} /{' '}
+                  {view.levelProgression.levelUpAt ?? 'NA'} points
+                </Badge>
+              }
+              title="Compétences"
+            >
+              <p className="kw-sheet__muted">
+                Points {view.creationBudget.skillPointsSpent}/{view.creationBudget.skillPointLimit}
+                {view.creationBudget.convertedSkillPoints > 0 &&
+                  ` · ${view.creationBudget.convertedSkillPoints} convertis en sorts`}
+              </p>
+              <p className="kw-sheet__muted">
+                Catalogue implicite : {skills.length} entrées, {trainedSkillCount} notées sur la
+                fiche.
+              </p>
+              {character.orientation.isMagical && (
+                <Toast title="Magicien" tone="info">
+                  Pas de compétence primaire mécanique, les sorts comptent double en progression.
+                </Toast>
               )}
-            </div>
-            <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-              {attributeOrder.map((attribute) => (
-                <button
-                  className="rounded-md border border-ink/10 bg-paper p-4 text-left shadow-sm transition hover:border-wine/30 hover:bg-vellum"
-                  key={attribute}
-                  onClick={() => roll(attribute)}
-                  type="button"
-                >
-                  <div className="flex items-center justify-between gap-3">
-                    <span className="text-sm font-semibold text-ink">
-                      {attributeLabels[attribute]}
-                    </span>
-                    <Dices aria-hidden="true" className="size-4 text-wine" />
-                  </div>
-                  <div className="mt-3 flex items-end justify-between gap-3">
-                    <span className="text-3xl font-semibold text-ink">
-                      {view.attributes[attribute]}
-                    </span>
-                    <span className="text-xs font-medium uppercase tracking-[0.12em] text-ink/50">
-                      base {character.attributes[attribute]}
-                    </span>
-                  </div>
-                </button>
-              ))}
-            </div>
-          </section>
+              <SkillTreeRows skills={skills} skillLabels={skillLabels} />
+            </SectionCard>
+          </div>
+        );
+    }
+  }
 
-          <section className="rounded-md border border-ink/10 bg-white/78 p-5 shadow-sm">
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <h2 className="text-xl font-semibold text-ink">Compétences</h2>
-                <p className="text-sm text-ink/58">
-                  Points {view.creationBudget.skillPointsSpent}/
-                  {view.creationBudget.skillPointLimit}
-                  {view.creationBudget.convertedSkillPoints > 0 &&
-                    ` · ${view.creationBudget.convertedSkillPoints} convertis en sorts`}
-                </p>
-                <p className="mt-1 text-sm text-ink/58">
-                  Catalogue implicite : {skills.length} entrées, {trainedSkillCount} notées sur la
-                  fiche.
-                </p>
-                {character.orientation.isMagical && (
-                  <p className="mt-1 text-sm text-wine">
-                    Magicien : pas de compétence primaire mécanique, les sorts comptent double en
-                    progression.
-                  </p>
-                )}
-              </div>
-              <span className="rounded-md bg-gold px-3 py-2 text-sm font-semibold text-ink">
-                Niveau {view.levelProgression.level ?? 'NA'} ·{' '}
-                {view.levelProgression.levelPoints ?? 'NA'} /{' '}
-                {view.levelProgression.levelUpAt ?? 'NA'} points
-              </span>
+  return (
+    <div className="kw-sheet">
+      <Card className="kw-sheet__hero">
+        <div className="kw-sheet__hero-head">
+          <div className="kw-sheet__title-lockup">
+            <Seal>PJ</Seal>
+            <div>
+              <Label>Fiche PJ</Label>
+              <h1>{character.name}</h1>
+              <p>
+                {character.race.name} · {character.orientation.name} · {character.classProfile.name}
+              </p>
             </div>
-            <div className="mt-4 grid gap-3">
-              {skills.map((skill) => (
-                <div
-                  className={[
-                    'grid grid-cols-[1fr_auto] items-center gap-3 rounded-md bg-paper p-3',
-                    skill.isImplicitZero ? 'opacity-70' : ''
-                  ].join(' ')}
-                  key={skill.id}
-                  style={{ marginLeft: `${skill.depth * 1.25}rem` }}
-                >
-                  <div>
-                    <p className="font-semibold text-ink">
-                      {skill.depth > 0 && <span className="text-ink/36">└ </span>}
-                      {skill.label ?? skillLabels[skill.id] ?? skill.id}
-                    </p>
-                    <p className="text-sm text-ink/56">
-                      {skill.isImplicitZero
-                        ? skill.parentId
-                          ? 'Spécialisation implicite à 0'
-                          : 'Compétence implicite à 0'
-                        : skill.isMain
-                          ? 'Compétence primaire'
-                          : skill.isInheritedPrimary
-                            ? 'Spécialisation héritée primaire'
-                            : skill.implicitParentId
-                              ? `Spécialisation, parent implicite à 0 (${skill.implicitParentId})`
-                              : skill.parentId
-                                ? 'Spécialisation'
-                                : 'Compétence'}
-                    </p>
-                  </div>
-                  <span className="rounded-md bg-ink px-3 py-2 font-mono text-sm font-semibold text-paper">
-                    {skill.points} {skill.points > 1 ? 'pts' : 'pt'}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </section>
+          </div>
+          <Badge tone="neutral">Skin armorial</Badge>
         </div>
-      )}
 
-      {mode === 'combat' && (
-        <div className="grid gap-5 lg:grid-cols-2">
-          <Panel title="Armes équipées">
-            {view.equippedWeapons.map((item) => (
-              <InventoryRow
-                item={item}
-                key={item.id}
-                onRemove={() => setInventory(removeInventoryItem(inventory, item.id))}
-              />
-            ))}
-          </Panel>
-          <Panel title="Sorts actifs">
-            {spells
-              .filter((spell) => spell.active)
-              .map((spell) => (
-                <div className="rounded-md bg-paper p-3" key={spell.id}>
-                  <p className="font-semibold text-ink">{spell.name}</p>
-                  <p className="text-sm text-ink/58">{spell.points} point de sort</p>
-                </div>
-              ))}
-          </Panel>
+        <div className="kw-sheet__resources" aria-label="Ressources personnage">
+          <ProgressBar
+            label="Vitalité"
+            max={character.vitality.max}
+            tone="danger"
+            value={character.vitality.current}
+          />
+          <ProgressBar
+            label="Énergie"
+            max={character.energy.max}
+            tone="info"
+            value={character.energy.current}
+          />
+          <StatBlock
+            items={[
+              { label: 'Facteur vitesse', value: character.speedFactor },
+              { label: 'Facteur volonté', value: character.willFactor }
+            ]}
+          />
         </div>
-      )}
+      </Card>
 
-      {mode === 'social' && (
-        <div className="grid gap-5 lg:grid-cols-[0.8fr_1.2fr]">
-          <Panel title="Attributs sociaux">
-            <div className="grid gap-3 sm:grid-cols-3">
-              {socialAttributeKeys.map((attribute) => (
-                <button
-                  className="rounded-md bg-paper p-4 text-left"
-                  key={attribute}
-                  onClick={() => roll(attribute)}
-                  type="button"
-                >
-                  <p className="text-sm font-semibold text-ink/64">{attributeLabels[attribute]}</p>
-                  <p className="mt-2 text-3xl font-semibold text-ink">
-                    {view.attributes[attribute]}
-                  </p>
-                </button>
-              ))}
-            </div>
-          </Panel>
-          <Panel title="Réputation et relations">
-            <p className="rounded-md bg-paper p-3 text-sm leading-6 text-ink/72">
-              {String(character.metadata.reputation)}
-            </p>
-            <p className="rounded-md bg-paper p-3 text-sm leading-6 text-ink/72">
-              Divinité : {String(character.metadata.deity)}
-            </p>
-            <p className="rounded-md bg-paper p-3 text-sm leading-6 text-ink/72">
-              Citation : {String(character.metadata.quote)}
-            </p>
-          </Panel>
-        </div>
-      )}
+      <Tabs
+        activeId={mode}
+        items={tabItems}
+        label="Modes fiche"
+        onTabChange={(nextMode) => setMode(nextMode as CharacterSheetMode)}
+      />
 
-      {mode === 'gm' && (
-        <div className="grid gap-5 lg:grid-cols-2">
-          <Panel title="Audit complet">
-            {view.sections.map((section) => (
-              <div
-                className="rounded-md bg-paper p-3 text-sm font-medium text-ink"
-                key={section.id}
-              >
-                {section.label}
-              </div>
-            ))}
-          </Panel>
-          <Panel title="Notes privées MJ">
-            <p className="rounded-md bg-paper p-3 text-sm leading-6 text-ink/72">
-              {String(character.metadata.gmNotes)}
-            </p>
-          </Panel>
-        </div>
-      )}
-
-      <div className="grid gap-5 lg:grid-cols-[1fr_0.85fr]">
-        <Panel
+      <div className="kw-sheet__bottom-grid">
+        <SectionCard
           action={
             equipmentCatalog.length > 0 ? (
-              <div className="flex items-center gap-2">
-                <label className="sr-only" htmlFor="equipment-picker">
-                  Équipement du catalogue
-                </label>
-                <select
-                  className="min-h-10 rounded-md border border-ink/15 bg-paper px-2 text-sm text-ink"
+              <div className="kw-sheet__inventory-tools">
+                <SelectField
                   id="equipment-picker"
+                  label="Équipement du catalogue"
                   onChange={(event) => setSelectedEquipmentId(event.target.value)}
+                  options={equipmentCatalog.map((option) => ({
+                    label: option.name,
+                    value: option.id
+                  }))}
                   value={selectedEquipmentId}
-                >
-                  {equipmentCatalog.map((option) => (
-                    <option key={option.id} value={option.id}>
-                      {option.name}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  className="inline-flex min-h-10 items-center gap-2 rounded-md bg-forest px-3 text-sm font-semibold text-paper"
+                />
+                <Button
+                  className="kw-sheet__add-button"
                   onClick={() => addEquipment(selectedEquipmentId)}
                   type="button"
                 >
-                  <PackagePlus aria-hidden="true" className="size-4" />
+                  <PackagePlus aria-hidden="true" className="kw-sheet__button-icon" />
                   Ajouter
-                </button>
+                </Button>
               </div>
             ) : undefined
           }
           title="Inventaire"
         >
-          <p className="text-sm text-ink/58">Charge {view.carriedWeightKg} kg</p>
-          {inventory.map((item) => (
-            <InventoryRow
-              item={item}
-              key={item.id}
-              onRemove={() => setInventory(removeInventoryItem(inventory, item.id))}
-            />
-          ))}
-        </Panel>
-
-        <Panel title="Grimoire">
-          <div className="grid grid-cols-3 gap-3">
-            <Metric label="Sorts" value={view.spellSummary.knownSpells} />
-            <Metric label="Points" value={view.spellSummary.pointsCommitted} />
-            <Metric label="Énergie" value={view.spellSummary.energyAvailable} />
+          <p className="kw-sheet__muted">Charge {view.carriedWeightKg} kg</p>
+          <div className="kw-sheet__row-list">
+            {inventory.map((item) => (
+              <InventoryRow
+                item={item}
+                key={item.id}
+                onRemove={() => setInventory((current) => removeInventoryItem(current, item.id))}
+              />
+            ))}
           </div>
+        </SectionCard>
+
+        <SectionCard title="Grimoire">
+          <StatBlock
+            items={[
+              { label: 'Sorts', value: view.spellSummary.knownSpells },
+              { label: 'Points', value: view.spellSummary.pointsCommitted },
+              { label: 'Énergie', value: view.spellSummary.energyAvailable }
+            ]}
+          />
           {character.orientation.isMagical && (
-            <p className="rounded-md bg-vellum/70 p-3 text-sm leading-6 text-ink/72">
-              Création : {view.creationBudget.spellPoints} points de sort ={' '}
-              {view.creationBudget.freeSpellPoints} gratuits +{' '}
-              {view.creationBudget.extraSpellPoints} achetés.
-            </p>
+            <InfoLine
+              label="Création"
+              value={`${view.creationBudget.spellPoints} points de sort = ${view.creationBudget.freeSpellPoints} gratuits + ${view.creationBudget.extraSpellPoints} achetés.`}
+            />
           )}
-          {spells.map((spell) => (
-            <div className="rounded-md bg-paper p-3" key={spell.id}>
-              <div className="flex items-center justify-between gap-3">
-                <p className="font-semibold text-ink">{spell.name}</p>
-                <span className="rounded-md bg-vellum px-2 py-1 text-xs font-semibold text-ink">
-                  {spell.points} pt
-                </span>
+          <div className="kw-sheet__row-list">
+            {spells.map((spell) => (
+              <div className="kw-sheet__spell-row" key={spell.id}>
+                <div>
+                  <h3>{spell.name}</h3>
+                  <p>{spell.active ? 'Actif' : 'Disponible'}</p>
+                </div>
+                <Badge tone={spell.active ? 'info' : 'neutral'}>{spell.points} pt</Badge>
               </div>
-              <p className="mt-1 text-sm text-ink/58">{spell.active ? 'Actif' : 'Disponible'}</p>
-            </div>
-          ))}
-        </Panel>
+            ))}
+          </div>
+        </SectionCard>
       </div>
     </div>
   );
 }
 
-function Panel({
+function SectionCard({
   action,
   children,
   title
 }: Readonly<{ action?: ReactNode; children: ReactNode; title: string }>) {
   return (
-    <section className="rounded-md border border-ink/10 bg-white/78 p-5 shadow-sm">
-      <div className="mb-4 flex items-center justify-between gap-3">
-        <h2 className="text-xl font-semibold text-ink">{title}</h2>
-        {action}
+    <Card className="kw-sheet__panel">
+      <div className="kw-sheet__panel-head">
+        <h2>{title}</h2>
+        {action ? <div className="kw-sheet__panel-action">{action}</div> : null}
       </div>
-      <div className="grid gap-3">{children}</div>
-    </section>
+      <div className="kw-sheet__panel-body">{children}</div>
+    </Card>
   );
 }
 
-function Resource({ label, max, value }: Readonly<{ label: string; max: number; value: number }>) {
-  const percent = max === 0 ? 0 : Math.round((value / max) * 100);
+function AttributeButton({
+  baseValue,
+  effectiveValue,
+  label,
+  onRoll
+}: Readonly<{
+  attribute: AttributeKey;
+  baseValue: number;
+  effectiveValue: number;
+  label: string;
+  onRoll: () => void;
+}>) {
+  return (
+    <button className="kw-sheet__attribute-card" onClick={onRoll} type="button">
+      <span className="kw-sheet__attribute-name">
+        {label}
+        <Dices aria-hidden="true" className="kw-sheet__attribute-icon" />
+      </span>
+      <span className="kw-sheet__attribute-score">
+        <Die kind={effectiveValue <= 0 ? 'one' : 'plain'} value={effectiveValue} />
+        <span>base {baseValue}</span>
+      </span>
+    </button>
+  );
+}
+
+function RollResult({
+  attributeLabels,
+  result
+}: Readonly<{
+  attributeLabels: Record<AttributeKey, string>;
+  result: AttributeRollResult;
+}>) {
+  const tone: ToastTone =
+    result.pool === 0 || result.isCriticalFailure
+      ? 'danger'
+      : result.isCriticalSuccess
+        ? 'success'
+        : 'info';
 
   return (
-    <div className="rounded-md bg-vellum/70 p-3">
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-sm font-medium text-ink/58">{label}</p>
-        <p className="font-mono text-sm font-semibold text-ink">
-          {value}/{max}
-        </p>
-      </div>
-      <div className="mt-3 h-2 rounded-full bg-ink/10">
-        <div className="h-2 rounded-full bg-wine" style={{ width: `${percent}%` }} />
-      </div>
+    <div className="kw-sheet__roll" data-testid="last-roll">
+      <Toast title="Dernier jet" tone={tone}>
+        <span>
+          {attributeLabels[result.attribute]} · {result.pool}D · DT {result.difficulty} ·{' '}
+          {result.successes} succès
+        </span>
+        {result.rolls.length > 0 ? (
+          <span className="kw-sheet__dice-row" aria-label="Dés lancés">
+            {result.rolls.map((value, index) => (
+              <Die
+                kind={dieKindForRoll(value, result.difficulty)}
+                key={`${value}-${index}`}
+                value={value}
+              />
+            ))}
+          </span>
+        ) : null}
+        {attributeRollOutcomeLabels(result).map((label) => (
+          <span className="kw-sheet__roll-outcome" data-testid={label.testId} key={label.id}>
+            {label.label}
+          </span>
+        ))}
+      </Toast>
     </div>
   );
 }
 
-function Metric({ label, value }: Readonly<{ label: string; value: number | string }>) {
+function SkillTreeRows({
+  skillLabels,
+  skills
+}: Readonly<{
+  skillLabels: Record<string, string>;
+  skills: SkillTreeRow[];
+}>) {
   return (
-    <div className="rounded-md bg-vellum/70 p-3">
-      <p className="text-xs font-semibold uppercase tracking-[0.14em] text-ink/52">{label}</p>
-      <p className="mt-1 text-2xl font-semibold text-ink">{value}</p>
+    <div className="kw-sheet__row-list">
+      {skills.map((skill) => (
+        <div
+          className="kw-sheet__skill-row"
+          data-implicit={skill.isImplicitZero ? 'true' : undefined}
+          key={skill.id}
+          style={{ '--kw-sheet-depth': skill.depth } as CSSProperties}
+        >
+          <div>
+            <h3>
+              {skill.depth > 0 && <span aria-hidden="true">↪ </span>}
+              {skill.label ?? skillLabels[skill.id] ?? skill.id}
+            </h3>
+            <p>{skillDescription(skill)}</p>
+          </div>
+          <Badge tone={skill.isImplicitZero ? 'neutral' : 'success'}>
+            {skill.points} {skill.points > 1 ? 'pts' : 'pt'}
+          </Badge>
+        </div>
+      ))}
     </div>
   );
 }
 
 function InventoryRow({ item, onRemove }: Readonly<{ item: InventoryItem; onRemove: () => void }>) {
   return (
-    <div className="grid grid-cols-[1fr_auto_auto] items-center gap-3 rounded-md bg-paper p-3">
+    <div className="kw-sheet__inventory-row">
       <div>
-        <p className="font-semibold text-ink">{item.name}</p>
-        <p className="text-sm text-ink/56">
+        <h3>{item.name}</h3>
+        <p>
           {item.equipped ? 'Équipé' : item.category} · {item.weightKg ?? 0} kg
         </p>
       </div>
-      <span className="font-mono text-sm font-semibold text-ink">x{item.quantity}</span>
-      <button
+      <Badge tone={item.equipped ? 'info' : 'neutral'}>x{item.quantity}</Badge>
+      <Button
         aria-label={`Retirer ${item.name}`}
-        className="grid size-9 place-items-center rounded-md bg-vellum text-ink transition hover:bg-wine hover:text-paper"
+        className="kw-sheet__icon-button"
         onClick={onRemove}
         type="button"
+        variant="secondary"
       >
-        <Minus aria-hidden="true" className="size-4" />
-      </button>
+        <Minus aria-hidden="true" className="kw-sheet__button-icon" />
+      </Button>
     </div>
   );
+}
+
+function InfoLine({ label, value }: Readonly<{ label: string; value: string }>) {
+  return (
+    <div className="kw-sheet__info-line">
+      <Badge tone="neutral">{label}</Badge>
+      <p>{value}</p>
+    </div>
+  );
+}
+
+function skillDescription(skill: SkillTreeRow): string {
+  if (skill.isImplicitZero) {
+    return skill.parentId ? 'Spécialisation implicite à 0' : 'Compétence implicite à 0';
+  }
+
+  if (skill.isMain) {
+    return 'Compétence primaire';
+  }
+
+  if (skill.isInheritedPrimary) {
+    return 'Spécialisation héritée primaire';
+  }
+
+  if (skill.implicitParentId) {
+    return `Spécialisation, parent implicite à 0 (${skill.implicitParentId})`;
+  }
+
+  return skill.parentId ? 'Spécialisation' : 'Compétence';
+}
+
+function dieKindForRoll(value: number, difficulty: number) {
+  if (value === 1) {
+    return 'one';
+  }
+
+  if (value === 10) {
+    return 'critical';
+  }
+
+  return value >= difficulty ? 'success' : 'plain';
 }

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -65,6 +65,10 @@ test.describe('K&W player and GM application flows', () => {
 
     await page.goto('/character');
 
+    await expect(page.locator('html')).toHaveAttribute('data-skin', 'armorial');
+    await expect(page.getByRole('tablist', { name: 'Modes fiche' })).toBeVisible();
+    await expect(page.getByRole('progressbar', { name: 'Vitalité' })).toBeVisible();
+    await expect(page.getByRole('progressbar', { name: 'Énergie' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Fiche active' })).toBeVisible();
     await expect(page.getByRole('heading', { name: '9 aptitudes' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Compétences' })).toBeVisible();
@@ -89,23 +93,26 @@ test.describe('K&W player and GM application flows', () => {
       'Échec critique · D100 = 73'
     );
 
-    await page.getByRole('button', { name: 'Combat' }).click();
-    await expect(page.getByRole('heading', { name: 'Armes équipées' })).toBeVisible();
-    await expect(page.getByText('Bouclier').first()).toBeVisible();
+    await page.getByRole('tab', { name: 'Combat' }).click();
+    const combatPanel = page.getByRole('tabpanel', { name: 'Combat' });
+    await expect(combatPanel.getByRole('heading', { name: 'Armes équipées' })).toBeVisible();
+    await expect(combatPanel.getByText('Bouclier').first()).toBeVisible();
 
-    await page.getByRole('button', { name: 'Social' }).click();
+    await page.getByRole('tab', { name: 'Social' }).click();
     await expect(page.getByRole('heading', { name: 'Attributs sociaux' })).toBeVisible();
 
-    await page.getByRole('button', { name: 'MJ' }).click();
+    await page.getByRole('tab', { name: 'MJ' }).click();
     await expect(page.getByRole('heading', { name: 'Audit complet' })).toBeVisible();
 
-    await page.getByRole('button', { name: 'Complet' }).click();
+    await page.getByRole('tab', { name: 'Complet' }).click();
     const equipmentPicker = page.locator('#equipment-picker');
     await expect(equipmentPicker).toBeVisible();
     expect(await equipmentPicker.locator('option').count()).toBeGreaterThan(0);
     await equipmentPicker.selectOption({ index: 0 });
     await page.getByRole('button', { name: 'Ajouter' }).click();
-    await expect(page.getByText(/Charge .* kg/)).toBeVisible();
+    await expect(
+      page.locator('p.kw-sheet__muted').filter({ hasText: /Charge .* kg/ })
+    ).toBeVisible();
   });
 
   test('character creation validates fighter and magician creation budgets', async ({


### PR DESCRIPTION
## Summary
- remount the real character sheet on `@knightandwizard/ui` primitives with the armorial skin surface
- replace ad-hoc Tailwind panels/resources with tokenized sheet CSS, accessible tabs and progress bars
- keep canonical read-model/rules-core flows for catalog data, attributes, rolls, D100 severity, inventory and level progression

Closes #93.

## Verification
- `pnpm exec vitest run apps/game/src/features/character-sheet/model.test.ts apps/game/src/features/character-sheet/read-models.test.ts`
- `E2E_GAME_PORT=3160 E2E_API_PORT=3162 pnpm exec playwright test tests/e2e/app-features.spec.ts -g "character sheet"`
- `E2E_GAME_PORT=3168 E2E_API_PORT=3170 pnpm exec playwright test tests/e2e/app-features.spec.ts -g "session manager"`
- `pnpm --filter @knightandwizard/game typecheck`
- `pnpm build:game`
- `pnpm lint && pnpm format:check && git diff --check`
- Browser smoke on `/character`: desktop day/night and mobile night; armorial skin, tabs, progressbars, no horizontal overflow; only known `favicon.ico` 404 in dev
- `pnpm validate`
- `pnpm canonical:check:strict`
