### PR TITLE
docs(combat): résolution touche/dégâts + corrections R-9.5/R-9.9

### DIFF
--- a/docs/canonical/canonical-matrix.yaml
+++ b/docs/canonical/canonical-matrix.yaml
@@ -133444,8 +133444,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 1209"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 1219"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "3. Si une spécialisation pertinente existe (ex. « Fauchage (Épée à deux mains) »), elle réduit la difficulté selon les règles standard (R-1.10 / R-9.5). from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -133624,8 +133624,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 685"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 695"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "1. **Type d'action** : action conservée (D1 R-1.12). Le perso déclare la transformation au DT `T`. Elle se résout au DT `T + 50` par défaut (cf. D3 Q-D3.7). from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -134200,8 +134200,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 2093"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 2103"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "| D1 R-1.2/12/25/34/36/40 | ⬅ rappel | Action standard, types d'action, interruption, échec critique, modificateurs | from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -134416,8 +134416,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 97"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 99"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "La réussite du jet actif réduit ou annule les réussites de l'attaque, selon le modèle général des contre-actions (D1 R-1.23). Si l'attaque est complètement neutralisée, le coup ne produit pas de dégâts. from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -134597,7 +134597,7 @@ units:
     sources:
       - path: "docs/rules/09-combat.md"
         ref: "line 56"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "*Rappel D1 R-1.25** : les DT déjà écoulés sont perdus. Il n'existe pas de demi-action récupérable par défaut. from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -135244,8 +135244,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 193"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 203"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "Les résistances exprimées en `%` (`feu`, `froid`, `poison`, `magie`, etc.) utilisent la mécanique D100 (D1 R-1.32 / D3 Q-D3.8). Elles sont testées avant la résolution des dégâts ou de l'effet concerné. Si le test réussit, la composante ou l'effet auquel la résistance s'oppose est ignoré. from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -135424,8 +135424,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 547"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 557"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "2. **Standard** (casse sur échec critique uniquement) — seule une fumble (D1 R-1.34, échec critique avec D100 sur table d'incidents) peut briser une arme ou endommager une armure. La table d'échec critique inclut des résultats `arme brisée`, `armure entaillée`, `lacet de protection rompu`. Aucun tracking continu. Conforme au legacy minimaliste. from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -135640,8 +135640,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 491"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 501"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "**MJ LLM** : applique automatiquement le modificateur de la catégorie courante, ajuste contextuellement (taille cible, mouvement, météo, couvert) avec D1 R-1.36. from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -139996,8 +139996,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 337"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 347"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "*Statut** : 🟢 acté (D2 R-2.X, D7 R-7.20) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -140140,8 +140140,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 2094"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 2104"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "| D2 R-2.10/17 | ⬅ rappel | Repos/vitalité, malus d'affaiblissement | from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -142372,8 +142372,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 2096"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 2106"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "| D4 R-4.9 | ⬅ rappel | Orientations / classes / atouts | from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -144316,8 +144316,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 681"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 691"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "Réfère D3 Q-D3.7 (durée canonique 50 DT ≈ 10 s) et D7 R-7.16/17/18 (math du changement de race). Cette règle traite uniquement de la **fenêtre temporelle** et du **flux d'action** pendant la transformation. from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -144424,8 +144424,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 710"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 720"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "   - Buffs/debuffs sur le personnage : conservés à travers la transformation tant que leur durée n'est pas expirée (cf. D7 R-7.17). from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -144568,8 +144568,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 785"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 795"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "*Migration** : changement de schéma d'item-type → moteur propose une stratégie de migration item par item. Admin valide. Les persos sont notifiés des items modifiés (cf. R-7.19 méta-principe règles vivantes). from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -144676,8 +144676,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 576"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 586"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "Le legacy ne mentionne explicitement que les états `mort`, `inconscient` (D7 R-7.20), `à terre` (regles:567 quand la Force est insuffisante pour porter l'équipement) et `affaibli` (D2 R-2.17). Tout système digital exige un catalogue plus large. from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -145180,8 +145180,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 798"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 808"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "2. **Coût en énergie** : déduction immédiate au DT `T` (l'énergie est mobilisée dès le début, cf. D8 R-8.10/12). from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -145648,8 +145648,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 804"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 814"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "5. **Effet** : si réussi, application immédiate. Si raté, énergie perdue (R-8.13). from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -145936,8 +145936,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 286"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 296"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "*Mécanique** : Jet d'aptitude brute (D8 R-8.19) sur Endurance, difficulté 7. Chaque réussite − 1 dégât. from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146045,7 +146045,7 @@ units:
     sources:
       - path: "docs/rules/09-combat.md"
         ref: "line 3"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "> Système de combat. Repose sur le rythme DT (Divisions de Temps, 1 DT = 0,2 s) acté en D8 R-8.20, le facteur de vitesse acté en D2, les types d'actions actés en D1 R-1.12, le modèle de modificateurs additif acté en D1 R-1.36/40, le malus d'affaiblissement acté en D2 R-2.17, la machine d'état mort/mourant actée en D7 R-7.20/21, les résistances multi-couches actées en D3 Q-D3.8. from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146188,8 +146188,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 803"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 813"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "4. **Résolution** au DT `T + TI` : jet d'action D8 R-8.5 (Intelligence + sort + spécialisations) contre la difficulté du sort. from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146260,8 +146260,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 793"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 803"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "Cette règle complète D8 R-8.6 (TI), R-8.7 (concentration / interruption) et l'école Abjuration (Captage d'énergie, sorts d'annulation). from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146405,7 +146405,7 @@ units:
     sources:
       - path: "docs/rules/09-combat.md"
         ref: "line 19"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.1 — DT comme rythme de combat (rappel D8 R-8.20) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146440,8 +146440,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 137"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 147"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.10 — Difficulté du jet de force = 7 − réussites au toucher from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146476,8 +146476,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 147"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 157"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.11 — Quatre types de dégâts (TD) : P/E/C/T from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146512,8 +146512,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 178"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 188"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.12 — Ordre fixe d'application des modificateurs de dégâts from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146548,8 +146548,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 208"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 218"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.13 — Modificateurs de circonstance (charge, chute) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146584,8 +146584,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 216"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 226"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.14 — Armures : protection P/E/C/T par pièce from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146692,8 +146692,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 265"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 275"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.15 — Modificateurs de zone de touche from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146764,8 +146764,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 280"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 290"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.16 — Endurance en dernier rempart from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146800,8 +146800,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 294"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 304"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.17 — Évanouissement / mort en un coup (rappel D2/D7) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146872,8 +146872,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 339"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 349"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.18 — Malus d'affaiblissement (rappel D2 R-2.17) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146908,8 +146908,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 343"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 353"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.18-bis — Dégâts subis retardent l'action from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -146944,8 +146944,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 363"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 373"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.19 — Catalogue d'armes (table vivante) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147017,7 +147017,7 @@ units:
     sources:
       - path: "docs/rules/09-combat.md"
         ref: "line 30"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.2 — Facteur de vitesse comme délai d'action from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147052,8 +147052,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 371"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 381"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.20 — Catalogue de protections (table vivante) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147088,8 +147088,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 377"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 387"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.21 — Table des touches (D100, table vivante) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147124,8 +147124,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 422"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 432"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.22 — Flux de combat digital = timeline dynamique, pas initiative fixe from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147160,8 +147160,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 442"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 452"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.22-bis — Audit `FightAssistantMan` vers `rules-core` from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147268,8 +147268,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 459"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 469"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.23 — Égalités de DT dans la timeline from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147304,8 +147304,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 470"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 480"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.24 — Portée des armes à distance (modèle hybride catégorie + numérique) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147376,8 +147376,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 500"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 510"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.25 — Munitions (stock, qualité, récupération) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147448,8 +147448,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 537"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 547"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.26 — Durabilité des armes et armures (mode paramétrable par campagne) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147556,8 +147556,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 572"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 582"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.27 — États tactiques en combat (catalogue vivant d'états) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147700,8 +147700,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 621"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 631"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.28 — Spawn de PNJ en cours de combat (renforts, vagues, invocations) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147772,8 +147772,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 677"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 687"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.29 — Transformation de race en cours de combat (action conservée 50 DT) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147809,7 +147809,7 @@ units:
     sources:
       - path: "docs/rules/09-combat.md"
         ref: "line 40"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.3 — Recharge des armes balistiques comme action from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147844,8 +147844,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 724"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 734"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.30 — Catalogues d'armes, protections et items : méta-modèle type-classes dynamiques from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -147988,8 +147988,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 789"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 799"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.31 — Sorts en combat (interruption, ciblage, AOE, contre-sort) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148024,8 +148024,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 881"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 891"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.32 — Déplacement et positionnement en combat (zones abstraites + vitesse numérique + terrain + UI) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148132,8 +148132,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 964"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 974"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.33 — Soins en combat (potions, sorts, médecine, atouts d'auto-soin) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148168,8 +148168,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 932"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 942"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "E. UI : zone de déplacement max visualisable (couplée au mode R-9.34) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148240,8 +148240,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 1060"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 1070"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.35 — Poisons (item-type, double échelle, catalogue Harold) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148348,8 +148348,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 1172"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 1182"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.36 — Attaques physiques multi-cibles (fauchage, cône, ligne, rebond, charge) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148420,8 +148420,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 1233"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 1243"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.37 — Fuite, poursuite et conditions de fin de combat from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148528,8 +148528,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 1302"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 1312"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.38 — Désengagement de mêlée (3 modes + atouts dédiés) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148564,8 +148564,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 1361"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 1371"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.39 — Round de surprise / embuscade (niveaux + atouts dédiés) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148601,7 +148601,7 @@ units:
     sources:
       - path: "docs/rules/09-combat.md"
         ref: "line 50"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.4 — Interruption d'action from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148636,8 +148636,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 1423"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 1433"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.40 — Tactique de groupe (5 modules + atouts dédiés) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148744,8 +148744,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 1506"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 1516"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.41 — Combat à mains nues, lutte, saisies, désarmement from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148816,8 +148816,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 1560"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 1570"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "Les pénalités de main faible ne s'appliquent qu'aux membres « surnuméraires », et seulement si le perso n'a pas un atout équivalent à Ambidextrie (R-9.42). from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148888,8 +148888,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 1631"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 1641"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.43 — Combat à cheval / sur monture from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -148996,8 +148996,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 1698"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 1708"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.44 — Coup de grâce, achèvement, reddition, interrogatoire from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -149100,14 +149100,14 @@ units:
   - unit_id: "R-9.5"
     unit_type: "rule"
     domain: "D9-combat"
