### PR TITLE
feat(rules-core): moteur d effets - applyEffects + integration (#125)

### DIFF
--- a/packages/rules-core/src/character.test.ts
+++ b/packages/rules-core/src/character.test.ts
@@ -13,6 +13,7 @@ import {
   validateSkillDistribution,
   validateSpellDistribution
 } from './character.js';
+import { parseEffectModel } from './effect-model.js';
 
 describe('character creation validation', () => {
   it('validates the canonical race-category attribute distribution', () => {
@@ -277,6 +278,44 @@ describe('character derived state', () => {
     expect(calculateEffectiveAttributes(character)).toMatchObject({
       strength: 2,
       aestheticism: 0
+    });
+  });
+
+  it('can include effect-model aptitude modifiers in effective attributes', () => {
+    const character = createPlayerCharacter({
+      id: 'pc-effect-model',
+      name: 'Jehan',
+      race: humanRace(),
+      orientation: { id: 'guerrier', name: 'Guerrier' },
+      classProfile: {
+        id: 'garde',
+        name: 'Garde',
+        orientationId: 'guerrier',
+        primarySkillIds: ['epee']
+      },
+      attributes: validAttributes(),
+      skills: validSkills()
+    });
+    const effects = [
+      parseEffectModel({
+        source: { prose: 'Bonus de niveau en force.', ref: 'fixture:strength-level' },
+        spec: {
+          target: 'aptitude',
+          scope: 'strength',
+          op: 'add',
+          value: 'level',
+          activation: 'active',
+          duration: 'ephemeral'
+        },
+        fidelity: 'covered'
+      })
+    ];
+
+    expect(
+      calculateEffectiveAttributes(character, effects, { activations: ['active'], level: 2 })
+    ).toMatchObject({
+      strength: 5,
+      dexterity: 3
     });
   });
 

--- a/packages/rules-core/src/character.ts
+++ b/packages/rules-core/src/character.ts
@@ -1,4 +1,6 @@
 import { type Combatant } from './combat.js';
+import { effectiveAttribute, type EffectApplicationContext } from './effects.js';
+import { type EffectModel } from './effect-model.js';
 import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
 
 export const ATTRIBUTE_KEYS = [
@@ -462,7 +464,11 @@ export function migrateCharacter<T extends Character>(
   return { character: migrated, changes, warnings };
 }
 
-export function calculateEffectiveAttributes(character: Character): CharacterAttributes {
+export function calculateEffectiveAttributes(
+  character: Character,
+  effects: EffectModel[] = [],
+  ctx: EffectApplicationContext = {}
+): CharacterAttributes {
   const effective = { ...character.attributes };
 
   for (const modifier of character.modifiers) {
@@ -474,6 +480,10 @@ export function calculateEffectiveAttributes(character: Character): CharacterAtt
     }
 
     effective[modifier.target] = clampMinZero(effective[modifier.target] + modifier.value);
+  }
+
+  for (const key of ATTRIBUTE_KEYS) {
+    effective[key] = effectiveAttribute(effective[key], key, effects, ctx);
   }
 
   return effective;

--- a/packages/rules-core/src/dice.test.ts
+++ b/packages/rules-core/src/dice.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { rollDice } from './dice.js';
+import { calculateEffectiveRollRequest, rollDice } from './dice.js';
+import { parseEffectModel } from './effect-model.js';
 
 describe('D10 resolution', () => {
   it('counts one success per die that reaches a standard difficulty', () => {
@@ -105,6 +106,44 @@ describe('D10 resolution', () => {
     expect(() => rollDice(1, 7, { randomInteger: () => 11 })).toThrow(
       'randomInteger(10) must return an integer between 1 and 10'
     );
+  });
+
+  it('calculates an effective roll request from pool and difficulty effects', () => {
+    const effects = [
+      parseEffectModel({
+        source: { prose: 'Aide au jet.', ref: 'fixture:pool' },
+        spec: {
+          target: 'pool',
+          scope: 'attack',
+          op: 'add',
+          value: 1,
+          activation: 'passive',
+          duration: 'permanent'
+        },
+        fidelity: 'covered'
+      }),
+      parseEffectModel({
+        source: { prose: 'Difficulte reduite.', ref: 'fixture:difficulty' },
+        spec: {
+          target: 'difficulty',
+          scope: 'attack',
+          op: 'sub',
+          value: 2,
+          activation: 'active',
+          duration: 'ephemeral'
+        },
+        fidelity: 'covered'
+      })
+    ];
+
+    expect(
+      calculateEffectiveRollRequest(
+        { pool: 2, difficulty: 7 },
+        effects,
+        { activations: ['active'] },
+        { scope: 'attack' }
+      )
+    ).toEqual({ pool: 3, difficulty: 5 });
   });
 
   it('can use the default random source', () => {

--- a/packages/rules-core/src/dice.ts
+++ b/packages/rules-core/src/dice.ts
@@ -80,9 +80,16 @@ export function calculateEffectiveRollRequest(
   const poolScope = scopes.pool ?? scopes.scope;
   const difficultyScope = scopes.difficulty ?? scopes.scope;
   const pool = effectiveValue(request.pool, 'pool', poolScope, effects, ctx, { minimum: 0 });
-  const difficulty = effectiveValue(request.difficulty, 'difficulty', difficultyScope, effects, ctx, {
-    minimum: 1
-  });
+  const difficulty = effectiveValue(
+    request.difficulty,
+    'difficulty',
+    difficultyScope,
+    effects,
+    ctx,
+    {
+      minimum: 1
+    }
+  );
 
   assertNonNegativeInteger('pool', pool);
   assertPositiveInteger('difficulty', difficulty);

--- a/packages/rules-core/src/dice.ts
+++ b/packages/rules-core/src/dice.ts
@@ -1,7 +1,16 @@
+import { effectiveValue, type EffectApplicationContext } from './effects.js';
+import { type EffectModel } from './effect-model.js';
+
 export type RandomInteger = (sides: number) => number;
 
 export interface RollDiceOptions {
   randomInteger?: RandomInteger;
+}
+
+export interface RollEffectScopes {
+  scope?: string;
+  pool?: string;
+  difficulty?: string;
 }
 
 export interface DiceRollResult {
@@ -11,6 +20,11 @@ export interface DiceRollResult {
   isCriticalFailure: boolean;
   total: number;
   criticalFailureSeverity?: number;
+}
+
+export interface DiceRollRequest {
+  pool: number;
+  difficulty: number;
 }
 
 interface InitialDie {
@@ -55,6 +69,25 @@ export function rollDice(
   }
 
   return resolveHighDifficulty(pool, difficulty, initialDice, randomInteger);
+}
+
+export function calculateEffectiveRollRequest(
+  request: DiceRollRequest,
+  effects: EffectModel[] = [],
+  ctx: EffectApplicationContext = {},
+  scopes: RollEffectScopes = {}
+): DiceRollRequest {
+  const poolScope = scopes.pool ?? scopes.scope;
+  const difficultyScope = scopes.difficulty ?? scopes.scope;
+  const pool = effectiveValue(request.pool, 'pool', poolScope, effects, ctx, { minimum: 0 });
+  const difficulty = effectiveValue(request.difficulty, 'difficulty', difficultyScope, effects, ctx, {
+    minimum: 1
+  });
+
+  assertNonNegativeInteger('pool', pool);
+  assertPositiveInteger('difficulty', difficulty);
+
+  return { pool, difficulty };
 }
 
 function resolveStandardDifficulty(

--- a/packages/rules-core/src/effects.test.ts
+++ b/packages/rules-core/src/effects.test.ts
@@ -109,7 +109,9 @@ describe('effect modifier engine', () => {
   });
 });
 
-function effect(spec: Partial<EffectSpec> & Pick<EffectSpec, 'target' | 'op' | 'value'>): EffectModel {
+function effect(
+  spec: Partial<EffectSpec> & Pick<EffectSpec, 'target' | 'op' | 'value'>
+): EffectModel {
   return parseEffectModel({
     source: { prose: 'Fixture effect.', ref: 'fixture:effect' },
     spec: {

--- a/packages/rules-core/src/effects.test.ts
+++ b/packages/rules-core/src/effects.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseEffectModel, type EffectModel, type EffectSpec } from './effect-model.js';
+import { computeEffectiveModifiers, effectiveAttribute } from './effects.js';
+
+describe('effect modifier engine', () => {
+  it('accumulates active additive modifiers by target and scope', () => {
+    const effects = [
+      effect({ target: 'aptitude', scope: 'strength', op: 'add', value: 2 }),
+      effect({
+        target: 'aptitude',
+        scope: 'strength',
+        op: 'add',
+        value: 'level',
+        activation: 'active'
+      }),
+      effect({
+        target: 'aptitude',
+        scope: 'dexterity',
+        op: 'add',
+        value: 4
+      })
+    ];
+
+    const modifiers = computeEffectiveModifiers(effects, { activations: ['active'], level: 3 });
+
+    expect(modifiers.aptitude.strength).toMatchObject({
+      target: 'aptitude',
+      scope: 'strength',
+      add: 5,
+      sub: 0,
+      multiply: 1,
+      additive: 5
+    });
+    expect(modifiers.aptitude.dexterity.add).toBe(4);
+  });
+
+  it('ignores effects whose condition, activation, or duration is inactive', () => {
+    const effects = [
+      effect({
+        target: 'difficulty',
+        scope: 'attack',
+        op: 'sub',
+        value: 1,
+        condition: { action_type: 'attack' }
+      }),
+      effect({
+        target: 'difficulty',
+        scope: 'attack',
+        op: 'sub',
+        value: 10,
+        condition: { action_type: 'defense' }
+      }),
+      effect({
+        target: 'difficulty',
+        scope: 'attack',
+        op: 'sub',
+        value: 10,
+        activation: 'triggered'
+      }),
+      effect({
+        target: 'difficulty',
+        scope: 'attack',
+        op: 'sub',
+        value: 10,
+        duration: { dt: 2 }
+      })
+    ];
+
+    const modifiers = computeEffectiveModifiers(effects, {
+      action_type: 'attack',
+      activations: ['active'],
+      elapsedDT: 2
+    });
+
+    expect(modifiers.difficulty.attack.sub).toBe(1);
+    expect(modifiers.difficulty.attack.additive).toBe(-1);
+    expect(modifiers.difficulty.attack.applications).toHaveLength(1);
+  });
+
+  it('applies set and multiply operations when resolving an effective aptitude', () => {
+    const effects = [
+      effect({ target: 'aptitude', scope: 'strength', op: 'set', value: 4 }),
+      effect({ target: 'aptitude', scope: 'strength', op: 'add', value: 1 }),
+      effect({ target: 'aptitude', scope: 'strength', op: 'multiply', value: 2 })
+    ];
+
+    expect(effectiveAttribute(3, 'strength', effects, {})).toBe(10);
+  });
+
+  it('floors effective aptitudes at zero', () => {
+    const effects = [effect({ target: 'aptitude', scope: 'aestheticism', op: 'sub', value: 5 })];
+
+    expect(effectiveAttribute(1, 'aestheticism', effects, {})).toBe(0);
+  });
+
+  it('recognizes status targets without resolving a status catalog', () => {
+    const effects = [
+      effect({ target: 'status', scope: 'stunned', op: 'grant', value: 0, activation: 'active' })
+    ];
+
+    const modifiers = computeEffectiveModifiers(effects, { activations: ['active'] });
+
+    expect(modifiers.status.stunned).toMatchObject({
+      target: 'status',
+      scope: 'stunned',
+      applications: [{ op: 'grant', sourceRef: 'fixture:effect' }]
+    });
+  });
+});
+
+function effect(spec: Partial<EffectSpec> & Pick<EffectSpec, 'target' | 'op' | 'value'>): EffectModel {
+  return parseEffectModel({
+    source: { prose: 'Fixture effect.', ref: 'fixture:effect' },
+    spec: {
+      activation: 'passive',
+      duration: 'permanent',
+      ...spec
+    },
+    fidelity: 'covered'
+  });
+}

--- a/packages/rules-core/src/effects.ts
+++ b/packages/rules-core/src/effects.ts
@@ -1,0 +1,290 @@
+import {
+  evaluateValue,
+  matchesCondition,
+  parseEffectModel,
+  type EffectActivation,
+  type EffectConditionContext,
+  type EffectDuration,
+  type EffectModel,
+  type EffectOperation,
+  type EffectSpec,
+  type EffectTarget,
+  type EffectValueContext
+} from './effect-model.js';
+
+export const GLOBAL_EFFECT_SCOPE = '__global__';
+
+export type NumericEffectTarget = Exclude<EffectTarget, 'status'>;
+export type NumericEffectOperation = Extract<EffectOperation, 'add' | 'sub' | 'set' | 'multiply'>;
+
+export type EffectApplicationContext = EffectConditionContext &
+  EffectValueContext & {
+    activations?: readonly EffectActivation[];
+    elapsedDT?: number;
+    includeEphemeral?: boolean;
+  };
+
+export interface EffectModifierApplication {
+  sourceRef: string;
+  target: NumericEffectTarget;
+  scope?: string;
+  op: NumericEffectOperation;
+  value: number;
+}
+
+export interface EffectModifierBucket {
+  target: NumericEffectTarget;
+  scope?: string;
+  add: number;
+  sub: number;
+  set?: number;
+  multiply: number;
+  additive: number;
+  applications: EffectModifierApplication[];
+}
+
+export interface EffectStatusApplication {
+  sourceRef: string;
+  op: EffectOperation;
+}
+
+export interface EffectStatusBucket {
+  target: 'status';
+  scope?: string;
+  applications: EffectStatusApplication[];
+}
+
+export interface EffectiveModifiers {
+  aptitude: Record<string, EffectModifierBucket>;
+  factor: Record<string, EffectModifierBucket>;
+  difficulty: Record<string, EffectModifierBucket>;
+  pool: Record<string, EffectModifierBucket>;
+  energy: Record<string, EffectModifierBucket>;
+  vitality: Record<string, EffectModifierBucket>;
+  status: Record<string, EffectStatusBucket>;
+}
+
+export interface EffectiveValueOptions {
+  minimum?: number;
+}
+
+export function computeEffectiveModifiers(
+  activeEffects: EffectModel[],
+  ctx: EffectApplicationContext
+): EffectiveModifiers {
+  const modifiers = createEmptyModifiers();
+
+  for (const activeEffect of activeEffects) {
+    const effect = parseEffectModel(activeEffect);
+
+    if (!isEffectActive(effect.spec, ctx)) {
+      continue;
+    }
+
+    if (effect.spec.target === 'status') {
+      recordStatusEffect(modifiers, effect);
+      continue;
+    }
+
+    if (!isNumericOperation(effect.spec.op)) {
+      throw new Error(`Effect operation "${effect.spec.op}" is only supported for status targets`);
+    }
+
+    const value = evaluateValue(effect.spec.value, ctx);
+    const bucket = getOrCreateModifierBucket(modifiers, effect.spec.target, effect.spec.scope);
+
+    applyNumericOperation(bucket, {
+      sourceRef: effect.source.ref,
+      target: effect.spec.target,
+      scope: effect.spec.scope,
+      op: effect.spec.op,
+      value
+    });
+  }
+
+  return modifiers;
+}
+
+export function effectiveAttribute(
+  base: number,
+  scope: string,
+  effects: EffectModel[],
+  ctx: EffectApplicationContext
+): number {
+  return effectiveValue(base, 'aptitude', scope, effects, ctx, { minimum: 0 });
+}
+
+export function effectiveValue(
+  base: number,
+  target: NumericEffectTarget,
+  scope: string | undefined,
+  effects: EffectModel[],
+  ctx: EffectApplicationContext,
+  options: EffectiveValueOptions = {}
+): number {
+  const modifiers = computeEffectiveModifiers(effects, ctx);
+
+  return applyEffectiveModifiers(base, target, scope, modifiers, options);
+}
+
+export function applyEffectiveModifiers(
+  base: number,
+  target: NumericEffectTarget,
+  scope: string | undefined,
+  modifiers: EffectiveModifiers,
+  options: EffectiveValueOptions = {}
+): number {
+  let value = base;
+
+  for (const bucket of collectBuckets(modifiers, target, scope)) {
+    value = applyBucket(value, bucket);
+  }
+
+  return options.minimum === undefined ? value : Math.max(options.minimum, value);
+}
+
+function createEmptyModifiers(): EffectiveModifiers {
+  return {
+    aptitude: {},
+    factor: {},
+    difficulty: {},
+    pool: {},
+    energy: {},
+    vitality: {},
+    status: {}
+  };
+}
+
+function isEffectActive(spec: EffectSpec, ctx: EffectApplicationContext): boolean {
+  return (
+    matchesCondition(spec.condition, ctx) &&
+    isActivationActive(spec.activation, ctx) &&
+    isDurationActive(spec.duration, ctx)
+  );
+}
+
+function isActivationActive(activation: EffectActivation, ctx: EffectApplicationContext): boolean {
+  if (activation === 'passive') {
+    return true;
+  }
+
+  return ctx.activations?.includes(activation) ?? false;
+}
+
+function isDurationActive(duration: EffectDuration, ctx: EffectApplicationContext): boolean {
+  if (duration === 'permanent' || duration === 'until_dispel') {
+    return true;
+  }
+
+  if (duration === 'ephemeral') {
+    return ctx.includeEphemeral !== false;
+  }
+
+  return ctx.elapsedDT === undefined || ctx.elapsedDT < duration.dt;
+}
+
+function isNumericOperation(op: EffectOperation): op is NumericEffectOperation {
+  return op === 'add' || op === 'sub' || op === 'set' || op === 'multiply';
+}
+
+function getOrCreateModifierBucket(
+  modifiers: EffectiveModifiers,
+  target: NumericEffectTarget,
+  scope: string | undefined
+): EffectModifierBucket {
+  const buckets = modifiers[target];
+  const key = effectScopeKey(scope);
+  const existing = buckets[key];
+
+  if (existing !== undefined) {
+    return existing;
+  }
+
+  const bucket = createModifierBucket(target, scope);
+  buckets[key] = bucket;
+
+  return bucket;
+}
+
+function createModifierBucket(
+  target: NumericEffectTarget,
+  scope: string | undefined
+): EffectModifierBucket {
+  return {
+    target,
+    ...(scope === undefined ? {} : { scope }),
+    add: 0,
+    sub: 0,
+    multiply: 1,
+    additive: 0,
+    applications: []
+  };
+}
+
+function applyNumericOperation(
+  bucket: EffectModifierBucket,
+  application: EffectModifierApplication
+): void {
+  switch (application.op) {
+    case 'add':
+      bucket.add += application.value;
+      break;
+    case 'sub':
+      bucket.sub += application.value;
+      break;
+    case 'set':
+      bucket.set = application.value;
+      break;
+    case 'multiply':
+      bucket.multiply *= application.value;
+      break;
+  }
+
+  bucket.additive = bucket.add - bucket.sub;
+  bucket.applications.push(application);
+}
+
+function recordStatusEffect(modifiers: EffectiveModifiers, effect: EffectModel): void {
+  const key = effectScopeKey(effect.spec.scope);
+  const existing = modifiers.status[key];
+  const bucket =
+    existing ??
+    ({
+      target: 'status',
+      ...(effect.spec.scope === undefined ? {} : { scope: effect.spec.scope }),
+      applications: []
+    } satisfies EffectStatusBucket);
+
+  bucket.applications.push({
+    sourceRef: effect.source.ref,
+    op: effect.spec.op
+  });
+  modifiers.status[key] = bucket;
+}
+
+function collectBuckets(
+  modifiers: EffectiveModifiers,
+  target: NumericEffectTarget,
+  scope: string | undefined
+): EffectModifierBucket[] {
+  const buckets = modifiers[target];
+  const keys =
+    scope === undefined || scope === GLOBAL_EFFECT_SCOPE
+      ? [GLOBAL_EFFECT_SCOPE]
+      : [GLOBAL_EFFECT_SCOPE, scope];
+
+  return keys.flatMap((key) => {
+    const bucket = buckets[key];
+    return bucket === undefined ? [] : [bucket];
+  });
+}
+
+function applyBucket(base: number, bucket: EffectModifierBucket): number {
+  const anchored = bucket.set ?? base;
+
+  return (anchored + bucket.additive) * bucket.multiply;
+}
+
+function effectScopeKey(scope: string | undefined): string {
+  return scope ?? GLOBAL_EFFECT_SCOPE;
+}

--- a/packages/rules-core/src/index.ts
+++ b/packages/rules-core/src/index.ts
@@ -3,6 +3,7 @@ export * from './character.js';
 export * from './combat.js';
 export * from './dice.js';
 export * from './effect-model.js';
+export * from './effects.js';
 export * from './npc-control.js';
 export * from './progression.js';
 export * from './rules-config.js';


### PR DESCRIPTION
effects.ts: computeEffectiveModifiers (empilement lineaire R-1.36/R-2.17) + effectiveAttribute (plancher 0). Integration ADDITIVE: calculateEffectiveAttributes(char, effects?, ctx?) retro-compatible, dice calculateEffectiveRollRequest (rollDice inchange). Consomme EffectModel (#123). 282 tests. EPIC #122. Closes #125.