### PR TITLE
feat(game): Cartulaire (skin armorial) (#110)

### DIFF
--- a/apps/game/src/app/cartulaire/page.tsx
+++ b/apps/game/src/app/cartulaire/page.tsx
@@ -1,0 +1,10 @@
+import { CartulaireSurface } from '@/features/cartulaire/CartulaireSurface';
+import { getCartulaireReadModel } from '@/features/cartulaire/read-models';
+
+export const dynamic = 'force-dynamic';
+
+export default async function CartulairePage() {
+  const readModel = await getCartulaireReadModel();
+
+  return <CartulaireSurface readModel={readModel} />;
+}

--- a/apps/game/src/app/globals.css
+++ b/apps/game/src/app/globals.css
@@ -221,6 +221,235 @@ a {
   background: var(--swatch-color, var(--color-accent));
 }
 
+.kw-cartulaire-page,
+.kw-cartulaire,
+.kw-cartulaire__side,
+.kw-cartulaire__detail,
+.kw-cartulaire__city-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.kw-cartulaire-page h1,
+.kw-cartulaire-page h2,
+.kw-cartulaire-page h3,
+.kw-cartulaire-page p,
+.kw-cartulaire-page dl,
+.kw-cartulaire-page dd {
+  margin: 0;
+}
+
+.kw-cartulaire-page h1,
+.kw-cartulaire-page h2,
+.kw-cartulaire-page h3 {
+  color: var(--color-text-ink);
+  font-family: var(--font-display);
+  line-height: var(--leading-tight);
+}
+
+.kw-cartulaire-page h1 {
+  margin-top: 4px;
+  font-size: var(--text-title-l);
+}
+
+.kw-cartulaire-page h2 {
+  font-size: var(--text-title-m);
+}
+
+.kw-cartulaire-page__toolbar {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.kw-cartulaire {
+  border: var(--border-strong) solid var(--color-border-rule);
+  background: var(--color-bg-canvas);
+  color: var(--color-text-ink);
+  font-family: var(--font-body);
+  padding: 24px;
+}
+
+.kw-cartulaire__hero,
+.kw-cartulaire__panel-head,
+.kw-cartulaire__badge-row,
+.kw-cartulaire__emaux-list,
+.kw-cartulaire__city-row,
+.kw-cartulaire__button,
+.kw-cartulaire__nation-button {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.kw-cartulaire__hero,
+.kw-cartulaire__panel-head,
+.kw-cartulaire__city-row {
+  justify-content: space-between;
+}
+
+.kw-cartulaire__hero {
+  align-items: center;
+}
+
+.kw-cartulaire__hero-copy {
+  min-width: 0;
+}
+
+.kw-cartulaire__hero .kw-seal {
+  flex: 0 0 auto;
+}
+
+.kw-cartulaire__badge-row,
+.kw-cartulaire__nation-button,
+.kw-cartulaire__button {
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.kw-cartulaire__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.kw-cartulaire__map-panel {
+  min-width: 0;
+}
+
+.kw-cartulaire-map {
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 10;
+  margin-top: 16px;
+  border: var(--border-hairline) solid var(--color-border-hairline);
+  background: var(--color-bg-elevated);
+}
+
+.kw-cartulaire-map__paper {
+  fill: var(--color-bg-elevated);
+}
+
+.kw-cartulaire-map__region {
+  fill: color-mix(in oklab, var(--region-emaux) 42%, var(--color-bg-surface));
+  stroke: var(--color-border-rule);
+  stroke-width: 0.25;
+  vector-effect: non-scaling-stroke;
+  cursor: pointer;
+  transition:
+    fill 120ms ease,
+    stroke-width 120ms ease;
+}
+
+.kw-cartulaire-map__region:hover,
+.kw-cartulaire-map__region:focus-visible,
+.kw-cartulaire-map__region[data-selected='true'] {
+  fill: color-mix(in oklab, var(--region-emaux) 72%, var(--color-bg-surface));
+  stroke: var(--color-text-ink);
+  stroke-width: 0.6;
+  outline: none;
+}
+
+.kw-cartulaire-map__city {
+  fill: var(--color-text-ink);
+  stroke: var(--color-bg-canvas);
+  stroke-width: 0.25;
+  vector-effect: non-scaling-stroke;
+}
+
+.kw-cartulaire-map__city[data-capital='true'] {
+  fill: var(--color-accent);
+}
+
+.kw-cartulaire__definition-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.kw-cartulaire__definition-list > div,
+.kw-cartulaire__city-row {
+  border: var(--border-hairline) solid var(--color-border-hairline);
+  background: var(--color-bg-elevated);
+  padding: 8px 10px;
+}
+
+.kw-cartulaire__definition-list dt {
+  color: var(--color-text-muted);
+  font-family: var(--font-label);
+  font-size: var(--text-label-sm);
+  letter-spacing: var(--tracking-label);
+  text-transform: uppercase;
+}
+
+.kw-cartulaire__definition-list dd {
+  color: var(--color-text-ink);
+  font-family: var(--font-display);
+  font-size: var(--text-body-l);
+}
+
+.kw-cartulaire__muted {
+  color: var(--color-text-muted);
+}
+
+.kw-cartulaire__feature-list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding-left: 18px;
+  color: var(--color-text-muted);
+}
+
+.kw-cartulaire__nation-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.kw-cartulaire__nation-button {
+  min-width: 0;
+  justify-content: space-between;
+  text-align: left;
+}
+
+.kw-cartulaire__nation-name {
+  min-width: 0;
+  flex: 1 1 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kw-cartulaire__emaux-list {
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 4px;
+}
+
+.kw-cartulaire__emaux-swatch {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: var(--border-hairline) solid var(--color-border-rule);
+  background: var(--emaux-token);
+}
+
+.kw-cartulaire__button-icon,
+.kw-cartulaire__section-icon {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
+}
+
+.kw-cartulaire__section-icon {
+  color: var(--color-accent);
+}
+
+.kw-cartulaire__city-row {
+  align-items: center;
+}
+
 @media (max-width: 720px) {
   .app-shell {
     padding: 10px;
@@ -262,6 +491,25 @@ a {
     max-width: 100%;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .kw-cartulaire {
+    padding: 16px;
+  }
+
+  .kw-cartulaire__hero,
+  .kw-cartulaire__panel-head {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .kw-cartulaire__layout,
+  .kw-cartulaire__definition-list {
+    grid-template-columns: 1fr;
+  }
+
+  .kw-cartulaire-map {
+    aspect-ratio: 1 / 1;
   }
 }
 

--- a/apps/game/src/components/app-shell.tsx
+++ b/apps/game/src/components/app-shell.tsx
@@ -7,6 +7,7 @@ import {
   FileArchive,
   LayoutDashboard,
   LibraryBig,
+  Map,
   Moon,
   PenLine,
   ScrollText,
@@ -40,6 +41,7 @@ const navIcons: Record<string, LucideIcon> = {
   '/dice': Dices,
   '/rules': FileArchive,
   '/bibliotheque': LibraryBig,
+  '/cartulaire': Map,
   '/design-proto': BookOpen
 };
 

--- a/apps/game/src/features/cartulaire/CartulaireSurface.tsx
+++ b/apps/game/src/features/cartulaire/CartulaireSurface.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import { Layers, MapPinned, Moon, Shield, Sun } from 'lucide-react';
+import { useMemo, useState, type CSSProperties, type KeyboardEvent } from 'react';
+
+import { Badge, Button, Card, Label, Seal, StatBlock } from '@knightandwizard/ui';
+
+import type { CartulaireReadModel, CartulaireRegion, Emau } from './model';
+
+const numberFormat = new Intl.NumberFormat('fr-FR');
+
+const emauxLabels: Record<Emau, string> = {
+  azur: 'Azur',
+  gueules: 'Gueules',
+  or: 'Or',
+  sinople: 'Sinople'
+};
+
+export function CartulaireSurface({ readModel }: Readonly<{ readModel: CartulaireReadModel }>) {
+  const [night, setNight] = useState(false);
+  const [selectedRegionId, setSelectedRegionId] = useState(readModel.regions[0]?.id ?? '');
+  const selectedRegion = useMemo(
+    () =>
+      readModel.regions.find((region) => region.id === selectedRegionId) ??
+      readModel.regions[0] ??
+      null,
+    [readModel.regions, selectedRegionId]
+  );
+
+  const selectedCities = selectedRegion
+    ? readModel.cities.filter((city) => city.parentRegionId === selectedRegion.id)
+    : [];
+  const summaryItems = [
+    { label: 'Nations', value: numberFormat.format(readModel.summary.nations) },
+    { label: 'Regions vectorisees', value: numberFormat.format(readModel.summary.vectorRegions) },
+    { label: 'Villes', value: numberFormat.format(readModel.summary.cities) },
+    {
+      label: 'Population',
+      value: numberFormat.format(readModel.summary.totalPopulation)
+    }
+  ];
+
+  return (
+    <div className="kw-cartulaire-page">
+      <div className="kw-cartulaire-page__toolbar">
+        <Button
+          aria-pressed={night}
+          className="kw-cartulaire__button"
+          onClick={() => setNight((current) => !current)}
+          variant="secondary"
+        >
+          {night ? (
+            <Moon aria-hidden="true" className="kw-cartulaire__button-icon" />
+          ) : (
+            <Sun aria-hidden="true" className="kw-cartulaire__button-icon" />
+          )}
+          <span>{night ? 'Veillee' : 'Jour'}</span>
+        </Button>
+      </div>
+
+      <div data-skin="armorial" data-theme={night ? 'night' : undefined} className="kw-cartulaire">
+        <Card className="kw-cartulaire__hero">
+          <div className="kw-cartulaire__hero-copy">
+            <Label>Cartulaire royal · emaux et marches</Label>
+            <h1>Terres Oubliees</h1>
+            <div className="kw-cartulaire__badge-row">
+              <Badge tone="info">Skin armorial</Badge>
+              <Badge tone="neutral">Source nations.yaml</Badge>
+              <Badge tone="neutral">GeoJSON interactive-map</Badge>
+            </div>
+          </div>
+          <Seal>{readModel.summary.vectorRegions} cartes</Seal>
+        </Card>
+
+        <div className="kw-cartulaire__layout">
+          <Card className="kw-cartulaire__map-panel">
+            <div className="kw-cartulaire__panel-head">
+              <div>
+                <Label>Carte vectorisee</Label>
+                <h2>Frontieres canoniques</h2>
+              </div>
+              <Badge tone="neutral">{selectedRegion?.category ?? 'region'}</Badge>
+            </div>
+
+            <svg
+              aria-label="Carte interactive des nations Knight & Wizard"
+              className="kw-cartulaire-map"
+              role="img"
+              viewBox="0 0 100 100"
+            >
+              <rect className="kw-cartulaire-map__paper" height="100" width="100" x="0" y="0" />
+              {readModel.regions.map((region) => (
+                <path
+                  aria-label={region.name}
+                  className="kw-cartulaire-map__region"
+                  d={region.mapPath}
+                  data-selected={region.id === selectedRegion?.id ? 'true' : undefined}
+                  key={region.id}
+                  onClick={() => setSelectedRegionId(region.id)}
+                  onKeyDown={(event) => handleRegionKeyDown(event, region, setSelectedRegionId)}
+                  role="button"
+                  style={regionStyle(region)}
+                  tabIndex={0}
+                />
+              ))}
+              {readModel.cities.map((city) => (
+                <circle
+                  className="kw-cartulaire-map__city"
+                  cx={city.x}
+                  cy={city.y}
+                  data-capital={city.role === 'capital' ? 'true' : undefined}
+                  key={city.id}
+                  r={city.role === 'capital' ? 0.9 : 0.55}
+                />
+              ))}
+            </svg>
+          </Card>
+
+          <div className="kw-cartulaire__side">
+            <Card>
+              <StatBlock title="Couverture" items={summaryItems} />
+            </Card>
+
+            {selectedRegion ? (
+              <Card className="kw-cartulaire__detail">
+                <div className="kw-cartulaire__panel-head">
+                  <div>
+                    <Label>Notice territoriale</Label>
+                    <h2>{selectedRegion.name}</h2>
+                  </div>
+                  <EmauxSwatches emaux={selectedRegion.emaux} />
+                </div>
+
+                <dl className="kw-cartulaire__definition-list">
+                  <div>
+                    <dt>Capitale</dt>
+                    <dd>{selectedRegion.capital ?? 'Non renseignee'}</dd>
+                  </div>
+                  <div>
+                    <dt>Population</dt>
+                    <dd>{formatNullableNumber(selectedRegion.population)}</dd>
+                  </div>
+                  <div>
+                    <dt>Surface</dt>
+                    <dd>
+                      {selectedRegion.surfaceKm2
+                        ? `${numberFormat.format(selectedRegion.surfaceKm2)} km2`
+                        : 'Non renseignee'}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Villes relevees</dt>
+                    <dd>{numberFormat.format(selectedCities.length)}</dd>
+                  </div>
+                </dl>
+
+                {selectedRegion.blasonDescription ? (
+                  <p className="kw-cartulaire__muted">{selectedRegion.blasonDescription}</p>
+                ) : null}
+
+                {selectedRegion.notableFeatures.length > 0 ? (
+                  <ul className="kw-cartulaire__feature-list">
+                    {selectedRegion.notableFeatures.slice(0, 3).map((feature) => (
+                      <li key={feature}>{feature}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </Card>
+            ) : null}
+          </div>
+        </div>
+
+        <Card>
+          <div className="kw-cartulaire__panel-head">
+            <div>
+              <Label>Emaux par nation</Label>
+              <h2>Armorial de consultation</h2>
+            </div>
+            <Layers aria-hidden="true" className="kw-cartulaire__section-icon" />
+          </div>
+
+          <div className="kw-cartulaire__nation-grid">
+            {readModel.emauxByNation.map((nation) => (
+              <Button
+                className="kw-cartulaire__nation-button"
+                key={nation.id}
+                onClick={() => setSelectedRegionId(nation.id)}
+                variant={nation.id === selectedRegion?.id ? 'primary' : 'secondary'}
+              >
+                <Shield aria-hidden="true" className="kw-cartulaire__button-icon" />
+                <span className="kw-cartulaire__nation-name">{nation.name}</span>
+                <EmauxSwatches emaux={nation.emaux} />
+              </Button>
+            ))}
+          </div>
+        </Card>
+
+        <Card>
+          <div className="kw-cartulaire__panel-head">
+            <div>
+              <Label>Villes et points releves</Label>
+              <h2>{selectedRegion?.name ?? 'Cartulaire'}</h2>
+            </div>
+            <MapPinned aria-hidden="true" className="kw-cartulaire__section-icon" />
+          </div>
+
+          <div className="kw-cartulaire__city-grid">
+            {selectedCities.length > 0 ? (
+              selectedCities.map((city) => (
+                <div className="kw-cartulaire__city-row" key={city.id}>
+                  <span>{city.name}</span>
+                  <Badge tone={city.role === 'capital' ? 'info' : 'neutral'}>{city.role}</Badge>
+                </div>
+              ))
+            ) : (
+              <p className="kw-cartulaire__muted">Aucune ville vectorisee pour cette notice.</p>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function EmauxSwatches({ emaux }: Readonly<{ emaux: Emau[] }>) {
+  if (emaux.length === 0) {
+    return <Badge tone="neutral">Sans emaux</Badge>;
+  }
+
+  return (
+    <span className="kw-cartulaire__emaux-list">
+      {emaux.map((emau) => (
+        <span
+          aria-label={emauxLabels[emau]}
+          className="kw-cartulaire__emaux-swatch"
+          key={emau}
+          style={{ '--emaux-token': `var(--emaux-${emau})` } as CSSProperties}
+          title={emauxLabels[emau]}
+        />
+      ))}
+    </span>
+  );
+}
+
+function regionStyle(region: CartulaireRegion): CSSProperties {
+  return {
+    '--region-emaux': region.emaux[0]
+      ? `var(--emaux-${region.emaux[0]})`
+      : 'var(--color-border-rule)'
+  } as CSSProperties;
+}
+
+function formatNullableNumber(value: number | null): string {
+  return value === null ? 'Non renseignee' : numberFormat.format(value);
+}
+
+function handleRegionKeyDown(
+  event: KeyboardEvent<SVGPathElement>,
+  region: CartulaireRegion,
+  setSelectedRegionId: (id: string) => void
+) {
+  if (event.key !== 'Enter' && event.key !== ' ') {
+    return;
+  }
+
+  event.preventDefault();
+  setSelectedRegionId(region.id);
+}

--- a/apps/game/src/features/cartulaire/model.test.ts
+++ b/apps/game/src/features/cartulaire/model.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildCartulaireReadModel } from './model';
+
+describe('cartulaire read model', () => {
+  it('binds vector regions to canonical nations and heraldic emaux', () => {
+    const readModel = buildCartulaireReadModel({
+      cities: {
+        features: [
+          {
+            geometry: { coordinates: [65, 55], type: 'Point' },
+            properties: {
+              id: 'erune',
+              name: 'Erune',
+              parent_region: 'alteria',
+              role: 'capital'
+            },
+            type: 'Feature'
+          }
+        ],
+        type: 'FeatureCollection'
+      },
+      nations: {
+        metadata: { total_entries: 2 },
+        regions: [
+          {
+            blason: { colors: ['or'], symbols: ['balance_or'] },
+            capital: 'Erune',
+            category: 'nation',
+            id: 'alteria',
+            metadata: { source: 'paper', version: 1 },
+            name: 'Alteria',
+            population: { total: 6500000 },
+            surface_km2: 240000
+          },
+          {
+            blason: { colors: ['rouge', 'bleu', 'blanc'], symbols: ['fontaine_oracle'] },
+            capital: 'Cortega',
+            category: 'nation',
+            id: 'cortega',
+            metadata: { source: 'paper', version: 1 },
+            name: 'Cortega',
+            population: { total: 9000000 },
+            surface_km2: 370000
+          }
+        ],
+        version: 2
+      },
+      regions: {
+        features: [
+          {
+            geometry: {
+              coordinates: [
+                [
+                  [57.5, 49],
+                  [72.5, 49],
+                  [72.5, 61],
+                  [57.5, 61],
+                  [57.5, 49]
+                ]
+              ],
+              type: 'Polygon'
+            },
+            properties: {
+              category: 'nation',
+              id: 'alteria',
+              name: 'Alteria',
+              regional_map: '/maps/alteria.jpg'
+            },
+            type: 'Feature'
+          }
+        ],
+        type: 'FeatureCollection'
+      }
+    });
+
+    expect(readModel.summary).toEqual({
+      cities: 1,
+      nations: 2,
+      totalPopulation: 15500000,
+      vectorRegions: 1
+    });
+    expect(readModel.regions).toEqual([
+      expect.objectContaining({
+        capital: 'Erune',
+        emaux: ['or'],
+        id: 'alteria',
+        mapPath: 'M 57.5 51 L 72.5 51 L 72.5 39 L 57.5 39 L 57.5 51 Z',
+        name: 'Alteria',
+        population: 6500000
+      })
+    ]);
+    expect(readModel.emauxByNation).toEqual([
+      expect.objectContaining({ emaux: ['or'], id: 'alteria' }),
+      expect.objectContaining({ emaux: ['gueules', 'azur'], id: 'cortega' })
+    ]);
+  });
+});

--- a/apps/game/src/features/cartulaire/model.ts
+++ b/apps/game/src/features/cartulaire/model.ts
@@ -1,0 +1,233 @@
+export type Emau = 'azur' | 'gueules' | 'or' | 'sinople';
+
+type GeoJsonPosition = [number, number];
+type GeoJsonPolygonCoordinates = GeoJsonPosition[][];
+type GeoJsonMultiPolygonCoordinates = GeoJsonPosition[][][];
+
+export interface GeoJsonFeatureCollection<Geometry, Properties> {
+  features: Array<GeoJsonFeature<Geometry, Properties>>;
+  type: 'FeatureCollection';
+}
+
+export interface GeoJsonFeature<Geometry, Properties> {
+  geometry: Geometry;
+  properties: Properties;
+  type: 'Feature';
+}
+
+export type RegionGeometry =
+  | { coordinates: GeoJsonPolygonCoordinates; type: 'Polygon' }
+  | { coordinates: GeoJsonMultiPolygonCoordinates; type: 'MultiPolygon' };
+
+export type CityGeometry = { coordinates: GeoJsonPosition; type: 'Point' };
+
+export interface RegionProperties {
+  capital?: string | null;
+  category?: string | null;
+  id: string;
+  name: string;
+  regional_map?: string | null;
+}
+
+export interface CityProperties {
+  id: string;
+  name: string;
+  notes?: string | null;
+  parent_region?: string | null;
+  role?: string | null;
+}
+
+export interface NationsCatalogDocument {
+  metadata?: {
+    total_entries?: number;
+  };
+  regions?: NationDocument[];
+  version?: number;
+}
+
+export interface NationDocument {
+  blason?: {
+    colors?: string[];
+    description?: string;
+    symbols?: string[];
+  };
+  capital?: string | null;
+  category?: string;
+  government?: string | null;
+  id: string;
+  metadata?: Record<string, unknown>;
+  name: string;
+  notable_features?: string[];
+  population?: {
+    total?: number | string | null;
+  };
+  surface_km2?: number | null;
+}
+
+export interface CartulaireReadModel {
+  cities: CartulaireCity[];
+  emauxByNation: CartulaireNationEmaux[];
+  regions: CartulaireRegion[];
+  summary: {
+    cities: number;
+    nations: number;
+    totalPopulation: number;
+    vectorRegions: number;
+  };
+}
+
+export interface CartulaireRegion {
+  blasonDescription: string | null;
+  capital: string | null;
+  category: string;
+  emaux: Emau[];
+  id: string;
+  mapPath: string;
+  name: string;
+  notableFeatures: string[];
+  population: number | null;
+  regionalMap: string | null;
+  surfaceKm2: number | null;
+}
+
+export interface CartulaireCity {
+  id: string;
+  name: string;
+  parentRegionId: string | null;
+  parentRegionName: string | null;
+  role: string;
+  x: number;
+  y: number;
+}
+
+export interface CartulaireNationEmaux {
+  blasonDescription: string | null;
+  category: string;
+  emaux: Emau[];
+  id: string;
+  name: string;
+}
+
+export interface CartulaireReadModelInput {
+  cities: GeoJsonFeatureCollection<CityGeometry, CityProperties>;
+  nations: NationsCatalogDocument;
+  regions: GeoJsonFeatureCollection<RegionGeometry, RegionProperties>;
+}
+
+const BLAZON_COLOR_TO_EMAU: Record<string, Emau> = {
+  bleu: 'azur',
+  or: 'or',
+  rouge: 'gueules',
+  vert: 'sinople'
+};
+
+export function buildCartulaireReadModel(input: CartulaireReadModelInput): CartulaireReadModel {
+  const nations = input.nations.regions ?? [];
+  const nationById = new Map(nations.map((nation) => [nation.id, nation]));
+
+  const regions = input.regions.features.map((feature) => {
+    const nation = nationById.get(feature.properties.id);
+
+    return {
+      blasonDescription: nation?.blason?.description ?? null,
+      capital: nation?.capital ?? feature.properties.capital ?? null,
+      category: nation?.category ?? feature.properties.category ?? 'region',
+      emaux: extractEmaux(nation),
+      id: feature.properties.id,
+      mapPath: toSvgPath(feature.geometry),
+      name: nation?.name ?? feature.properties.name,
+      notableFeatures: nation?.notable_features ?? [],
+      population: readPopulation(nation),
+      regionalMap: feature.properties.regional_map ?? null,
+      surfaceKm2: nation?.surface_km2 ?? null
+    } satisfies CartulaireRegion;
+  });
+
+  const regionNameById = new Map(regions.map((region) => [region.id, region.name]));
+  const cities = input.cities.features.map((feature) => ({
+    id: feature.properties.id,
+    name: feature.properties.name,
+    parentRegionId: feature.properties.parent_region ?? null,
+    parentRegionName: feature.properties.parent_region
+      ? regionNameById.get(feature.properties.parent_region) ?? null
+      : null,
+    role: feature.properties.role ?? 'town',
+    x: feature.geometry.coordinates[0],
+    y: invertY(feature.geometry.coordinates[1])
+  }));
+
+  return {
+    cities,
+    emauxByNation: nations.map((nation) => ({
+      blasonDescription: nation.blason?.description ?? null,
+      category: nation.category ?? 'region',
+      emaux: extractEmaux(nation),
+      id: nation.id,
+      name: nation.name
+    })),
+    regions,
+    summary: {
+      cities: cities.length,
+      nations: nations.length,
+      totalPopulation: nations.reduce((total, nation) => total + (readPopulation(nation) ?? 0), 0),
+      vectorRegions: regions.length
+    }
+  };
+}
+
+function extractEmaux(nation: NationDocument | undefined): Emau[] {
+  const colors = nation?.blason?.colors ?? [];
+  const unique = new Set<Emau>();
+
+  for (const color of colors) {
+    const emau = BLAZON_COLOR_TO_EMAU[color.toLowerCase()];
+
+    if (emau) {
+      unique.add(emau);
+    }
+  }
+
+  return [...unique];
+}
+
+function readPopulation(nation: NationDocument | undefined): number | null {
+  const total = nation?.population?.total;
+
+  if (typeof total === 'number') {
+    return Number.isFinite(total) ? total : null;
+  }
+
+  if (typeof total === 'string') {
+    const parsed = Number(total);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function toSvgPath(geometry: RegionGeometry): string {
+  if (geometry.type === 'Polygon') {
+    return polygonToPath(geometry.coordinates);
+  }
+
+  return geometry.coordinates.map(polygonToPath).join(' ');
+}
+
+function polygonToPath(polygon: GeoJsonPolygonCoordinates): string {
+  return polygon
+    .map((ring) =>
+      ring
+        .map(([x, y], index) => `${index === 0 ? 'M' : 'L'} ${format(x)} ${format(invertY(y))}`)
+        .join(' ')
+        .concat(' Z')
+    )
+    .join(' ');
+}
+
+function invertY(value: number): number {
+  return 100 - value;
+}
+
+function format(value: number): string {
+  return String(Number(value.toFixed(3)));
+}

--- a/apps/game/src/features/cartulaire/model.ts
+++ b/apps/game/src/features/cartulaire/model.ts
@@ -149,7 +149,7 @@ export function buildCartulaireReadModel(input: CartulaireReadModelInput): Cartu
     name: feature.properties.name,
     parentRegionId: feature.properties.parent_region ?? null,
     parentRegionName: feature.properties.parent_region
-      ? regionNameById.get(feature.properties.parent_region) ?? null
+      ? (regionNameById.get(feature.properties.parent_region) ?? null)
       : null,
     role: feature.properties.role ?? 'town',
     x: feature.geometry.coordinates[0],

--- a/apps/game/src/features/cartulaire/read-models.ts
+++ b/apps/game/src/features/cartulaire/read-models.ts
@@ -1,0 +1,56 @@
+import { access, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { getCatalogDocument } from '@/lib/catalogs';
+
+import {
+  buildCartulaireReadModel,
+  type CartulaireReadModel,
+  type CityGeometry,
+  type CityProperties,
+  type GeoJsonFeatureCollection,
+  type NationsCatalogDocument,
+  type RegionGeometry,
+  type RegionProperties
+} from './model';
+
+const GEOJSON_CANDIDATE_ROOTS = [
+  resolve(process.cwd(), '../interactive-map/public/data/geojson'),
+  resolve(process.cwd(), 'apps/interactive-map/public/data/geojson')
+] as const;
+
+export async function getCartulaireReadModel(): Promise<CartulaireReadModel> {
+  const [nations, regions, cities] = await Promise.all([
+    getCatalogDocument<NationsCatalogDocument>('nations.yaml'),
+    readGeoJson<GeoJsonFeatureCollection<RegionGeometry, RegionProperties>>('regions.geojson'),
+    readGeoJson<GeoJsonFeatureCollection<CityGeometry, CityProperties>>('cities.geojson')
+  ]);
+
+  return buildCartulaireReadModel({
+    cities,
+    nations,
+    regions
+  });
+}
+
+async function readGeoJson<Document>(fileName: string): Promise<Document> {
+  const filePath = await resolveGeoJsonPath(fileName);
+  const content = await readFile(filePath, 'utf8');
+
+  return JSON.parse(content) as Document;
+}
+
+async function resolveGeoJsonPath(fileName: string): Promise<string> {
+  for (const root of GEOJSON_CANDIDATE_ROOTS) {
+    const filePath = resolve(root, fileName);
+
+    try {
+      await access(filePath);
+      return filePath;
+    } catch {
+      // Try the next known workspace cwd layout.
+    }
+  }
+
+  throw new Error(`Unable to locate interactive-map GeoJSON file ${fileName}.`);
+}

--- a/apps/game/src/lib/surface-theme.test.ts
+++ b/apps/game/src/lib/surface-theme.test.ts
@@ -18,6 +18,7 @@ describe('surface theme contract', () => {
     expect(resolveSkinForPath('/dice')).toBe('tripot');
     expect(resolveSkinForPath('/rules')).toBe('archives');
     expect(resolveSkinForPath('/bibliotheque')).toBe('bibliotheque');
+    expect(resolveSkinForPath('/cartulaire')).toBe('armorial');
     expect(resolveSkinForPath('/design-proto')).toBe('moderne');
   });
 

--- a/apps/game/src/lib/surface-theme.ts
+++ b/apps/game/src/lib/surface-theme.ts
@@ -32,6 +32,7 @@ export const surfaceNavItems: readonly SurfaceNavItem[] = [
   { href: '/dice', label: 'Des', shortLabel: 'D10', skin: 'tripot' },
   { href: '/rules', label: 'Archives', shortLabel: 'D1-D13', skin: 'archives' },
   { href: '/bibliotheque', label: 'Bibliotheque', shortLabel: 'CMS', skin: 'bibliotheque' },
+  { href: '/cartulaire', label: 'Cartulaire', shortLabel: 'Carte', skin: 'armorial' },
   { href: '/design-proto', label: 'Lab', shortLabel: 'Skin', skin: 'moderne' }
 ] as const;
 
@@ -46,6 +47,7 @@ export const routeSkins: readonly [prefix: string, skin: KwSkin][] = [
   ['/dice', 'tripot'],
   ['/rules', 'archives'],
   ['/bibliotheque', 'bibliotheque'],
+  ['/cartulaire', 'armorial'],
   ['/design-proto', 'moderne']
 ] as const;
 


### PR DESCRIPTION
Closes #110. Codex fleet worker under orchestration. Composed with @knightandwizard/ui + design tokens; adds app/cartulaire route + features/cartulaire model. Local gates clean: lint, typecheck, canonical:check current, nomos export in sync.