-    title: "R-9.5 — Jet pour toucher = jet d'action standard (rappel D1 R-1.2)"
+    title: "R-9.5 — Jet pour toucher = Dextérité + Compétence d'arme (rappel D1 R-1.2)"
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
         ref: "line 69"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
-      summary: "R-9.5 — Jet pour toucher = jet d'action standard (rappel D1 R-1.2) from docs/rules/09-combat.md."
+      summary: "R-9.5 — Jet pour toucher = Dextérité + Compétence d'arme (rappel D1 R-1.2) from docs/rules/09-combat.md."
       ambiguity_ref: null
     yaml:
       status: not_applicable
@@ -149212,8 +149212,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 75"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 77"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.6 — Esquive = contre-action improvisée (rappel D1 R-1.12) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -149248,8 +149248,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 85"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 87"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.7 — Bouclier actif from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -149320,8 +149320,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 101"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 103"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "R-9.8 — Bouclier passif (jet de chance) from docs/rules/09-combat.md."
       ambiguity_ref: null
@@ -149352,14 +149352,14 @@ units:
   - unit_id: "R-9.9"
     unit_type: "rule"
     domain: "D9-combat"
-    title: "R-9.9 — Jet de dégâts = Force seule (mêlée) ou arme seule (distance)"
+    title: "*Correction d'autorité (2026-05-25)** : la phase de toucher se fait **systématiquement à la Dextérité**. La Force n'intervient **jamais** au toucher — elle est réservée au jet de dégâts (R-9.9). L'ancienne formulation « souvent Dextérité ou Force » était une scorie de lecture du cas général D1 R-1.2 ; elle est annulée pour le maniement d'armes."
     status: partial
     sources:
       - path: "docs/rules/09-combat.md"
