### PR TITLE
feat(rules-core): EffectModel — schéma activité/Domaine (#137 #139 #142)

### DIFF
--- a/packages/rules-core/src/effect-model.test.ts
+++ b/packages/rules-core/src/effect-model.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { evaluateValue, matchesCondition, parseEffectModel } from './effect-model.js';
+import type {
+  EffectCondition,
+  EffectConditionContext,
+  EffectConditionValue
+} from './effect-model.js';
 
 describe('EffectModel parsing', () => {
   it('parses a valid data-driven effect model', () => {
@@ -53,6 +58,172 @@ describe('EffectModel parsing', () => {
 
     expect(expressionEffect.spec.value).toBe('level * 2');
     expect(tableEffect.spec.value).toEqual({ table: 'energy_by_level', key: 'level' });
+  });
+
+  it('parses damage targets and activity governance fields', () => {
+    const raw = {
+      source: { prose: 'Inflige des degats supplementaires.', ref: 'fixture:damage' },
+      spec: {
+        target: 'damage',
+        op: 'add',
+        value: 2,
+        condition: { action_type: 'weapon_damage' },
+        activation: 'active',
+        duration: 'ephemeral',
+        requires_mj_validation: true,
+        uses_per_day: 1
+      },
+      fidelity: 'covered'
+    };
+
+    expect(parseEffectModel(raw)).toEqual(raw);
+  });
+
+  it('accepts activity condition keys in parsed models and condition matching', () => {
+    const cases = [
+      ['competence', 'danse', 'forge'],
+      ['spec', 'alchimie_mutagenes', 'pistage'],
+      ['aptitude', ['perception', 'willpower'], 'force'],
+      ['target_disposition', 'ally', 'enemy'],
+      ['target_ref', 'employeur', 'inconnu'],
+      ['intent', 'sauvegarder', 'nuire'],
+      ['directness', 'direct_only', 'indirect']
+    ] as const satisfies readonly (readonly [string, EffectConditionValue, EffectConditionValue])[];
+
+    for (const [key, matching, nonMatching] of cases) {
+      const condition = { [key]: matching };
+
+      const model = parseEffectModel({
+        source: { prose: `Condition ${key}.`, ref: `fixture:condition:${key}` },
+        spec: {
+          target: 'pool',
+          op: 'add',
+          value: 1,
+          condition,
+          activation: 'passive',
+          duration: 'permanent'
+        },
+        fidelity: 'pending'
+      });
+
+      expect(model.spec.condition).toEqual(condition);
+      expect(
+        matchesCondition(
+          condition as EffectCondition,
+          { [key]: matching } as EffectConditionContext
+        )
+      ).toBe(true);
+      expect(
+        matchesCondition(
+          condition as EffectCondition,
+          {
+            [key]: nonMatching
+          } as EffectConditionContext
+        )
+      ).toBe(false);
+    }
+  });
+
+  it('defaults optional activity governance fields by absence', () => {
+    const model = parseEffectModel({
+      source: { prose: 'No governance field.', ref: 'fixture:governance:absent' },
+      spec: {
+        target: 'pool',
+        op: 'add',
+        value: 1,
+        activation: 'passive',
+        duration: 'permanent'
+      },
+      fidelity: 'covered'
+    });
+
+    expect(model.spec.requires_mj_validation).toBeUndefined();
+    expect(model.spec.uses_per_day).toBeUndefined();
+  });
+
+  it('rejects non-boolean activity governance validation flags', () => {
+    expect(() =>
+      parseEffectModel({
+        source: { prose: 'Invalid MJ validation flag.', ref: 'fixture:governance:boolean' },
+        spec: {
+          target: 'pool',
+          op: 'add',
+          value: 1,
+          activation: 'passive',
+          duration: 'permanent',
+          requires_mj_validation: 'yes'
+        },
+        fidelity: 'pending'
+      })
+    ).toThrow(/EffectModel\.spec\.requires_mj_validation must be a boolean/);
+  });
+
+  it('rejects non-positive or non-integer uses per day limits', () => {
+    for (const uses_per_day of [0, -1, 1.5, '1']) {
+      expect(() =>
+        parseEffectModel({
+          source: { prose: 'Invalid uses per day.', ref: 'fixture:uses-per-day' },
+          spec: {
+            target: 'pool',
+            op: 'add',
+            value: 1,
+            activation: 'active',
+            duration: 'ephemeral',
+            uses_per_day
+          },
+          fidelity: 'pending'
+        })
+      ).toThrow(/EffectModel\.spec\.uses_per_day must be a positive integer/);
+    }
+  });
+
+  it('parses expression-based locked durations', () => {
+    const raw = {
+      source: { prose: 'Duree verrouillee par niveau.', ref: 'fixture:duration:locked' },
+      spec: {
+        target: 'status',
+        scope: 'fou_furieux',
+        op: 'grant',
+        value: 1,
+        activation: 'active',
+        duration: { dt: '25*level', locked: true }
+      },
+      fidelity: 'covered'
+    };
+
+    expect(parseEffectModel(raw)).toEqual(raw);
+  });
+
+  it('rejects invalid locked duration fields', () => {
+    expect(() =>
+      parseEffectModel({
+        source: { prose: 'Invalid duration expression.', ref: 'fixture:duration:expression' },
+        spec: {
+          target: 'status',
+          scope: 'fou_furieux',
+          op: 'grant',
+          value: 1,
+          activation: 'active',
+          duration: { dt: '25*unknown' }
+        },
+        fidelity: 'pending'
+      })
+    ).toThrow(/Unknown effect value variable "unknown"/);
+
+    expect(() =>
+      parseEffectModel({
+        source: { prose: 'Invalid duration lock.', ref: 'fixture:duration:lock' },
+        spec: {
+          target: 'status',
+          scope: 'fou_furieux',
+          op: 'grant',
+          value: 1,
+          activation: 'active',
+          duration: { dt: 25, locked: 'yes' }
+        },
+        fidelity: 'pending'
+      })
+    ).toThrow(/Effect duration locked must be a boolean/);
   });
 
   it('rejects unknown operations', () => {

--- a/packages/rules-core/src/effect-model.ts
+++ b/packages/rules-core/src/effect-model.ts
@@ -3,6 +3,7 @@ export const EFFECT_TARGETS = [
   'factor',
   'difficulty',
   'pool',
+  'damage',
   'energy',
   'vitality',
   'status'
@@ -18,7 +19,11 @@ export const EFFECT_ACTIVATIONS = ['passive', 'active', 'triggered'] as const;
 
 export type EffectActivation = (typeof EFFECT_ACTIVATIONS)[number];
 
-export type EffectDuration = 'permanent' | 'ephemeral' | { dt: number } | 'until_dispel';
+export type EffectDuration =
+  | 'permanent'
+  | 'ephemeral'
+  | { dt: number | string; locked?: boolean }
+  | 'until_dispel';
 
 export const EFFECT_FIDELITIES = ['covered', 'ambiguous', 'pending'] as const;
 
@@ -54,10 +59,17 @@ export const EFFECT_CONDITION_KEYS = [
   'context',
   'env',
   'action_type',
+  'competence',
+  'spec',
+  'aptitude',
   'target_tag',
+  'target_disposition',
+  'target_ref',
   'weapon',
   'school',
-  'self_state'
+  'self_state',
+  'intent',
+  'directness'
 ] as const;
 
 export type EffectConditionKey = (typeof EFFECT_CONDITION_KEYS)[number];
@@ -88,6 +100,8 @@ export interface EffectSpec {
   condition?: EffectCondition;
   activation: EffectActivation;
   duration: EffectDuration;
+  requires_mj_validation?: boolean;
+  uses_per_day?: number;
 }
 
 export interface EffectModel {
@@ -130,7 +144,17 @@ export function parseEffectModel(raw: unknown): EffectModel {
   const spec = requireRecord(raw, 'spec', 'EffectModel.spec');
   assertKnownKeys(
     spec,
-    ['target', 'scope', 'op', 'value', 'condition', 'activation', 'duration'],
+    [
+      'target',
+      'scope',
+      'op',
+      'value',
+      'condition',
+      'activation',
+      'duration',
+      'requires_mj_validation',
+      'uses_per_day'
+    ],
     'EffectModel.spec'
   );
   assertEnum(spec.target, EFFECT_TARGETS, 'effect target');
@@ -142,6 +166,8 @@ export function parseEffectModel(raw: unknown): EffectModel {
   }
   assertEnum(spec.activation, EFFECT_ACTIVATIONS, 'effect activation');
   validateEffectDuration(spec.duration);
+  assertOptionalBoolean(spec.requires_mj_validation, 'EffectModel.spec.requires_mj_validation');
+  assertOptionalPositiveInteger(spec.uses_per_day, 'EffectModel.spec.uses_per_day');
 
   if ('render' in raw) {
     assertString(raw.render, 'EffectModel.render');
@@ -224,10 +250,17 @@ function validateEffectDuration(duration: unknown): asserts duration is EffectDu
   }
 
   if (isRecord(duration)) {
-    assertKnownKeys(duration, ['dt'], 'effect duration');
-    if (typeof duration.dt !== 'number' || !Number.isInteger(duration.dt) || duration.dt <= 0) {
-      throw new Error('Effect duration dt must be a positive integer');
+    assertKnownKeys(duration, ['dt', 'locked'], 'effect duration');
+
+    if (typeof duration.dt === 'number') {
+      assertPositiveInteger(duration.dt, 'Effect duration dt');
+    } else if (typeof duration.dt === 'string') {
+      parseValueExpression(duration.dt);
+    } else {
+      throw new Error('Effect duration dt must be a positive integer or value expression');
     }
+
+    assertOptionalBoolean(duration.locked, 'Effect duration locked');
     return;
   }
 
@@ -585,6 +618,36 @@ function assertString(value: unknown, label: string): asserts value is string {
 function assertOptionalString(value: unknown, label: string): asserts value is string | undefined {
   if (value !== undefined) {
     assertString(value, label);
+  }
+}
+
+function assertOptionalBoolean(
+  value: unknown,
+  label: string
+): asserts value is boolean | undefined {
+  if (value !== undefined) {
+    assertBoolean(value, label);
+  }
+}
+
+function assertBoolean(value: unknown, label: string): asserts value is boolean {
+  if (typeof value !== 'boolean') {
+    throw new Error(`${label} must be a boolean`);
+  }
+}
+
+function assertOptionalPositiveInteger(
+  value: unknown,
+  label: string
+): asserts value is number | undefined {
+  if (value !== undefined) {
+    assertPositiveInteger(value, label);
+  }
+}
+
+function assertPositiveInteger(value: unknown, label: string): asserts value is number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`${label} must be a positive integer`);
   }
 }
 

--- a/packages/rules-core/src/effect-renderer.test.ts
+++ b/packages/rules-core/src/effect-renderer.test.ts
@@ -102,6 +102,41 @@ describe('renderEffect', () => {
     expect(renderEffect(factor)).toBe('Réduit le facteur volonté de 1');
   });
 
+  it('renders damage additions', () => {
+    const model = effectModel({
+      target: 'damage',
+      op: 'add',
+      value: 'level + 1',
+      activation: 'active',
+      duration: 'ephemeral'
+    });
+
+    expect(renderEffect(model)).toBe('Inflige niveau + 1 dégâts supplémentaires');
+  });
+
+  it('renders activity condition dimensions', () => {
+    const model = effectModel({
+      target: 'pool',
+      op: 'add',
+      value: 1,
+      condition: {
+        competence: 'danse',
+        spec: 'alchimie_mutagenes',
+        aptitude: 'perception',
+        target_disposition: 'ally',
+        target_ref: 'employeur',
+        intent: 'sauvegarder',
+        directness: 'direct_only'
+      },
+      activation: 'passive',
+      duration: 'permanent'
+    });
+
+    expect(renderEffect(model)).toBe(
+      'Ajoute 1 au pool de dés avec la compétence danse et avec la spécialisation alchimie mutagenes et avec l’aptitude Perception et sur un allié et visant employeur et avec l’intention sauvegarder et en action directe'
+    );
+  });
+
   it('uses a readable generic fallback for uncovered target-operation pairs', () => {
     const model = effectModel({
       target: 'status',

--- a/packages/rules-core/src/effect-renderer.ts
+++ b/packages/rules-core/src/effect-renderer.ts
@@ -47,6 +47,7 @@ const TARGET_LABELS: Record<EffectTarget, string> = {
   factor: 'facteur',
   difficulty: 'difficulté',
   pool: 'pool de dés',
+  damage: 'dégâts',
   energy: 'énergie',
   vitality: 'vitalité',
   status: 'état'
@@ -92,6 +93,11 @@ const TARGET_TAG_LABELS: Record<string, string> = {
   living: 'les vivants'
 };
 
+const TARGET_DISPOSITION_PHRASES: Record<string, string> = {
+  ally: 'sur un allié',
+  enemy: 'contre un ennemi'
+};
+
 const WEAPON_LABELS: Record<string, string> = {
   sword: 'une épée',
   epee: 'une épée',
@@ -114,6 +120,10 @@ const SELF_STATE_LABELS: Record<string, string> = {
   wounded: 'blessé',
   prone: 'à terre',
   hidden: 'caché'
+};
+
+const DIRECTNESS_PHRASES: Record<string, string> = {
+  direct_only: 'en action directe'
 };
 
 export const EFFECT_RENDER_TEMPLATE_KEYS = [
@@ -142,6 +152,7 @@ export const EFFECT_RENDER_TEMPLATE_KEYS = [
   'vitality:sub',
   'vitality:set',
   'vitality:multiply',
+  'damage:add',
   'status:grant',
   'status:sub',
   'status:set'
@@ -178,6 +189,7 @@ const EFFECT_RENDER_TEMPLATES: Partial<Record<RenderTemplateKey, (spec: EffectSp
   'vitality:sub': (spec) => `Retire ${renderValue(spec.value)} points de vitalité`,
   'vitality:set': (spec) => `Fixe la vitalité à ${renderValue(spec.value)}`,
   'vitality:multiply': (spec) => `Multiplie la vitalité par ${renderValue(spec.value)}`,
+  'damage:add': (spec) => `Inflige ${renderValue(spec.value)} dégâts supplémentaires`,
   'status:grant': (spec) => `Inflige l'état ${renderScope(spec.scope)}`,
   'status:sub': (spec) => `Retire l'état ${renderScope(spec.scope)}`,
   'status:set': (spec) => `Fixe l'état à ${renderScope(spec.scope)}`
@@ -316,10 +328,17 @@ function renderFlatCondition(buckets: ConditionBuckets): string {
   }
 
   appendConditionPart(parts, buckets.action_type, renderActionPhrase);
+  appendConditionPart(parts, buckets.competence, renderCompetencePhrase);
+  appendConditionPart(parts, buckets.spec, renderSpecializationPhrase);
+  appendConditionPart(parts, buckets.aptitude, renderAptitudeConditionPhrase);
   appendConditionPart(parts, buckets.target_tag, renderTargetTagPhrase);
+  appendConditionPart(parts, buckets.target_disposition, renderTargetDispositionPhrase);
+  appendConditionPart(parts, buckets.target_ref, renderTargetReferencePhrase);
   appendConditionPart(parts, buckets.weapon, renderWeaponPhrase);
   appendConditionPart(parts, buckets.school, renderSchoolPhrase);
   appendConditionPart(parts, buckets.self_state, renderSelfStatePhrase);
+  appendConditionPart(parts, buckets.intent, renderIntentPhrase);
+  appendConditionPart(parts, buckets.directness, renderDirectnessPhrase);
 
   return parts.join(' et ');
 }
@@ -406,8 +425,28 @@ function renderActionPhrase(value: string): string {
   return ACTION_PHRASES[value] ?? `lors de l'action ${humanize(value)}`;
 }
 
+function renderCompetencePhrase(value: string): string {
+  return `avec la compétence ${humanize(value)}`;
+}
+
+function renderSpecializationPhrase(value: string): string {
+  return `avec la spécialisation ${humanize(value)}`;
+}
+
+function renderAptitudeConditionPhrase(value: string): string {
+  return `avec l’aptitude ${renderScope(value)}`;
+}
+
 function renderTargetTagPhrase(value: string): string {
   return `contre ${TARGET_TAG_LABELS[value] ?? `les cibles ${humanize(value)}`}`;
+}
+
+function renderTargetDispositionPhrase(value: string): string {
+  return TARGET_DISPOSITION_PHRASES[value] ?? `sur une cible ${humanize(value)}`;
+}
+
+function renderTargetReferencePhrase(value: string): string {
+  return `visant ${humanize(value)}`;
 }
 
 function renderWeaponPhrase(value: string): string {
@@ -420,6 +459,14 @@ function renderSchoolPhrase(value: string): string {
 
 function renderSelfStatePhrase(value: string): string {
   return `si le porteur est ${SELF_STATE_LABELS[value] ?? humanize(value)}`;
+}
+
+function renderIntentPhrase(value: string): string {
+  return `avec l’intention ${humanize(value)}`;
+}
+
+function renderDirectnessPhrase(value: string): string {
+  return DIRECTNESS_PHRASES[value] ?? `avec une causalité ${humanize(value)}`;
 }
 
 function renderScope(scope: string | undefined): string {

--- a/packages/rules-core/src/effects.ts
+++ b/packages/rules-core/src/effects.ts
@@ -14,8 +14,17 @@ import {
 
 export const GLOBAL_EFFECT_SCOPE = '__global__';
 
-export type NumericEffectTarget = Exclude<EffectTarget, 'status'>;
+export type NumericEffectTarget = Exclude<EffectTarget, 'status' | 'damage'>;
 export type NumericEffectOperation = Extract<EffectOperation, 'add' | 'sub' | 'set' | 'multiply'>;
+
+const COMPUTED_NUMERIC_EFFECT_TARGETS = [
+  'aptitude',
+  'factor',
+  'difficulty',
+  'pool',
+  'energy',
+  'vitality'
+] as const satisfies readonly NumericEffectTarget[];
 
 export type EffectApplicationContext = EffectConditionContext &
   EffectValueContext & {
@@ -88,6 +97,12 @@ export function computeEffectiveModifiers(
 
     if (!isNumericOperation(effect.spec.op)) {
       throw new Error(`Effect operation "${effect.spec.op}" is only supported for status targets`);
+    }
+
+    if (!isComputedNumericEffectTarget(effect.spec.target)) {
+      throw new Error(
+        `Effect target "${effect.spec.target}" is not supported by computeEffectiveModifiers`
+      );
     }
 
     const value = evaluateValue(effect.spec.value, ctx);
@@ -180,11 +195,17 @@ function isDurationActive(duration: EffectDuration, ctx: EffectApplicationContex
     return ctx.includeEphemeral !== false;
   }
 
-  return ctx.elapsedDT === undefined || ctx.elapsedDT < duration.dt;
+  const dt = typeof duration.dt === 'number' ? duration.dt : evaluateValue(duration.dt, ctx);
+
+  return ctx.elapsedDT === undefined || ctx.elapsedDT < dt;
 }
 
 function isNumericOperation(op: EffectOperation): op is NumericEffectOperation {
   return op === 'add' || op === 'sub' || op === 'set' || op === 'multiply';
+}
+
+function isComputedNumericEffectTarget(target: EffectTarget): target is NumericEffectTarget {
+  return (COMPUTED_NUMERIC_EFFECT_TARGETS as readonly string[]).includes(target);
 }
 
 function getOrCreateModifierBucket(


### PR DESCRIPTION
Extensions schéma EffectModel (doc §4ter) : target damage + render (damage,add) ; condition keys competence/spec/aptitude/target_disposition/target_ref/intent/directness ; spec requires_mj_validation + uses_per_day ; duration {dt:number|string, locked} ; guard effects.ts (damage hors computeEffectiveModifiers). Tests 124 verts + format + canonical. Closes #137, #139, #142. Ref §4ter, épic #122.