### PR TITLE
feat(rules-core): renderer d effets spec->FR (#124)

### DIFF
--- a/packages/rules-core/src/effect-renderer.test.ts
+++ b/packages/rules-core/src/effect-renderer.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+
+import type { EffectModel } from './effect-model.js';
+import { describeFidelity, renderEffect } from './effect-renderer.js';
+
+function effectModel(spec: EffectModel['spec'], prose = 'Prose canonique.'): EffectModel {
+  return {
+    source: {
+      prose,
+      ref: 'fixture:effect-renderer'
+    },
+    spec,
+    fidelity: 'covered'
+  };
+}
+
+describe('renderEffect', () => {
+  it('renders pool additions from a variable value with all_of conditions', () => {
+    const model = effectModel({
+      target: 'pool',
+      scope: 'abordage',
+      op: 'add',
+      value: 'level',
+      condition: {
+        all_of: [{ context: 'combat' }, { env: 'naval' }]
+      },
+      activation: 'passive',
+      duration: 'permanent'
+    });
+
+    expect(renderEffect(model)).toBe('Ajoute niveau au pool de dés en combat naval');
+  });
+
+  it('renders difficulty reductions with any_of target conditions', () => {
+    const model = effectModel({
+      target: 'difficulty',
+      op: 'sub',
+      value: 5,
+      condition: {
+        any_of: [{ target_tag: 'undead' }, { target_tag: 'demon' }]
+      },
+      activation: 'active',
+      duration: 'ephemeral'
+    });
+
+    expect(renderEffect(model)).toBe(
+      'Réduit la difficulté de 5 contre les morts-vivants ou contre les démons'
+    );
+  });
+
+  it('renders aptitude and status templates with scoped labels', () => {
+    const aptitude = effectModel({
+      target: 'aptitude',
+      scope: 'force',
+      op: 'add',
+      value: 2,
+      condition: { action_type: 'attaque' },
+      activation: 'triggered',
+      duration: { dt: 10 }
+    });
+    const status = effectModel({
+      target: 'status',
+      scope: 'effrayé',
+      op: 'grant',
+      value: 1,
+      activation: 'triggered',
+      duration: 'ephemeral'
+    });
+
+    expect(renderEffect(aptitude)).toBe('+2 en Force lors d’une attaque');
+    expect(renderEffect(status)).toBe("Inflige l'état effrayé");
+  });
+
+  it('renders vitality, energy and factor numeric templates', () => {
+    const vitality = effectModel({
+      target: 'vitality',
+      op: 'add',
+      value: { table: 'soins_par_niveau', key: 'level' },
+      activation: 'active',
+      duration: 'ephemeral'
+    });
+    const energy = effectModel({
+      target: 'energy',
+      op: 'add',
+      value: 'level * 2',
+      activation: 'active',
+      duration: 'ephemeral'
+    });
+    const factor = effectModel({
+      target: 'factor',
+      scope: 'volonté',
+      op: 'sub',
+      value: 1,
+      activation: 'active',
+      duration: { dt: 5 }
+    });
+
+    expect(renderEffect(vitality)).toBe(
+      'Restaure la valeur de la table soins_par_niveau selon niveau points de vitalité'
+    );
+    expect(renderEffect(energy)).toBe("Restaure niveau x 2 points d'énergie");
+    expect(renderEffect(factor)).toBe('Réduit le facteur volonté de 1');
+  });
+
+  it('uses a readable generic fallback for uncovered target-operation pairs', () => {
+    const model = effectModel({
+      target: 'status',
+      scope: 'confusion',
+      op: 'multiply',
+      value: 2,
+      activation: 'active',
+      duration: 'ephemeral'
+    });
+
+    expect(renderEffect(model)).toBe('Applique multiply 2 sur état (confusion)');
+  });
+});
+
+describe('describeFidelity', () => {
+  it('exposes source prose next to the current generated render without semantic claims', () => {
+    const model: EffectModel = {
+      ...effectModel(
+        {
+          target: 'pool',
+          op: 'add',
+          value: 1,
+          activation: 'passive',
+          duration: 'permanent'
+        },
+        'Le personnage gagne un dé.'
+      ),
+      render: 'ancien rendu',
+      fidelity: 'ambiguous'
+    };
+
+    expect(describeFidelity(model)).toEqual({
+      prose: 'Le personnage gagne un dé.',
+      render: 'Ajoute 1 au pool de dés',
+      fidelity: 'ambiguous'
+    });
+  });
+});

--- a/packages/rules-core/src/effect-renderer.ts
+++ b/packages/rules-core/src/effect-renderer.ts
@@ -158,8 +158,7 @@ const EFFECT_RENDER_TEMPLATES: Partial<Record<RenderTemplateKey, (spec: EffectSp
   'difficulty:multiply': (spec) => `Multiplie la difficulté par ${renderValue(spec.value)}`,
   'aptitude:add': (spec) => `+${renderValue(spec.value)} en ${renderScope(spec.scope)}`,
   'aptitude:sub': (spec) => `-${renderValue(spec.value)} en ${renderScope(spec.scope)}`,
-  'aptitude:set': (spec) =>
-    `Fixe ${renderScope(spec.scope)} à ${renderValue(spec.value)}`,
+  'aptitude:set': (spec) => `Fixe ${renderScope(spec.scope)} à ${renderValue(spec.value)}`,
   'aptitude:multiply': (spec) =>
     `Multiplie ${renderScope(spec.scope)} par ${renderValue(spec.value)}`,
   'aptitude:grant': (spec) => `Accorde ${renderScope(spec.scope)}`,

--- a/packages/rules-core/src/effect-renderer.ts
+++ b/packages/rules-core/src/effect-renderer.ts
@@ -1,0 +1,456 @@
+import { EFFECT_CONDITION_KEYS } from './effect-model.js';
+import type {
+  EffectCondition,
+  EffectConditionKey,
+  EffectConditionValue,
+  EffectFidelity,
+  EffectModel,
+  EffectOperation,
+  EffectSpec,
+  EffectTarget,
+  EffectValue,
+  EffectValueVariable
+} from './effect-model.js';
+
+type RenderTemplateKey = `${EffectTarget}:${EffectOperation}`;
+type ConditionBuckets = Partial<Record<EffectConditionKey, string[]>>;
+
+export interface EffectFidelityDescription {
+  prose: string;
+  render: string;
+  fidelity: EffectFidelity;
+}
+
+const VALUE_LABELS: Record<EffectValueVariable, string> = {
+  level: 'niveau',
+  force: 'Force',
+  dexterity: 'Dextérité',
+  stamina: 'Endurance',
+  reflexes: 'Réflexes',
+  perception: 'Perception',
+  intelligence: 'Intelligence',
+  charisma: 'Charisme',
+  empathy: 'Empathie',
+  aestheticism: 'Esthétique',
+  vitalityMax: 'vitalité maximale',
+  energyMax: 'énergie maximale'
+};
+
+const SCOPE_LABELS: Record<string, string> = {
+  ...VALUE_LABELS,
+  volonte: 'volonté',
+  volonté: 'volonté'
+};
+
+const TARGET_LABELS: Record<EffectTarget, string> = {
+  aptitude: 'aptitude',
+  factor: 'facteur',
+  difficulty: 'difficulté',
+  pool: 'pool de dés',
+  energy: 'énergie',
+  vitality: 'vitalité',
+  status: 'état'
+};
+
+const CONTEXT_LABELS: Record<string, string> = {
+  combat: 'combat',
+  exploration: 'exploration',
+  social: 'interaction sociale',
+  rest: 'repos'
+};
+
+const ENVIRONMENT_LABELS: Record<string, string> = {
+  naval: 'naval',
+  mounted: 'monté',
+  underwater: 'sous-marin',
+  darkness: 'obscur'
+};
+
+const ENVIRONMENT_PHRASES: Record<string, string> = {
+  naval: 'en environnement naval',
+  mounted: 'à dos de monture',
+  underwater: 'sous l’eau',
+  darkness: 'dans l’obscurité'
+};
+
+const ACTION_PHRASES: Record<string, string> = {
+  attaque: 'lors d’une attaque',
+  attack: 'lors d’une attaque',
+  defense: 'lors d’une défense',
+  défense: 'lors d’une défense',
+  sort: 'lors d’un sort',
+  spell: 'lors d’un sort',
+  esquive: 'lors d’une esquive',
+  dodge: 'lors d’une esquive'
+};
+
+const TARGET_TAG_LABELS: Record<string, string> = {
+  undead: 'les morts-vivants',
+  demon: 'les démons',
+  magical: 'les cibles magiques',
+  armored: 'les cibles armurées',
+  living: 'les vivants'
+};
+
+const WEAPON_LABELS: Record<string, string> = {
+  sword: 'une épée',
+  epee: 'une épée',
+  épée: 'une épée',
+  bow: 'un arc',
+  arc: 'un arc',
+  knife: 'un couteau',
+  couteau: 'un couteau'
+};
+
+const SCHOOL_LABELS: Record<string, string> = {
+  abjuration: 'd’abjuration',
+  necromancy: 'de nécromancie',
+  nécromancie: 'de nécromancie',
+  illusion: 'd’illusion'
+};
+
+const SELF_STATE_LABELS: Record<string, string> = {
+  enraged: 'enragé',
+  wounded: 'blessé',
+  prone: 'à terre',
+  hidden: 'caché'
+};
+
+export const EFFECT_RENDER_TEMPLATE_KEYS = [
+  'pool:add',
+  'pool:sub',
+  'pool:set',
+  'pool:multiply',
+  'difficulty:add',
+  'difficulty:sub',
+  'difficulty:set',
+  'difficulty:multiply',
+  'aptitude:add',
+  'aptitude:sub',
+  'aptitude:set',
+  'aptitude:multiply',
+  'aptitude:grant',
+  'factor:add',
+  'factor:sub',
+  'factor:set',
+  'factor:multiply',
+  'energy:add',
+  'energy:sub',
+  'energy:set',
+  'energy:multiply',
+  'vitality:add',
+  'vitality:sub',
+  'vitality:set',
+  'vitality:multiply',
+  'status:grant',
+  'status:sub',
+  'status:set'
+] as const satisfies readonly RenderTemplateKey[];
+
+const EFFECT_RENDER_TEMPLATES: Partial<Record<RenderTemplateKey, (spec: EffectSpec) => string>> = {
+  'pool:add': (spec) => `Ajoute ${renderValue(spec.value)} au pool de dés`,
+  'pool:sub': (spec) => `Retire ${renderValue(spec.value)} du pool de dés`,
+  'pool:set': (spec) => `Fixe le pool de dés à ${renderValue(spec.value)}`,
+  'pool:multiply': (spec) => `Multiplie le pool de dés par ${renderValue(spec.value)}`,
+  'difficulty:add': (spec) => `Augmente la difficulté de ${renderValue(spec.value)}`,
+  'difficulty:sub': (spec) => `Réduit la difficulté de ${renderValue(spec.value)}`,
+  'difficulty:set': (spec) => `Fixe la difficulté à ${renderValue(spec.value)}`,
+  'difficulty:multiply': (spec) => `Multiplie la difficulté par ${renderValue(spec.value)}`,
+  'aptitude:add': (spec) => `+${renderValue(spec.value)} en ${renderScope(spec.scope)}`,
+  'aptitude:sub': (spec) => `-${renderValue(spec.value)} en ${renderScope(spec.scope)}`,
+  'aptitude:set': (spec) =>
+    `Fixe ${renderScope(spec.scope)} à ${renderValue(spec.value)}`,
+  'aptitude:multiply': (spec) =>
+    `Multiplie ${renderScope(spec.scope)} par ${renderValue(spec.value)}`,
+  'aptitude:grant': (spec) => `Accorde ${renderScope(spec.scope)}`,
+  'factor:add': (spec) =>
+    `Augmente ${renderScopedTarget('le facteur', spec.scope)} de ${renderValue(spec.value)}`,
+  'factor:sub': (spec) =>
+    `Réduit ${renderScopedTarget('le facteur', spec.scope)} de ${renderValue(spec.value)}`,
+  'factor:set': (spec) =>
+    `Fixe ${renderScopedTarget('le facteur', spec.scope)} à ${renderValue(spec.value)}`,
+  'factor:multiply': (spec) =>
+    `Multiplie ${renderScopedTarget('le facteur', spec.scope)} par ${renderValue(spec.value)}`,
+  'energy:add': (spec) => `Restaure ${renderValue(spec.value)} points d'énergie`,
+  'energy:sub': (spec) => `Retire ${renderValue(spec.value)} points d'énergie`,
+  'energy:set': (spec) => `Fixe l'énergie à ${renderValue(spec.value)}`,
+  'energy:multiply': (spec) => `Multiplie l'énergie par ${renderValue(spec.value)}`,
+  'vitality:add': (spec) => `Restaure ${renderValue(spec.value)} points de vitalité`,
+  'vitality:sub': (spec) => `Retire ${renderValue(spec.value)} points de vitalité`,
+  'vitality:set': (spec) => `Fixe la vitalité à ${renderValue(spec.value)}`,
+  'vitality:multiply': (spec) => `Multiplie la vitalité par ${renderValue(spec.value)}`,
+  'status:grant': (spec) => `Inflige l'état ${renderScope(spec.scope)}`,
+  'status:sub': (spec) => `Retire l'état ${renderScope(spec.scope)}`,
+  'status:set': (spec) => `Fixe l'état à ${renderScope(spec.scope)}`
+};
+
+export function renderEffect(model: EffectModel): string {
+  const baseRender = renderEffectSpec(model.spec);
+  const conditionRender = renderConditionSuffix(model.spec.condition);
+
+  return `${baseRender}${conditionRender}`;
+}
+
+/**
+ * Exposes source prose beside the generated render for human audit.
+ * The returned fidelity is the model's declared review state, not an automatic semantic verdict.
+ */
+export function describeFidelity(model: EffectModel): EffectFidelityDescription {
+  return {
+    prose: model.source.prose,
+    render: renderEffect(model),
+    fidelity: model.fidelity
+  };
+}
+
+function renderEffectSpec(spec: EffectSpec): string {
+  const template = EFFECT_RENDER_TEMPLATES[toTemplateKey(spec)];
+
+  if (template !== undefined) {
+    return template(spec);
+  }
+
+  return renderFallback(spec);
+}
+
+function renderFallback(spec: EffectSpec): string {
+  const scope = spec.scope === undefined ? '' : ` (${renderScope(spec.scope)})`;
+
+  return `Applique ${spec.op} ${renderValue(spec.value)} sur ${TARGET_LABELS[spec.target]}${scope}`;
+}
+
+function renderValue(value: EffectValue): string {
+  if (typeof value === 'number') {
+    return String(value);
+  }
+
+  if (typeof value === 'string') {
+    return isEffectValueVariable(value) ? VALUE_LABELS[value] : renderExpression(value);
+  }
+
+  return `la valeur de la table ${value.table} selon ${VALUE_LABELS[value.key]}`;
+}
+
+function renderExpression(expression: string): string {
+  const tokens = expression.match(/[A-Za-z_][A-Za-z0-9_]*|\d+|[()+\-*/]/g) ?? [];
+
+  return tokens
+    .map((token) => renderExpressionToken(token))
+    .join(' ')
+    .replace(/\( /g, '(')
+    .replace(/ \)/g, ')')
+    .trim();
+}
+
+function renderExpressionToken(token: string): string {
+  if (token === '*') {
+    return 'x';
+  }
+
+  if (isEffectValueVariable(token)) {
+    return VALUE_LABELS[token];
+  }
+
+  return token;
+}
+
+function renderConditionSuffix(condition: EffectCondition | undefined): string {
+  if (condition === undefined) {
+    return '';
+  }
+
+  const conditionRender = renderConditionBody(condition);
+
+  return conditionRender === '' ? '' : ` ${conditionRender}`;
+}
+
+function renderConditionBody(condition: EffectCondition): string {
+  const flatCondition = flattenConjunction(condition);
+
+  if (flatCondition !== null) {
+    return renderFlatCondition(flatCondition);
+  }
+
+  const parts: string[] = [];
+  const directConditions = renderDirectConditionKeys(condition);
+
+  if (directConditions !== '') {
+    parts.push(directConditions);
+  }
+
+  if (condition.all_of !== undefined) {
+    parts.push(...condition.all_of.map(renderConditionBody).filter(Boolean));
+  }
+
+  if (condition.any_of !== undefined) {
+    const anyOfRender = condition.any_of.map(renderConditionBody).filter(Boolean).join(' ou ');
+
+    if (anyOfRender !== '') {
+      parts.push(anyOfRender);
+    }
+  }
+
+  return parts.join(' et ');
+}
+
+function renderDirectConditionKeys(condition: EffectCondition): string {
+  const buckets = readDirectConditionKeys(condition);
+
+  return renderFlatCondition(buckets);
+}
+
+function renderFlatCondition(buckets: ConditionBuckets): string {
+  const parts: string[] = [];
+  const contextValues = buckets.context ?? [];
+  const environmentValues = buckets.env ?? [];
+
+  if (contextValues.length > 0 && environmentValues.length > 0) {
+    parts.push(
+      `en ${joinLabels(contextValues.map(renderContextLabel))} ${joinLabels(
+        environmentValues.map(renderEnvironmentLabel)
+      )}`
+    );
+  } else if (contextValues.length > 0) {
+    parts.push(joinLabels(contextValues.map(renderContextPhrase)));
+  } else if (environmentValues.length > 0) {
+    parts.push(joinLabels(environmentValues.map(renderEnvironmentPhrase)));
+  }
+
+  appendConditionPart(parts, buckets.action_type, renderActionPhrase);
+  appendConditionPart(parts, buckets.target_tag, renderTargetTagPhrase);
+  appendConditionPart(parts, buckets.weapon, renderWeaponPhrase);
+  appendConditionPart(parts, buckets.school, renderSchoolPhrase);
+  appendConditionPart(parts, buckets.self_state, renderSelfStatePhrase);
+
+  return parts.join(' et ');
+}
+
+function flattenConjunction(condition: EffectCondition): ConditionBuckets | null {
+  if (condition.any_of !== undefined) {
+    return null;
+  }
+
+  const buckets = readDirectConditionKeys(condition);
+
+  for (const child of condition.all_of ?? []) {
+    const childBuckets = flattenConjunction(child);
+
+    if (childBuckets === null) {
+      return null;
+    }
+
+    mergeConditionBuckets(buckets, childBuckets);
+  }
+
+  return buckets;
+}
+
+function readDirectConditionKeys(condition: EffectCondition): ConditionBuckets {
+  const buckets: ConditionBuckets = {};
+
+  for (const key of EFFECT_CONDITION_KEYS) {
+    const value = condition[key];
+
+    if (value !== undefined) {
+      buckets[key] = readConditionValues(value);
+    }
+  }
+
+  return buckets;
+}
+
+function mergeConditionBuckets(target: ConditionBuckets, source: ConditionBuckets): void {
+  for (const key of EFFECT_CONDITION_KEYS) {
+    const values = source[key];
+
+    if (values !== undefined) {
+      target[key] = [...(target[key] ?? []), ...values];
+    }
+  }
+}
+
+function appendConditionPart(
+  parts: string[],
+  values: string[] | undefined,
+  render: (value: string) => string
+): void {
+  if (values !== undefined && values.length > 0) {
+    parts.push(joinLabels(values.map(render)));
+  }
+}
+
+function readConditionValues(value: EffectConditionValue): string[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+function renderContextLabel(value: string): string {
+  return CONTEXT_LABELS[value] ?? humanize(value);
+}
+
+function renderContextPhrase(value: string): string {
+  if (value === 'rest') {
+    return 'au repos';
+  }
+
+  return `en ${renderContextLabel(value)}`;
+}
+
+function renderEnvironmentLabel(value: string): string {
+  return ENVIRONMENT_LABELS[value] ?? humanize(value);
+}
+
+function renderEnvironmentPhrase(value: string): string {
+  return ENVIRONMENT_PHRASES[value] ?? `en environnement ${renderEnvironmentLabel(value)}`;
+}
+
+function renderActionPhrase(value: string): string {
+  return ACTION_PHRASES[value] ?? `lors de l'action ${humanize(value)}`;
+}
+
+function renderTargetTagPhrase(value: string): string {
+  return `contre ${TARGET_TAG_LABELS[value] ?? `les cibles ${humanize(value)}`}`;
+}
+
+function renderWeaponPhrase(value: string): string {
+  return `avec ${WEAPON_LABELS[value] ?? humanize(value)}`;
+}
+
+function renderSchoolPhrase(value: string): string {
+  return `pour l’école ${SCHOOL_LABELS[value] ?? `de ${humanize(value)}`}`;
+}
+
+function renderSelfStatePhrase(value: string): string {
+  return `si le porteur est ${SELF_STATE_LABELS[value] ?? humanize(value)}`;
+}
+
+function renderScope(scope: string | undefined): string {
+  if (scope === undefined) {
+    return 'non précisé';
+  }
+
+  return SCOPE_LABELS[scope] ?? humanize(scope);
+}
+
+function renderScopedTarget(base: string, scope: string | undefined): string {
+  if (scope === undefined) {
+    return base;
+  }
+
+  return `${base} ${renderScope(scope)}`;
+}
+
+function toTemplateKey(spec: EffectSpec): RenderTemplateKey {
+  return `${spec.target}:${spec.op}`;
+}
+
+function joinLabels(values: string[]): string {
+  return values.join(' ou ');
+}
+
+function humanize(value: string): string {
+  return value.replace(/[_-]+/g, ' ');
+}
+
+function isEffectValueVariable(value: string): value is EffectValueVariable {
+  return value in VALUE_LABELS;
+}

--- a/packages/rules-core/src/index.ts
+++ b/packages/rules-core/src/index.ts
@@ -3,6 +3,7 @@ export * from './character.js';
 export * from './combat.js';
 export * from './dice.js';
 export * from './effect-model.js';
+export * from './effect-renderer.js';
 export * from './npc-control.js';
 export * from './progression.js';
 export * from './rules-config.js';


### PR DESCRIPTION
effect-renderer.ts: renderEffect(spec)->texte FR (gabarits par target x op + fallback) ; describeFidelity expose prose+render pour audit humain (pas de NLP auto, honnete). Consomme EffectModel (#123). 281 tests. EPIC #122. Closes #124.