### PR TITLE
feat(sheet): load API drafts and keep roll history

### DIFF
--- a/apps/game/src/app/character/page.tsx
+++ b/apps/game/src/app/character/page.tsx
@@ -8,8 +8,14 @@ import { getCharacterSheetReadModel } from '@/features/character-sheet/read-mode
 
 export const dynamic = 'force-dynamic';
 
-export default async function CharacterPage() {
-  const sheet = await getCharacterSheetReadModel();
+interface CharacterPageProps {
+  searchParams?: Promise<{ draftId?: string | string[] }>;
+}
+
+export default async function CharacterPage({ searchParams }: Readonly<CharacterPageProps>) {
+  const params = await searchParams;
+  const draftId = normalizeSearchParam(params?.draftId);
+  const sheet = await getCharacterSheetReadModel({ draftId });
 
   return (
     <div className="kw-character-page">
@@ -31,6 +37,7 @@ export default async function CharacterPage() {
         attributeLabels={sheet.attributeLabels}
         attributeOrder={sheet.attributeOrder}
         character={sheet.character}
+        dataSourceLabel={sheet.dataSourceLabel}
         equipmentCatalog={sheet.equipmentCatalog}
         initialInventory={sheet.initialInventory}
         skillCatalog={sheet.skillCatalog}
@@ -39,4 +46,12 @@ export default async function CharacterPage() {
       />
     </div>
   );
+}
+
+function normalizeSearchParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
 }

--- a/apps/game/src/app/globals.css
+++ b/apps/game/src/app/globals.css
@@ -582,7 +582,8 @@ a {
 .kw-sheet__skill-row,
 .kw-sheet__inventory-row,
 .kw-sheet__info-line,
-.kw-sheet__tab-label {
+.kw-sheet__tab-label,
+.kw-sheet__badge-row {
   display: flex;
   align-items: flex-start;
   gap: 12px;
@@ -759,11 +760,29 @@ a {
   text-transform: uppercase;
 }
 
+.kw-sheet__roll-history {
+  display: grid;
+  gap: 10px;
+  border-top: var(--border-hairline) solid var(--color-border-hairline);
+  padding-top: 12px;
+}
+
+.kw-sheet__roll-history-row {
+  align-items: center;
+  justify-content: space-between;
+}
+
+.kw-sheet__roll-history-row div {
+  display: grid;
+  gap: 4px;
+}
+
 .kw-sheet__skill-row,
 .kw-sheet__spell-row,
 .kw-sheet__inventory-row,
 .kw-sheet__audit-row,
-.kw-sheet__info-line {
+.kw-sheet__info-line,
+.kw-sheet__roll-history-row {
   border: var(--border-hairline) solid var(--color-border-hairline);
   background: var(--color-bg-elevated);
   padding: 10px 12px;
@@ -771,7 +790,8 @@ a {
 
 .kw-sheet__skill-row,
 .kw-sheet__inventory-row,
-.kw-sheet__spell-row {
+.kw-sheet__spell-row,
+.kw-sheet__roll-history-row {
   align-items: center;
   justify-content: space-between;
 }

--- a/apps/game/src/features/character-sheet/CharacterSheet.tsx
+++ b/apps/game/src/features/character-sheet/CharacterSheet.tsx
@@ -40,6 +40,7 @@ interface CharacterSheetProps {
   attributeLabels: Record<AttributeKey, string>;
   attributeOrder: AttributeKey[];
   character: Character;
+  dataSourceLabel: string;
   equipmentCatalog: EquipmentCatalogEntry[];
   initialInventory: InventoryItem[];
   skillCatalog: SkillCatalogEntry[];
@@ -65,6 +66,7 @@ export function CharacterSheet({
   attributeLabels,
   attributeOrder,
   character,
+  dataSourceLabel,
   equipmentCatalog,
   initialInventory,
   skillCatalog,
@@ -74,6 +76,7 @@ export function CharacterSheet({
   const [mode, setMode] = useState<CharacterSheetMode>('complete');
   const [inventory, setInventory] = useState(initialInventory);
   const [lastRoll, setLastRoll] = useState<AttributeRollResult | null>(null);
+  const [rollHistory, setRollHistory] = useState<AttributeRollResult[]>([]);
   const [selectedEquipmentId, setSelectedEquipmentId] = useState<string>(
     () => equipmentCatalog[0]?.id ?? ''
   );
@@ -107,9 +110,15 @@ export function CharacterSheet({
   const trainedSkillCount = skills.filter((skill) => !skill.isImplicitZero).length;
 
   function roll(attribute: AttributeKey) {
-    setLastRoll(
-      rollAttributeCheck(character, attribute, 7, (sides) => Math.floor(Math.random() * sides) + 1)
+    const result = rollAttributeCheck(
+      character,
+      attribute,
+      7,
+      (sides) => Math.floor(Math.random() * sides) + 1
     );
+
+    setLastRoll(result);
+    setRollHistory((current) => [result, ...current].slice(0, 6));
   }
 
   const tabItems = modes.map((item) => {
@@ -222,6 +231,7 @@ export function CharacterSheet({
                   />
                 ))}
               </div>
+              <RollHistory attributeLabels={attributeLabels} results={rollHistory} />
             </SectionCard>
 
             <SectionCard
@@ -269,7 +279,12 @@ export function CharacterSheet({
               </p>
             </div>
           </div>
-          <Badge tone="neutral">Skin armorial</Badge>
+          <div className="kw-sheet__badge-row">
+            <Badge tone="neutral">Skin armorial</Badge>
+            <Badge tone={dataSourceLabel === 'Brouillon API' ? 'info' : 'neutral'}>
+              {dataSourceLabel}
+            </Badge>
+          </div>
         </div>
 
         <div className="kw-sheet__resources" aria-label="Ressources personnage">
@@ -421,12 +436,7 @@ function RollResult({
   attributeLabels: Record<AttributeKey, string>;
   result: AttributeRollResult;
 }>) {
-  const tone: ToastTone =
-    result.pool === 0 || result.isCriticalFailure
-      ? 'danger'
-      : result.isCriticalSuccess
-        ? 'success'
-        : 'info';
+  const tone = rollTone(result);
 
   return (
     <div className="kw-sheet__roll" data-testid="last-roll">
@@ -453,6 +463,44 @@ function RollResult({
         ))}
       </Toast>
     </div>
+  );
+}
+
+function RollHistory({
+  attributeLabels,
+  results
+}: Readonly<{
+  attributeLabels: Record<AttributeKey, string>;
+  results: AttributeRollResult[];
+}>) {
+  if (results.length === 0) {
+    return null;
+  }
+
+  return (
+    <section aria-label="Historique des jets" className="kw-sheet__roll-history">
+      <h3>Historique des jets</h3>
+      <div className="kw-sheet__row-list">
+        {results.map((result, index) => (
+          <div className="kw-sheet__roll-history-row" key={`${result.attribute}-${index}`}>
+            <div>
+              <p>
+                {attributeLabels[result.attribute]} · {result.pool}D · DT {result.difficulty} ·{' '}
+                {result.successes} succès
+              </p>
+              {attributeRollOutcomeLabels(result).map((label) => (
+                <span className="kw-sheet__roll-outcome" key={label.id}>
+                  {label.label}
+                </span>
+              ))}
+            </div>
+            <Badge tone={rollTone(result) === 'success' ? 'success' : 'neutral'}>
+              {index === 0 ? 'Dernier' : `Jet ${results.length - index}`}
+            </Badge>
+          </div>
+        ))}
+      </div>
+    </section>
   );
 }
 
@@ -538,6 +586,14 @@ function skillDescription(skill: SkillTreeRow): string {
   }
 
   return skill.parentId ? 'Spécialisation' : 'Compétence';
+}
+
+function rollTone(result: AttributeRollResult): ToastTone {
+  if (result.pool === 0 || result.isCriticalFailure) {
+    return 'danger';
+  }
+
+  return result.isCriticalSuccess ? 'success' : 'info';
 }
 
 function dieKindForRoll(value: number, difficulty: number) {

--- a/apps/game/src/features/character-sheet/model.test.ts
+++ b/apps/game/src/features/character-sheet/model.test.ts
@@ -10,6 +10,7 @@ import {
   addInventoryItem,
   attributeRollOutcomeLabels,
   buildCharacterSheetView,
+  buildInventoryFromCharacterEquipment,
   removeInventoryItem,
   rollAttributeCheck,
   skillPoints,
@@ -182,6 +183,34 @@ describe('character sheet model', () => {
         id: 'critical-failure',
         label: 'Échec critique · D100 = 73',
         testId: 'last-roll-critical-failure'
+      }
+    ]);
+  });
+
+  it('hydrates inventory rows from saved character equipment and canonical catalog details', () => {
+    expect(
+      buildInventoryFromCharacterEquipment(
+        [
+          { id: 'epee_batarde', quantity: 2 },
+          { id: 'unknown-kit', name: 'Kit sans catalogue', quantity: 1 }
+        ],
+        [{ category: 'weapon', id: 'epee_batarde', name: 'Épée bâtarde', weightKg: 2.2 }]
+      )
+    ).toEqual([
+      {
+        category: 'weapon',
+        equipped: true,
+        id: 'epee_batarde',
+        name: 'Épée bâtarde',
+        quantity: 2,
+        weightKg: 2.2
+      },
+      {
+        category: 'gear',
+        id: 'unknown-kit',
+        name: 'Kit sans catalogue',
+        quantity: 1,
+        weightKg: undefined
       }
     ]);
   });

--- a/apps/game/src/features/character-sheet/model.ts
+++ b/apps/game/src/features/character-sheet/model.ts
@@ -6,6 +6,7 @@ import {
   type AttributeKey,
   type Character,
   type CharacterAttributes,
+  type CharacterEquipmentItem,
   type CharacterSkill,
   type DiceRollResult,
   type LevelProgression,
@@ -148,6 +149,28 @@ export function buildInventory(input: {
   ];
 
   return items.filter((item): item is InventoryItem => item !== undefined);
+}
+
+export function buildInventoryFromCharacterEquipment(
+  equipment: CharacterEquipmentItem[],
+  catalog: EquipmentCatalogEntry[]
+): InventoryItem[] {
+  const catalogById = new Map(catalog.map((entry) => [entry.id, entry]));
+
+  return equipment.map((item) => {
+    const catalogEntry = catalogById.get(item.id);
+    const category = catalogEntry?.category ?? 'gear';
+    const equipped = ['armor', 'shield', 'weapon'].includes(category) ? true : undefined;
+
+    return {
+      category,
+      ...(equipped ? { equipped } : {}),
+      id: item.id,
+      name: catalogEntry?.name ?? item.name ?? item.id,
+      quantity: Math.max(1, item.quantity ?? 1),
+      weightKg: catalogEntry?.weightKg
+    };
+  });
 }
 
 function toEquipmentCatalogEntry(

--- a/apps/game/src/features/character-sheet/read-models.ts
+++ b/apps/game/src/features/character-sheet/read-models.ts
@@ -2,13 +2,20 @@ import {
   ATTRIBUTE_KEYS,
   createPlayerCharacter,
   type AttributeKey,
+  type Character,
   type CharacterAttributes
 } from '@knightandwizard/rules-core';
 
-import { getCatalogDocument } from '@/lib/catalogs';
+import { getApiBaseUrl, getCatalogDocument } from '@/lib/catalogs';
 
 import {
+  fromDraftSnapshot,
+  previewCharacter,
+  type DraftSnapshot
+} from '../character-creation/model';
+import {
   attributeLabels,
+  buildCharacterCreationCatalogFromReadModels,
   toClassProfiles,
   toOrientationProfiles,
   toRaceProfiles,
@@ -25,6 +32,7 @@ import {
 import {
   buildEquipmentCatalog,
   buildInventory,
+  buildInventoryFromCharacterEquipment,
   type EquipmentCatalogEntry,
   type InventoryItem,
   type SkillCatalogEntry,
@@ -34,7 +42,8 @@ import {
 export interface CharacterSheetReadModel {
   attributeLabels: Record<AttributeKey, string>;
   attributeOrder: AttributeKey[];
-  character: ReturnType<typeof createPlayerCharacter>;
+  character: Character;
+  dataSourceLabel: string;
   equipmentCatalog: EquipmentCatalogEntry[];
   initialInventory: InventoryItem[];
   skillCatalog: SkillCatalogEntry[];
@@ -42,7 +51,13 @@ export interface CharacterSheetReadModel {
   spells: SpellEntry[];
 }
 
-export async function getCharacterSheetReadModel(): Promise<CharacterSheetReadModel> {
+export interface CharacterSheetReadModelOptions {
+  draftId?: string;
+}
+
+export async function getCharacterSheetReadModel(
+  options: CharacterSheetReadModelOptions = {}
+): Promise<CharacterSheetReadModel> {
   const [races, orientations, classes, skills, spells, weapons, protections, potions] =
     await Promise.all([
       getCatalogDocument<RacesCatalogDocument>('races.yaml'),
@@ -54,19 +69,66 @@ export async function getCharacterSheetReadModel(): Promise<CharacterSheetReadMo
       getCatalogDocument<ProtectionsCatalogDocument>('protections.yaml'),
       getCatalogDocument<PotionsCatalogDocument>('potions.yaml')
     ]);
+  const draftSnapshot = options.draftId ? await getCharacterDraftSnapshot(options.draftId) : null;
+  const creationCatalog = buildCharacterCreationCatalogFromReadModels({
+    classes,
+    orientations,
+    potions,
+    protections,
+    races,
+    skills,
+    spells,
+    weapons
+  });
+  const character = draftSnapshot
+    ? previewCharacter(fromDraftSnapshot(draftSnapshot), creationCatalog)
+    : buildActiveCharacter({ classes, orientations, races });
+  const equipmentCatalog = buildEquipmentCatalog({ potions, protections, weapons });
   const skillCatalog = toSkillOptions(skills);
   const skillLabels = Object.fromEntries(skillCatalog.map((skill) => [skill.id, skill.label]));
 
   return {
     attributeLabels,
     attributeOrder: [...ATTRIBUTE_KEYS],
-    character: buildActiveCharacter({ classes, orientations, races }),
-    equipmentCatalog: buildEquipmentCatalog({ potions, protections, weapons }),
-    initialInventory: buildInventory({ potions, protections, weapons }),
+    character,
+    dataSourceLabel: draftSnapshot ? 'Brouillon API' : 'Catalogues API',
+    equipmentCatalog,
+    initialInventory: draftSnapshot
+      ? buildInventoryFromCharacterEquipment(character.equipment, equipmentCatalog)
+      : buildInventory({ potions, protections, weapons }),
     skillCatalog,
     skillLabels,
-    spells: buildSpells(spells)
+    spells: draftSnapshot ? buildCharacterSpells(character, spells) : buildSpells(spells)
   };
+}
+
+async function getCharacterDraftSnapshot(draftId: string): Promise<DraftSnapshot | null> {
+  const response = await fetch(
+    `${getApiBaseUrl()}/character-drafts/${encodeURIComponent(draftId)}`,
+    { cache: 'no-store' }
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Unable to load character draft ${draftId}: HTTP ${response.status}`);
+  }
+
+  const body = (await response.json()) as CharacterDraftEnvelope;
+
+  return {
+    currentStep: body.currentStep,
+    id: body.id,
+    payload: body.payload,
+    updatedAt: body.updatedAt
+  };
+}
+
+interface CharacterDraftEnvelope extends DraftSnapshot {
+  status?: 'found';
+  userId?: string;
 }
 
 function buildActiveCharacter(input: {
@@ -138,4 +200,19 @@ function buildSpells(catalog: SpellsCatalogDocument): SpellEntry[] {
       name: spell.name as string,
       points: 1
     }));
+}
+
+function buildCharacterSpells(character: Character, catalog: SpellsCatalogDocument): SpellEntry[] {
+  const namesById = new Map(
+    (catalog.spells ?? [])
+      .filter((spell) => spell.id && spell.name)
+      .map((spell) => [spell.id as string, spell.name as string])
+  );
+
+  return character.spells.map((spell) => ({
+    active: spell.id === 'bouclier',
+    id: spell.id,
+    name: namesById.get(spell.id) ?? spell.id,
+    points: spell.points
+  }));
 }

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -6,6 +6,9 @@ import {
   type CanonicalE2EScenario
 } from './fixtures/canonical';
 
+const e2eApiBaseUrl =
+  process.env.E2E_API_URL ?? `http://127.0.0.1:${process.env.E2E_API_PORT ?? '3102'}`;
+
 test.describe('K&W player and GM application flows', () => {
   test('dashboard reports the API and links the main work surfaces', async ({ page }, testInfo) => {
     annotateCanonical(testInfo, 'dashboard');
@@ -92,6 +95,10 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByTestId('last-roll-critical-failure')).toHaveText(
       'Échec critique · D100 = 73'
     );
+    const rollHistory = page.getByLabel('Historique des jets');
+    await expect(page.getByRole('heading', { name: 'Historique des jets' })).toBeVisible();
+    await expect(rollHistory.getByText('Échec automatique (attribut 0)')).toBeVisible();
+    await expect(rollHistory.getByText('Échec critique · D100 = 73')).toBeVisible();
 
     await page.getByRole('tab', { name: 'Combat' }).click();
     const combatPanel = page.getByRole('tabpanel', { name: 'Combat' });
@@ -113,6 +120,62 @@ test.describe('K&W player and GM application flows', () => {
     await expect(
       page.locator('p.kw-sheet__muted').filter({ hasText: /Charge .* kg/ })
     ).toBeVisible();
+  });
+
+  test('character sheet can render an API-backed saved draft', async ({ page }, testInfo) => {
+    annotateCanonical(testInfo, 'characterSheet');
+
+    const draftId = 'draft-sheet-api-e2e';
+    const saveResponse = await page.request.put(`${e2eApiBaseUrl}/character-drafts/${draftId}`, {
+      data: {
+        currentStep: 'review',
+        payload: {
+          attributes: {
+            aestheticism: 1,
+            charisma: 2,
+            dexterity: 3,
+            empathy: 2,
+            intelligence: 2,
+            perception: 2,
+            reflexes: 2,
+            stamina: 3,
+            strength: 3
+          },
+          background: 'Formee dans une tour frontaliere.',
+          classId: 'enchanteur',
+          deity: 'Les Trois Flammes',
+          equipmentIds: ['epee_batarde', 'bouclier_bois'],
+          extraSpellPoints: 1,
+          genderId: 'unspecified',
+          name: 'Aveline API',
+          orientationId: 'magicien',
+          psychology: 'calme',
+          quote: 'Le mot engage.',
+          raceId: 'humain',
+          skills: [
+            { id: 'arcanologie', points: 4 },
+            { id: 'histoire', points: 4 },
+            { id: 'arcanologie-des-rituels', parentId: 'arcanologie', points: 2 }
+          ],
+          spells: [
+            { id: 'boule-de-feu', points: 2 },
+            { id: 'bouclier', points: 1 }
+          ]
+        }
+      }
+    });
+
+    expect(saveResponse.ok()).toBe(true);
+
+    await page.goto(`/character?draftId=${draftId}`);
+
+    await expect(page.locator('html')).toHaveAttribute('data-skin', 'armorial');
+    await expect(page.getByRole('heading', { name: 'Aveline API' })).toBeVisible();
+    await expect(page.getByText('Brouillon API')).toBeVisible();
+    const inventoryRows = page.locator('.kw-sheet__inventory-row');
+    await expect(inventoryRows.getByRole('heading', { name: 'Épée bâtarde' })).toBeVisible();
+    await expect(inventoryRows.getByRole('heading', { name: 'Bouclier (bois)' })).toBeVisible();
+    await expect(page.getByText('Niveau 0 · 16 / 20 points')).toBeVisible();
   });
 
   test('character creation validates fighter and magician creation budgets', async ({


### PR DESCRIPTION
## Summary
- allow `/character?draftId=...` to reconstruct the sheet from a saved `character-drafts` API record, using canonical catalogs and `previewCharacter`
- hydrate inventory/spells from the saved character while preserving canonical catalog names, categories and weights
- keep an in-session roll history on the sheet so forced failures and critical D100 outcomes remain visible after later rolls

Closes #52.

## Verification
- `pnpm exec vitest run apps/game/src/features/character-sheet/model.test.ts apps/game/src/features/character-sheet/read-models.test.ts`
- `E2E_GAME_PORT=3172 E2E_API_PORT=3174 pnpm exec playwright test tests/e2e/app-features.spec.ts -g "character sheet"`
- `pnpm --filter @knightandwizard/game typecheck`
- `pnpm build:game`
- `pnpm lint && pnpm format:check && git diff --check`
- Browser smoke on `/character?draftId=draft-visual-api`: API badge, API character, inventory, roll history, no horizontal overflow; only known `favicon.ico` 404 in dev
- `pnpm validate`
- `pnpm canonical:check:strict`