-        ref: "line 125"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        ref: "line 73"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
-      summary: "R-9.9 — Jet de dégâts = Force seule (mêlée) ou arme seule (distance) from docs/rules/09-combat.md."
+      summary: "*Correction d'autorité (2026-05-25)** : la phase de toucher se fait **systématiquement à la Dextérité**. La Force n'intervient **jamais** au toucher — elle est réservée au jet de dégâts (R-9.9). L'ancienne formulation « souvent Dextérité ou Force » était une scorie de lecture du cas général D1 R-1.2 ; elle est annulée pour le maniement d'armes. from docs/rules/09-combat.md."
       ambiguity_ref: null
     yaml:
       status: not_applicable
@@ -262371,7 +262371,7 @@ units:
     sources:
       - path: "docs/rules/09-combat.md"
         ref: "docs/rules/09-combat.md"
-        sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+        sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     business_rule:
       summary: "docs/rules/09-combat.md from docs/rules/09-combat.md."
       ambiguity_ref: null

--- a/docs/canonical/moteurs-rules-core.md
+++ b/docs/canonical/moteurs-rules-core.md
@@ -85,6 +85,7 @@ Génère une phrase FR depuis le `spec` : `gabarit[(target, op)] + value rendue 
 | (aptitude, add) | « +{value} en {scope} » |
 | (status, grant) | « Inflige l'état {scope} » |
 | (vitality, add) | « Restaure {value} points de vitalité » |
+| (damage, add) | « Inflige {value} dégâts supplémentaires » |
 
 + condition : « … en combat naval », « … contre les morts-vivants ». Les clés de condition ont des **libellés FR**. Le `render` reste **toujours synchrone** avec le `spec`.
 
@@ -114,6 +115,40 @@ Génère une phrase FR depuis le `spec` : `gabarit[(target, op)] + value rendue 
 - **Mécaniques (ordre R-9.12)** : jet de dégâts R-9.9/9.10 → 4 types R-9.11 → bouclier R-9.7/8 → résistances % R-1.32/33 → circonstance R-9.13 → protections P/E/C/T par couche R-9.14 → **endurance R-9.16 (si la zone l'autorise)** → **×2 zone R-9.15 (en dernier)** → seuils R-9.17 *(déjà dans `applyDamage`)*.
 - **Intégration** : `combat.ts` — nouvelle `computeAttackDamage(attacker, defender, ctx)` **en amont** de `applyDamage` (inchangé : vitalité/mort/inconscient/malus/retard). Consomme **données armes/protections** (catalogues) + **résistances** (du moteur d'effets / race).
 - **Build** : chaque étape de la chaîne = **fonction pure testable** vs les **exemples canoniques** des règles.
+
+---
+
+## 4bis. Résolution d'attaque d'arme & attribut par type d'action
+
+**Acté (autorité K&W, 2026-05-25).** Une attaque d'arme se résout en **deux phases couplées**, à **attributs imposés** (≠ action générale, où l'attribut est libre) :
+
+| Phase | Attribut | Pool / calcul | Modificateurs qui s'y appliquent |
+|---|---|---|---|
+| ① **Touche** | **Dextérité (toujours)** | Dex + Compétence(arme) + Σ Spés + dés ajoutés | tous les modificateurs de **difficulté** ; dés de **pool** (atout de classe « +niveau », effets, équipement) |
+| ② **Dégâts** *(si touche)* | **Force** *(si la formule de l'arme inclut `F`)* | jet de Force, difficulté `7 − réussites nettes de touche` (R-9.10) ; `dégâts = (réussites_force si F) + dégâts_arme + munition + Σ mods` | modificateurs de **dégâts** (atout / effet / sort) |
+
+- **Couplage** : les réussites **nettes** de touche (R-1.23 : après esquive/parade) fixent la difficulté du jet de Force (R-9.10). Les deux phases ne sont **pas** indépendantes.
+- **Inclusion de la Force = par arme** (token `F` de `damage_formula`), **pas** mêlée/distance (R-9.9 corrigé ; preuves Fronde `F+bille` vs Lance-pierres `2+bille`, couteau de lancer `F+1`).
+
+**Pattern général — l'attribut est fonction du type d'action** (au-delà du combat) :
+
+| `action_type` | Attribut imposé |
+|---|---|
+| `general` | **libre** (choisi par le joueur) |
+| `weapon_hit` | Dextérité |
+| `weapon_damage` | Force (si l'arme l'inclut) |
+| `sort` | Intelligence (D8) |
+| `endurance` | Endurance |
+| `esquive` / `parade` | contre-action (Réflexes + Gymnastique + Esquive / arme) |
+
+**Conséquence EffectModel** — les modificateurs sont **typés par `target`**, et `target` détermine **la phase** où ils atterrissent :
+
+| `target` | Phase |
+|---|---|
+| `difficulty`, `pool`, `aptitude` | ① touche |
+| **`damage`** *(à AJOUTER à l'enum)* | ② dégâts |
+
+L'enum actuel (`aptitude|factor|difficulty|pool|energy|vitality|status`) **n'a pas** `damage` → les adds de dégâts (atouts / effets / sorts) n'ont aujourd'hui aucune cible. **Ajout requis** (suite épic effets #122).
 
 ---
 

--- a/docs/canonical/nomos/canonical-matrix.yaml
+++ b/docs/canonical/nomos/canonical-matrix.yaml
@@ -70969,8 +70969,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 1209
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 1219
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       3. Si une spécialisation pertinente existe (ex. « Fauchage (Épée à deux mains) »), elle réduit la difficulté selon
       les règles standard (R-1.10 / R-9.5). from docs/rules/09-combat.md.
@@ -71072,8 +71072,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 685
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 695
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       1. **Type d'action** : action conservée (D1 R-1.12). Le perso déclare la transformation au DT `T`. Elle se résout
       au DT `T + 50` par défaut (cf. D3 Q-D3.7). from docs/rules/09-combat.md.
@@ -71412,8 +71412,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 2093
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 2103
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       | D1 R-1.2/12/25/34/36/40 | ⬅ rappel | Action standard, types d'action, interruption, échec critique,
       modificateurs | from docs/rules/09-combat.md.
@@ -71532,8 +71532,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 97
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 99
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       La réussite du jet actif réduit ou annule les réussites de l'attaque, selon le modèle général des contre-actions
       (D1 R-1.23). Si l'attaque est complètement neutralisée, le coup ne produit pas de dégâts. from
@@ -71641,7 +71641,7 @@ units:
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
         locator: line 56
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       *Rappel D1 R-1.25** : les DT déjà écoulés sont perdus. Il n'existe pas de demi-action récupérable par défaut. from
       docs/rules/09-combat.md.
@@ -72010,8 +72010,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 193
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 203
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       Les résistances exprimées en `%` (`feu`, `froid`, `poison`, `magie`, etc.) utilisent la mécanique D100 (D1 R-1.32
       / D3 Q-D3.8). Elles sont testées avant la résolution des dégâts ou de l'effet concerné. Si le test réussit, la
@@ -72116,8 +72116,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 547
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 557
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       2. **Standard** (casse sur échec critique uniquement) — seule une fumble (D1 R-1.34, échec critique avec D100 sur
       table d'incidents) peut briser une arme ou endommager une armure. La table d'échec critique inclut des résultats
@@ -72243,8 +72243,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 491
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 501
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       **MJ LLM** : applique automatiquement le modificateur de la catégorie courante, ajuste contextuellement (taille
       cible, mouvement, météo, couvert) avec D1 R-1.36. from docs/rules/09-combat.md.
@@ -74603,8 +74603,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 337
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 347
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: '*Statut** : 🟢 acté (D2 R-2.X, D7 R-7.20) from docs/rules/09-combat.md.'
     status: partial
     gaps:
@@ -74685,8 +74685,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 2094
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 2104
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: '| D2 R-2.10/17 | ⬅ rappel | Repos/vitalité, malus d''affaiblissement | from docs/rules/09-combat.md.'
     status: partial
     gaps:
@@ -75947,8 +75947,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 2096
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 2106
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: '| D4 R-4.9 | ⬅ rappel | Orientations / classes / atouts | from docs/rules/09-combat.md.'
     status: partial
     gaps:
@@ -77004,8 +77004,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 681
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 691
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       Réfère D3 Q-D3.7 (durée canonique 50 DT ≈ 10 s) et D7 R-7.16/17/18 (math du changement de race). Cette règle
       traite uniquement de la **fenêtre temporelle** et du **flux d'action** pendant la transformation. from
@@ -77066,8 +77066,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 710
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 720
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: '   - Buffs/debuffs sur le personnage : conservés à travers la transformation tant que leur durée n''est pas expirée (cf. D7 R-7.17). from docs/rules/09-combat.md.'
     status: partial
     gaps:
@@ -77148,8 +77148,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 785
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 795
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       *Migration** : changement de schéma d'item-type → moteur propose une stratégie de migration item par item. Admin
       valide. Les persos sont notifiés des items modifiés (cf. R-7.19 méta-principe règles vivantes). from
@@ -77211,8 +77211,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 576
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 586
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       Le legacy ne mentionne explicitement que les états `mort`, `inconscient` (D7 R-7.20), `à terre` (regles:567 quand
       la Force est insuffisante pour porter l'équipement) et `affaibli` (D2 R-2.17). Tout système digital exige un
@@ -77482,8 +77482,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 798
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 808
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       2. **Coût en énergie** : déduction immédiate au DT `T` (l'énergie est mobilisée dès le début, cf. D8 R-8.10/12).
       from docs/rules/09-combat.md.
@@ -77739,8 +77739,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 804
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 814
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: '5. **Effet** : si réussi, application immédiate. Si raté, énergie perdue (R-8.13). from docs/rules/09-combat.md.'
     status: partial
     gaps:
@@ -77891,8 +77891,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 286
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 296
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       *Mécanique** : Jet d'aptitude brute (D8 R-8.19) sur Endurance, difficulté 7. Chaque réussite − 1 dégât. from
       docs/rules/09-combat.md.
@@ -77959,7 +77959,7 @@ units:
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
         locator: line 3
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       > Système de combat. Repose sur le rythme DT (Divisions de Temps, 1 DT = 0,2 s) acté en D8 R-8.20, le facteur de
       vitesse acté en D2, les types d'actions actés en D1 R-1.12, le modèle de modificateurs additif acté en D1
@@ -78040,8 +78040,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 803
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 813
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       4. **Résolution** au DT `T + TI` : jet d'action D8 R-8.5 (Intelligence + sort + spécialisations) contre la
       difficulté du sort. from docs/rules/09-combat.md.
@@ -78082,8 +78082,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 793
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 803
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       Cette règle complète D8 R-8.6 (TI), R-8.7 (concentration / interruption) et l'école Abjuration (Captage d'énergie,
       sorts d'annulation). from docs/rules/09-combat.md.
@@ -78161,7 +78161,7 @@ units:
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
         locator: line 19
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.1 — DT comme rythme de combat (rappel D8 R-8.20) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78179,8 +78179,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 137
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 147
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.10 — Difficulté du jet de force = 7 − réussites au toucher from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78198,8 +78198,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 147
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 157
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: 'R-9.11 — Quatre types de dégâts (TD) : P/E/C/T from docs/rules/09-combat.md.'
     status: partial
     gaps:
@@ -78217,8 +78217,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 178
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 188
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.12 — Ordre fixe d'application des modificateurs de dégâts from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78236,8 +78236,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 208
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 218
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.13 — Modificateurs de circonstance (charge, chute) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78255,8 +78255,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 216
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 226
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: 'R-9.14 — Armures : protection P/E/C/T par pièce from docs/rules/09-combat.md.'
     status: partial
     gaps:
@@ -78312,8 +78312,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 265
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 275
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.15 — Modificateurs de zone de touche from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78350,8 +78350,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 280
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 290
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.16 — Endurance en dernier rempart from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78369,8 +78369,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 294
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 304
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.17 — Évanouissement / mort en un coup (rappel D2/D7) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78411,8 +78411,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 339
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 349
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.18 — Malus d'affaiblissement (rappel D2 R-2.17) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78430,8 +78430,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 343
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 353
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.18-bis — Dégâts subis retardent l'action from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78449,8 +78449,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 363
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 373
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.19 — Catalogue d'armes (table vivante) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78492,7 +78492,7 @@ units:
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
         locator: line 30
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.2 — Facteur de vitesse comme délai d'action from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78510,8 +78510,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 371
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 381
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.20 — Catalogue de protections (table vivante) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78529,8 +78529,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 377
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 387
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.21 — Table des touches (D100, table vivante) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78548,8 +78548,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 422
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 432
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.22 — Flux de combat digital = timeline dynamique, pas initiative fixe from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78567,8 +78567,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 442
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 452
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.22-bis — Audit `FightAssistantMan` vers `rules-core` from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78626,8 +78626,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 459
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 469
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.23 — Égalités de DT dans la timeline from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78645,8 +78645,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 470
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 480
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.24 — Portée des armes à distance (modèle hybride catégorie + numérique) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78683,8 +78683,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 500
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 510
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.25 — Munitions (stock, qualité, récupération) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78721,8 +78721,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 537
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 547
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.26 — Durabilité des armes et armures (mode paramétrable par campagne) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78778,8 +78778,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 572
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 582
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.27 — États tactiques en combat (catalogue vivant d'états) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78858,8 +78858,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 621
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 631
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.28 — Spawn de PNJ en cours de combat (renforts, vagues, invocations) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78896,8 +78896,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 677
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 687
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.29 — Transformation de race en cours de combat (action conservée 50 DT) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78916,7 +78916,7 @@ units:
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
         locator: line 40
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.3 — Recharge des armes balistiques comme action from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -78934,8 +78934,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 724
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 734
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       R-9.30 — Catalogues d'armes, protections et items : méta-modèle type-classes dynamiques from
       docs/rules/09-combat.md.
@@ -79021,8 +79021,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 789
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 799
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.31 — Sorts en combat (interruption, ciblage, AOE, contre-sort) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79040,8 +79040,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 881
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 891
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       R-9.32 — Déplacement et positionnement en combat (zones abstraites + vitesse numérique + terrain + UI) from
       docs/rules/09-combat.md.
@@ -79099,8 +79099,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 964
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 974
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.33 — Soins en combat (potions, sorts, médecine, atouts d'auto-soin) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79118,8 +79118,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 932
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 942
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: 'E. UI : zone de déplacement max visualisable (couplée au mode R-9.34) from docs/rules/09-combat.md.'
     status: partial
     gaps:
@@ -79156,8 +79156,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 1060
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 1070
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.35 — Poisons (item-type, double échelle, catalogue Harold) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79217,8 +79217,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 1172
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 1182
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.36 — Attaques physiques multi-cibles (fauchage, cône, ligne, rebond, charge) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79255,8 +79255,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 1233
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 1243
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.37 — Fuite, poursuite et conditions de fin de combat from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79316,8 +79316,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 1302
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 1312
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.38 — Désengagement de mêlée (3 modes + atouts dédiés) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79335,8 +79335,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 1361
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 1371
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.39 — Round de surprise / embuscade (niveaux + atouts dédiés) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79355,7 +79355,7 @@ units:
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
         locator: line 50
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.4 — Interruption d'action from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79373,8 +79373,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 1423
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 1433
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.40 — Tactique de groupe (5 modules + atouts dédiés) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79434,8 +79434,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 1506
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 1516
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.41 — Combat à mains nues, lutte, saisies, désarmement from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79474,8 +79474,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 1560
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 1570
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: >-
       Les pénalités de main faible ne s'appliquent qu'aux membres « surnuméraires », et seulement si le perso n'a pas un
       atout équivalent à Ambidextrie (R-9.42). from docs/rules/09-combat.md.
@@ -79514,8 +79514,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 1631
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 1641
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.43 — Combat à cheval / sur monture from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79573,8 +79573,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 1698
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 1708
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.44 — Coup de grâce, achèvement, reddition, interrogatoire from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79631,14 +79631,14 @@ units:
       - collection: knowledge_chunks
   - unit_id: R-9-5
     unit_type: rule
-    name: R-9.5 — Jet pour toucher = jet d'action standard (rappel D1 R-1.2)
+    name: R-9.5 — Jet pour toucher = Dextérité + Compétence d'arme (rappel D1 R-1.2)
     domain: d9-combat
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
         locator: line 69
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
-    business_rule: R-9.5 — Jet pour toucher = jet d'action standard (rappel D1 R-1.2) from docs/rules/09-combat.md.
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
+    business_rule: R-9.5 — Jet pour toucher = Dextérité + Compétence d'arme (rappel D1 R-1.2) from docs/rules/09-combat.md.
     status: partial
     gaps:
       - 'relational_db: Canonical relational tables/import evidence pending.'
@@ -79693,8 +79693,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 75
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 77
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.6 — Esquive = contre-action improvisée (rappel D1 R-1.12) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79712,8 +79712,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 85
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 87
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.7 — Bouclier actif from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79750,8 +79750,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 101
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        locator: line 103
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: R-9.8 — Bouclier passif (jet de chance) from docs/rules/09-combat.md.
     status: partial
     gaps:
@@ -79764,14 +79764,22 @@ units:
       - collection: knowledge_chunks
   - unit_id: R-9-9
     unit_type: rule
-    name: R-9.9 — Jet de dégâts = Force seule (mêlée) ou arme seule (distance)
+    name: >-
+      *Correction d'autorité (2026-05-25)** : la phase de toucher se fait **systématiquement à la Dextérité**. La Force
+      n'intervient **jamais** au toucher — elle est réservée au jet de dégâts (R-9.9). L'ancienne formulation « souvent
+      Dextérité ou Force » était une scorie de lecture du cas général D1 R-1.2 ; elle est annulée pour le maniement
+      d'armes.
     domain: d9-combat
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
-        locator: line 125
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
-    business_rule: R-9.9 — Jet de dégâts = Force seule (mêlée) ou arme seule (distance) from docs/rules/09-combat.md.
+        locator: line 73
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
+    business_rule: >-
+      *Correction d'autorité (2026-05-25)** : la phase de toucher se fait **systématiquement à la Dextérité**. La Force
+      n'intervient **jamais** au toucher — elle est réservée au jet de dégâts (R-9.9). L'ancienne formulation « souvent
+      Dextérité ou Force » était une scorie de lecture du cas général D1 R-1.2 ; elle est annulée pour le maniement
+      d'armes. from docs/rules/09-combat.md.
     status: partial
     gaps:
       - 'relational_db: Canonical relational tables/import evidence pending.'
@@ -133525,7 +133533,7 @@ units:
     source_refs:
       - source_id: DOCS-RULES-09-COMBAT
         locator: docs/rules/09-combat.md
-        hash: sha256:8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+        hash: sha256:4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     business_rule: docs/rules/09-combat.md from docs/rules/09-combat.md.
     status: partial
     gaps:

--- a/docs/canonical/nomos/source-manifest.yaml
+++ b/docs/canonical/nomos/source-manifest.yaml
@@ -20861,7 +20861,7 @@ sources:
     domain: D9-combat
     priority: primary
     status: active
-    hash: 8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a
+    hash: 4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c
     owner: decarvalhoe
     license: proprietary
     confidentiality: internal

--- a/docs/canonical/source-manifest.yaml
+++ b/docs/canonical/source-manifest.yaml
@@ -13324,7 +13324,7 @@ sources:
     notes: "Canonical rule document."
   - id: "docs-rules-09-combat"
     path: "docs/rules/09-combat.md"
-    sha256: "8a5fc8414c35f70fbae0851ab5265498f02807086a75d883940e91265c4dfe9a"
+    sha256: "4bf247d2b27149a663a4baaa94ce00601c2f838f8a8ab5be96b0f9511de7ff9c"
     source_type: canonical_rule
     priority: 100
     status: active

--- a/docs/rules/09-combat.md
+++ b/docs/rules/09-combat.md
@@ -66,11 +66,13 @@ Donc : tirer à l'arbalète = 1) recharger (FV DT) + 2) viser (FV DT) + 3) tirer
 
 ## Partie B — Résolution du toucher (rappels)
 
-### R-9.5 — Jet pour toucher = jet d'action standard (rappel D1 R-1.2)
+### R-9.5 — Jet pour toucher = Dextérité + Compétence d'arme (rappel D1 R-1.2)
 
-Aptitude (souvent Dextérité ou Force) + Compétence (arme spécifique) + Σ Spécialisations, contre la difficulté convenue de l'arme (cf. Table des armes, colonne Difficulté).
+**Dextérité (toujours)** + Compétence (arme spécifique) + Σ Spécialisations engagées, contre la difficulté convenue de l'arme (cf. Table des armes, colonne Difficulté). Le pool de touche reçoit en plus les **dés ajoutés** par atouts / effets / équipement (atout de classe « +niveau », cf. `docs/canonical/moteurs-rules-core.md` §4bis).
 
-**Statut** : 🟢 acté (D1)
+**Correction d'autorité (2026-05-25)** : la phase de toucher se fait **systématiquement à la Dextérité**. La Force n'intervient **jamais** au toucher — elle est réservée au jet de dégâts (R-9.9). L'ancienne formulation « souvent Dextérité ou Force » était une scorie de lecture du cas général D1 R-1.2 ; elle est annulée pour le maniement d'armes.
+
+**Statut** : 🟢 acté (correction d'autorité)
 
 ### R-9.6 — Esquive = contre-action improvisée (rappel D1 R-1.12)
 
@@ -122,17 +124,25 @@ Les valeurs `P/E/C/T` du bouclier ne s'appliquent pas à cette déviation passiv
 
 ## Partie D — Résolution des dégâts (rappels et nouveautés)
 
-### R-9.9 — Jet de dégâts = Force seule (mêlée) ou arme seule (distance)
+### R-9.9 — Jet de dégâts = Force (si l'arme l'inclut) + dégâts d'arme
 
 **Énoncé legacy** ([regles:484-495](documents/regles/index.md)) :
 
 > Pour se faire, le personnage ayant touché fait un jet de force (il n'existe pas vraiment de compétence pour appuyer ses coups), donc les seul dés qui seront lancé seront ceux de la force. La difficulté sera toujours de 7 moins le nombre de réussites obtenues au toucher, mais n'oubliez pas qu'un 1 est toujours un échec. (...) Le nombre de dégâts infligé sera égal au nombre de réussites faites sur le jet de force additionné aux dégâts de l'arme utilisé. (...) Bien évidement, la force n'agit pas sur des armes telles que l'arc, l'arbalète,...
 
-**Mécanique** :
-- Mêlée : `dégâts = réussites_force + dégâts_arme` (où dégâts_arme = "F + N" dans la table)
-- Distance : `dégâts = dégâts_arme` seul (ex. arc long P: 4+flèche = 4 + bonus de la flèche)
+**Correction d'autorité (2026-05-25)** : l'inclusion de la Force dans les dégâts est une **propriété par arme**, déclarée par la `damage_formula` du catalogue (présence du token `F`), et **non** une distinction mêlée/distance. Les exemples legacy (« la force n'agit pas sur l'arc, l'arbalète ») sont des **cas**, pas une règle catégorielle.
 
-**Statut** : 🟢 claire
+**Mécanique (pilotée par la table des armes)** :
+- Si `damage_formula` contient `F` → `dégâts = réussites_force + N (+ munition) + Σ modificateurs`.
+- Sinon → `dégâts = N (+ munition) + Σ modificateurs` (pas de Force).
+- `Σ modificateurs` = adds de dégâts d'atouts / effets / sorts (cible `target:'damage'`, cf. `moteurs-rules-core.md` §4bis).
+
+**Preuves catalogue (`data/catalogs/armes.yaml`)** :
+- `couteau_de_lancer` (thrown) → `"F+1"` : arme **non-mêlée avec Force**.
+- `fronde` (ranged) → `"F+bille"` **vs** `lance_pierres` (ranged) → `"2+bille"` : deux frondes, une **avec** Force, une **sans** — la catégorie ne décide rien, seule la formule.
+- arc / arbalète → `"3+flèche"`, `"5+carreau"` : sans Force.
+
+**Statut** : 🟢 acté (correction d'autorité)
 
 ### R-9.10 — Difficulté du jet de force = 7 − réussites au toucher
 


### PR DESCRIPTION
## Contexte

Capture d'une session de sparring règles avec l'auteur (autorité K&W) sur la résolution d'une attaque d'arme. Deux corrections de canon + un cadrage moteur. **PR docs-only.**

## Corrections de canon (`docs/rules/09-combat.md`)

- **R-9.5** — La phase de **toucher** se fait **systématiquement à la Dextérité**. La Force n'y intervient jamais. L'ancienne formulation « souvent Dextérité ou Force » (lecture du cas général D1 R-1.2) est annulée pour le maniement d'armes.
- **R-9.9** — L'inclusion de la **Force dans les dégâts** est une **propriété par arme** (présence du token `F` dans `damage_formula`), **pas** une distinction mêlée/distance. Preuves catalogue : `fronde` = `F+bille` (avec Force) vs `lance_pierres` = `2+bille` (sans), `couteau_de_lancer` = `F+1` (jet, avec Force).

## Cadrage moteur (`docs/canonical/moteurs-rules-core.md` §4bis)

- Modèle de résolution **touche → dégâts** : deux phases couplées à **attributs imposés** (Dextérité au toucher, Force aux dégâts si l'arme l'inclut), couplage R-9.10 (réussites nettes de touche → difficulté du jet de Force).
- Pattern **attribut = fonction du type d'action** (`general` libre, `weapon_hit`=Dex, `weapon_damage`=Force, `sort`=Int, `endurance`=End, `esquive`/`parade`=contre-action).
- Mapping **modificateurs → phase** : `difficulty | pool | aptitude` → touche ; `damage` → dégâts.
- Ajout de la ligne render `(damage, add)`.

## Suite

L'EffectModel n'a pas de cible `target:'damage'` aujourd'hui → les adds de dégâts (atouts / effets / sorts) n'ont aucune cible. Ajout requis, traité en **issue séparée** (suite épic effets #122).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
