### PR TITLE
feat(rules-core): moteur dégâts/défense computeAttackDamage (R-9.9→9.16)

### DIFF
--- a/packages/rules-core/src/combat-damage.test.ts
+++ b/packages/rules-core/src/combat-damage.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeAttackDamage } from './combat-damage.js';
+
+describe('computeAttackDamage', () => {
+  it('rolls melee F+N damage as force successes plus the weapon flat bonus', () => {
+    const result = computeAttackDamage({
+      attackerForce: 4,
+      netToucheSuccesses: 2,
+      weaponDamage: {
+        components: [{ type: 'C', includesForce: true, flat: 3 }]
+      },
+      randomInteger: scriptedRolls([5, 6, 4, 2])
+    });
+
+    expect(result.finalDamage).toBe(5);
+    expect(result.components).toEqual([
+      expect.objectContaining({
+        type: 'C',
+        raw: 5,
+        afterShield: 5,
+        afterResistance: 5,
+        afterCircumstance: 5,
+        protection: 0,
+        afterProtection: 5,
+        enduranceReduction: 0,
+        afterEndurance: 5,
+        zoneMultiplier: 1,
+        final: 5
+      })
+    ]);
+    expect(result.log).toContainEqual(
+      expect.objectContaining({
+        step: 'force_roll',
+        difficulty: 5,
+        successes: 2
+      })
+    );
+  });
+
+  it('resolves ranged N+munition damage without rolling force', () => {
+    const result = computeAttackDamage({
+      attackerForce: 5,
+      netToucheSuccesses: 3,
+      weaponDamage: {
+        components: [{ type: 'P', includesForce: false, flat: 3, ammoBonus: 1 }]
+      },
+      randomInteger: () => {
+        throw new Error('N+munition damage must not roll force');
+      }
+    });
+
+    expect(result.finalDamage).toBe(4);
+    expect(result.components[0]).toMatchObject({
+      type: 'P',
+      raw: 4,
+      final: 4
+    });
+    expect(result.log.some((entry) => entry.step === 'force_roll')).toBe(false);
+  });
+
+  it('supports ranged weapons whose formula includes force such as F+bille', () => {
+    const result = computeAttackDamage({
+      attackerForce: 3,
+      netToucheSuccesses: 1,
+      weaponDamage: {
+        components: [{ type: 'C', includesForce: true, flat: 0, ammoBonus: 1 }]
+      },
+      randomInteger: scriptedRolls([6, 8, 2])
+    });
+
+    expect(result.finalDamage).toBe(3);
+    expect(result.components[0]).toMatchObject({
+      type: 'C',
+      forceSuccesses: 2,
+      raw: 3,
+      final: 3
+    });
+  });
+
+  it('adds only matching typed damage modifiers before mitigation', () => {
+    const result = computeAttackDamage({
+      attackerForce: 0,
+      netToucheSuccesses: 1,
+      weaponDamage: {
+        components: [{ type: 'C', includesForce: false, flat: 2 }]
+      },
+      damageModifiers: [
+        { type: 'C', value: 2, source: 'atout' },
+        { type: 'E', value: 99, source: 'spell-other-type' }
+      ],
+      randomInteger: scriptedRolls([])
+    });
+
+    expect(result.finalDamage).toBe(4);
+    expect(result.components[0]).toMatchObject({
+      type: 'C',
+      damageModifier: 2,
+      raw: 4
+    });
+  });
+
+  it('lowers the force-roll difficulty when net touche successes increase', () => {
+    const weakHit = computeAttackDamage({
+      attackerForce: 3,
+      netToucheSuccesses: 0,
+      weaponDamage: {
+        components: [{ type: 'T', includesForce: true, flat: 0 }]
+      },
+      randomInteger: scriptedRolls([5, 5, 5])
+    });
+    const strongHit = computeAttackDamage({
+      attackerForce: 3,
+      netToucheSuccesses: 2,
+      weaponDamage: {
+        components: [{ type: 'T', includesForce: true, flat: 0 }]
+      },
+      randomInteger: scriptedRolls([5, 5, 5])
+    });
+
+    expect(weakHit.finalDamage).toBe(0);
+    expect(strongHit.finalDamage).toBe(3);
+    expect(weakHit.log).toContainEqual(
+      expect.objectContaining({ step: 'force_roll', difficulty: 7, successes: 0 })
+    );
+    expect(strongHit.log).toContainEqual(
+      expect.objectContaining({ step: 'force_roll', difficulty: 5, successes: 3 })
+    );
+  });
+
+  it('subtracts protections by damage type and covering layer', () => {
+    const result = computeAttackDamage({
+      attackerForce: 0,
+      netToucheSuccesses: 1,
+      weaponDamage: {
+        components: [{ type: 'P', includesForce: false, flat: 6 }]
+      },
+      defense: {
+        protections: [
+          {
+            id: 'cuir',
+            layer: 'soft',
+            zones: ['thorax'],
+            values: { P: 1, E: 1, C: 0, T: 1 }
+          },
+          {
+            id: 'maille',
+            layer: 'mail',
+            zones: ['thorax'],
+            values: { P: 2, E: 1, C: 1, T: 2 }
+          },
+          {
+            id: 'casque',
+            layer: 'plate',
+            zones: ['tete'],
+            values: { P: 3, E: 1, C: 2, T: 3 }
+          }
+        ]
+      },
+      zone: { id: 'thorax' },
+      randomInteger: scriptedRolls([])
+    });
+
+    expect(result.finalDamage).toBe(3);
+    expect(result.components[0]).toMatchObject({
+      type: 'P',
+      raw: 6,
+      protection: 3,
+      afterProtection: 3,
+      final: 3
+    });
+  });
+
+  it('applies typed circumstance modifiers before protections', () => {
+    const result = computeAttackDamage({
+      attackerForce: 0,
+      netToucheSuccesses: 1,
+      weaponDamage: {
+        components: [{ type: 'T', includesForce: false, flat: 2 }]
+      },
+      defense: {
+        circumstanceModifiers: [{ type: 'T', value: 3, source: 'charge' }],
+        protections: [
+          {
+            id: 'cuir',
+            layer: 'soft',
+            zones: ['thorax'],
+            values: { P: 1, E: 1, C: 0, T: 1 }
+          }
+        ]
+      },
+      zone: { id: 'thorax' },
+      randomInteger: scriptedRolls([])
+    });
+
+    expect(result.finalDamage).toBe(4);
+    expect(result.components[0]).toMatchObject({
+      raw: 2,
+      circumstanceModifier: 3,
+      afterCircumstance: 5,
+      protection: 1,
+      final: 4
+    });
+  });
+
+  it('negates a component when its D100 resistance succeeds', () => {
+    const result = computeAttackDamage({
+      attackerForce: 0,
+      netToucheSuccesses: 1,
+      weaponDamage: {
+        components: [{ type: 'E', includesForce: false, flat: 5 }]
+      },
+      defense: {
+        percentageResistances: { E: 40 }
+      },
+      randomInteger: scriptedRolls([39])
+    });
+
+    expect(result.finalDamage).toBe(0);
+    expect(result.components[0]).toMatchObject({
+      type: 'E',
+      raw: 5,
+      resistanceRoll: 39,
+      resisted: true,
+      afterResistance: 0,
+      final: 0
+    });
+  });
+
+  it('fully deflects a component when the shield D100 succeeds', () => {
+    const result = computeAttackDamage({
+      attackerForce: 0,
+      netToucheSuccesses: 1,
+      weaponDamage: {
+        components: [{ type: 'C', includesForce: false, flat: 5 }]
+      },
+      defense: {
+        shield: { percent: 30, usable: true }
+      },
+      randomInteger: scriptedRolls([30])
+    });
+
+    expect(result.finalDamage).toBe(0);
+    expect(result.components[0]).toMatchObject({
+      type: 'C',
+      shieldRoll: 30,
+      shieldDeflected: true,
+      afterShield: 0,
+      final: 0
+    });
+  });
+
+  it('applies the zone multiplier after protections and endurance', () => {
+    const result = computeAttackDamage({
+      attackerForce: 0,
+      netToucheSuccesses: 1,
+      weaponDamage: {
+        components: [{ type: 'C', includesForce: false, flat: 6 }]
+      },
+      defense: {
+        endurance: { pool: 3 },
+        protections: [
+          {
+            id: 'casque',
+            layer: 'plate',
+            zones: ['tete'],
+            values: { P: 2, E: 1, C: 2, T: 2 }
+          }
+        ]
+      },
+      zone: { id: 'tete', damageMultiplier: 2, allowsEndurance: true },
+      randomInteger: scriptedRolls([7, 8, 2])
+    });
+
+    expect(result.finalDamage).toBe(4);
+    expect(result.components[0]).toMatchObject({
+      raw: 6,
+      protection: 2,
+      afterProtection: 4,
+      enduranceReduction: 2,
+      afterEndurance: 2,
+      zoneMultiplier: 2,
+      final: 4
+    });
+  });
+
+  it('forbids endurance for throat and eye style zones before applying their multiplier', () => {
+    const result = computeAttackDamage({
+      attackerForce: 0,
+      netToucheSuccesses: 1,
+      weaponDamage: {
+        components: [{ type: 'T', includesForce: false, flat: 6 }]
+      },
+      defense: {
+        endurance: { pool: 3 },
+        protections: [
+          {
+            id: 'gorgerin',
+            layer: 'plate',
+            zones: ['gorge'],
+            values: { P: 2, E: 1, C: 2, T: 2 }
+          }
+        ]
+      },
+      zone: { id: 'gorge', damageMultiplier: 2, allowsEndurance: false },
+      randomInteger: scriptedRolls([])
+    });
+
+    expect(result.finalDamage).toBe(8);
+    expect(result.components[0]).toMatchObject({
+      protection: 2,
+      afterProtection: 4,
+      enduranceReduction: 0,
+      afterEndurance: 4,
+      final: 8
+    });
+    expect(result.log.some((entry) => entry.step === 'endurance_roll')).toBe(false);
+  });
+
+  it('resolves multi-type weapons against each component type protection', () => {
+    const result = computeAttackDamage({
+      attackerForce: 2,
+      netToucheSuccesses: 1,
+      weaponDamage: {
+        components: [
+          { type: 'C', includesForce: true, flat: 2 },
+          { type: 'E', includesForce: false, flat: 1 }
+        ]
+      },
+      defense: {
+        protections: [
+          {
+            id: 'cuir',
+            layer: 'soft',
+            zones: ['main'],
+            values: { P: 1, E: 1, C: 2, T: 1 }
+          }
+        ]
+      },
+      zone: { id: 'main' },
+      randomInteger: scriptedRolls([6, 3])
+    });
+
+    expect(result.finalDamage).toBe(1);
+    expect(result.components).toEqual([
+      expect.objectContaining({ type: 'C', raw: 3, protection: 2, final: 1 }),
+      expect.objectContaining({ type: 'E', raw: 1, protection: 1, final: 0 })
+    ]);
+  });
+
+  it('uses one endurance roll for the final multi-type wound', () => {
+    const result = computeAttackDamage({
+      attackerForce: 0,
+      netToucheSuccesses: 1,
+      weaponDamage: {
+        components: [
+          { type: 'C', includesForce: false, flat: 4 },
+          { type: 'E', includesForce: false, flat: 3 }
+        ]
+      },
+      defense: {
+        endurance: { pool: 2 }
+      },
+      randomInteger: scriptedRolls([7, 8])
+    });
+
+    expect(result.finalDamage).toBe(5);
+    expect(result.log.filter((entry) => entry.step === 'endurance_roll')).toHaveLength(1);
+    expect(result.components).toEqual([
+      expect.objectContaining({ type: 'C', afterProtection: 4, enduranceReduction: 2, final: 2 }),
+      expect.objectContaining({ type: 'E', afterProtection: 3, enduranceReduction: 0, final: 3 })
+    ]);
+  });
+});
+
+function scriptedRolls(values: number[]) {
+  let index = 0;
+
+  return (sides: number): number => {
+    const value = values[index];
+    index += 1;
+
+    if (value === undefined) {
+      throw new Error(`No scripted roll left for D${sides}`);
+    }
+
+    if (!Number.isInteger(value) || value < 1 || value > sides) {
+      throw new Error(`Invalid scripted D${sides} roll: ${value}`);
+    }
+
+    return value;
+  };
+}

--- a/packages/rules-core/src/combat-damage.ts
+++ b/packages/rules-core/src/combat-damage.ts
@@ -1,0 +1,725 @@
+import { type DiceRollResult, type RandomInteger, rollDice } from './dice.js';
+import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
+
+export type DamageType = 'P' | 'E' | 'C' | 'T';
+export type DamageProtectionValues = Partial<Record<DamageType, number>>;
+
+export interface WeaponDamageSpec {
+  components: WeaponDamageComponentSpec[];
+}
+
+export interface WeaponDamageComponentSpec {
+  type: DamageType;
+  includesForce?: boolean;
+  flat?: number;
+  ammoBonus?: number;
+  label?: string;
+}
+
+export interface DamageModifier {
+  type: DamageType;
+  value: number;
+  source?: string;
+}
+
+export interface DamageShieldInput {
+  percent: number;
+  usable?: boolean;
+  source?: string;
+}
+
+export interface DamageProtectionLayerInput {
+  id?: string;
+  layer: string;
+  zones: string[];
+  values: DamageProtectionValues;
+  enabled?: boolean;
+}
+
+export interface DamageEnduranceInput {
+  pool: number;
+  difficulty?: number;
+  enabled?: boolean;
+}
+
+export interface DamageDefenseInput {
+  shield?: DamageShieldInput;
+  percentageResistances?: Partial<Record<DamageType, number>>;
+  circumstanceModifiers?: DamageModifier[];
+  protections?: DamageProtectionLayerInput[];
+  endurance?: DamageEnduranceInput;
+}
+
+export interface DamageZoneInput {
+  id?: string;
+  damageMultiplier?: number;
+  allowsEndurance?: boolean;
+}
+
+export interface ComputeAttackDamageInput {
+  attackerForce: number;
+  netToucheSuccesses: number;
+  weaponDamage: WeaponDamageSpec;
+  damageModifiers?: DamageModifier[];
+  defense?: DamageDefenseInput;
+  zone?: DamageZoneInput;
+  randomInteger: RandomInteger;
+  config?: RulesConfig;
+}
+
+export interface RollAttackDamageInput {
+  attackerForce: number;
+  netToucheSuccesses: number;
+  weaponDamage: WeaponDamageSpec;
+  damageModifiers?: DamageModifier[];
+  randomInteger: RandomInteger;
+}
+
+export interface RolledDamageComponent {
+  type: DamageType;
+  label?: string;
+  includesForce: boolean;
+  forceSuccesses: number;
+  flat: number;
+  ammoBonus: number;
+  damageModifier: number;
+  raw: number;
+}
+
+export interface RollAttackDamageResult {
+  components: RolledDamageComponent[];
+  log: CombatDamageLogEntry[];
+}
+
+export interface MitigateDamageInput {
+  components: RolledDamageComponent[];
+  defense?: DamageDefenseInput;
+  zone?: DamageZoneInput;
+  randomInteger: RandomInteger;
+  config?: RulesConfig;
+}
+
+export interface ComputedDamageComponent extends RolledDamageComponent {
+  shieldPercent?: number;
+  shieldRoll?: number;
+  shieldDeflected: boolean;
+  afterShield: number;
+  resistancePercent?: number;
+  resistanceRoll?: number;
+  resisted: boolean;
+  afterResistance: number;
+  circumstanceModifier: number;
+  afterCircumstance: number;
+  protection: number;
+  protectionLayers: string[];
+  protectionIds: string[];
+  afterProtection: number;
+  enduranceReduction: number;
+  afterEndurance: number;
+  zoneMultiplier: number;
+  final: number;
+}
+
+export interface CombatDamageResult {
+  finalDamage: number;
+  components: ComputedDamageComponent[];
+  log: CombatDamageLogEntry[];
+}
+
+export type CombatDamageLogEntry =
+  | {
+      step: 'force_roll';
+      pool: number;
+      difficulty: number;
+      successes: number;
+      roll: DiceRollResult;
+    }
+  | {
+      step: 'raw_damage';
+      componentIndex: number;
+      type: DamageType;
+      forceSuccesses: number;
+      flat: number;
+      ammoBonus: number;
+      damageModifier: number;
+      after: number;
+    }
+  | {
+      step: 'shield';
+      componentIndex: number;
+      type: DamageType;
+      before: number;
+      percent: number;
+      roll?: number;
+      deflected: boolean;
+      after: number;
+    }
+  | {
+      step: 'resistance';
+      componentIndex: number;
+      type: DamageType;
+      before: number;
+      percent: number;
+      roll?: number;
+      resisted: boolean;
+      after: number;
+    }
+  | {
+      step: 'circumstance';
+      componentIndex: number;
+      type: DamageType;
+      before: number;
+      modifier: number;
+      after: number;
+    }
+  | {
+      step: 'protection';
+      componentIndex: number;
+      type: DamageType;
+      before: number;
+      protection: number;
+      layers: string[];
+      protectionIds: string[];
+      after: number;
+    }
+  | {
+      step: 'endurance_roll';
+      pool: number;
+      difficulty: number;
+      successes: number;
+      roll: DiceRollResult;
+      before: number;
+      reduction: number;
+      after: number;
+    }
+  | {
+      step: 'endurance';
+      componentIndex: number;
+      type: DamageType;
+      before: number;
+      reduction: number;
+      after: number;
+      skipped: boolean;
+      reason?: 'zone_forbids_endurance' | 'no_endurance_pool' | 'no_damage';
+    }
+  | {
+      step: 'zone';
+      componentIndex: number;
+      type: DamageType;
+      before: number;
+      multiplier: number;
+      after: number;
+    };
+
+interface MitigatedBeforeEnduranceComponent extends RolledDamageComponent {
+  shieldPercent?: number;
+  shieldRoll?: number;
+  shieldDeflected: boolean;
+  afterShield: number;
+  resistancePercent?: number;
+  resistanceRoll?: number;
+  resisted: boolean;
+  afterResistance: number;
+  circumstanceModifier: number;
+  afterCircumstance: number;
+  protection: number;
+  protectionLayers: string[];
+  protectionIds: string[];
+  afterProtection: number;
+}
+
+export function computeAttackDamage(input: ComputeAttackDamageInput): CombatDamageResult {
+  const rolled = rollAttackDamage(input);
+  const mitigated = mitigateDamageComponents({
+    components: rolled.components,
+    defense: input.defense,
+    zone: input.zone,
+    randomInteger: input.randomInteger,
+    config: input.config
+  });
+
+  return {
+    finalDamage: mitigated.finalDamage,
+    components: mitigated.components,
+    log: [...rolled.log, ...mitigated.log]
+  };
+}
+
+export function rollAttackDamage(input: RollAttackDamageInput): RollAttackDamageResult {
+  assertNonNegativeInteger('attackerForce', input.attackerForce);
+  assertNonNegativeInteger('netToucheSuccesses', input.netToucheSuccesses);
+  assertWeaponDamage(input.weaponDamage);
+
+  const difficulty = damageRollDifficulty(input.netToucheSuccesses);
+  const includesForce = input.weaponDamage.components.some((component) => component.includesForce);
+  const log: CombatDamageLogEntry[] = [];
+  const forceRoll = includesForce
+    ? rollDice(input.attackerForce, difficulty, { randomInteger: input.randomInteger })
+    : undefined;
+  const forceSuccesses = forceRoll?.successes ?? 0;
+
+  if (forceRoll !== undefined) {
+    log.push({
+      step: 'force_roll',
+      pool: input.attackerForce,
+      difficulty,
+      successes: forceSuccesses,
+      roll: forceRoll
+    });
+  }
+
+  const components = input.weaponDamage.components.map((component, componentIndex) => {
+    const flat = component.flat ?? 0;
+    const ammoBonus = component.ammoBonus ?? 0;
+    const damageModifier = sumDamageModifiers(input.damageModifiers, component.type);
+    const componentForceSuccesses = component.includesForce ? forceSuccesses : 0;
+    const raw = clampDamage(componentForceSuccesses + flat + ammoBonus + damageModifier);
+
+    log.push({
+      step: 'raw_damage',
+      componentIndex,
+      type: component.type,
+      forceSuccesses: componentForceSuccesses,
+      flat,
+      ammoBonus,
+      damageModifier,
+      after: raw
+    });
+
+    return {
+      type: component.type,
+      label: component.label,
+      includesForce: component.includesForce ?? false,
+      forceSuccesses: componentForceSuccesses,
+      flat,
+      ammoBonus,
+      damageModifier,
+      raw
+    };
+  });
+
+  return { components, log };
+}
+
+export function mitigateDamageComponents(input: MitigateDamageInput): CombatDamageResult {
+  const config = input.config ?? DEFAULT_RULES_CONFIG;
+  const defense = input.defense ?? {};
+  const zone = normalizeZone(input.zone);
+  const log: CombatDamageLogEntry[] = [];
+  const beforeEndurance = input.components.map((component, componentIndex) =>
+    applyComponentMitigationBeforeEndurance({
+      component,
+      componentIndex,
+      defense,
+      zoneId: zone.id,
+      randomInteger: input.randomInteger,
+      log
+    })
+  );
+
+  const afterEndurance = applyEndurance({
+    components: beforeEndurance,
+    defense,
+    zone,
+    randomInteger: input.randomInteger,
+    config,
+    log
+  });
+  const afterZone = afterEndurance.map((component, componentIndex) => {
+    const final = clampDamage(component.afterEndurance * zone.damageMultiplier);
+
+    log.push({
+      step: 'zone',
+      componentIndex,
+      type: component.type,
+      before: component.afterEndurance,
+      multiplier: zone.damageMultiplier,
+      after: final
+    });
+
+    return {
+      ...component,
+      zoneMultiplier: zone.damageMultiplier,
+      final
+    };
+  });
+
+  return {
+    finalDamage: afterZone.reduce((sum, component) => sum + component.final, 0),
+    components: afterZone,
+    log
+  };
+}
+
+export function damageRollDifficulty(netToucheSuccesses: number): number {
+  assertNonNegativeInteger('netToucheSuccesses', netToucheSuccesses);
+
+  return Math.max(1, 7 - netToucheSuccesses);
+}
+
+function applyComponentMitigationBeforeEndurance(input: {
+  component: RolledDamageComponent;
+  componentIndex: number;
+  defense: DamageDefenseInput;
+  zoneId: string;
+  randomInteger: RandomInteger;
+  log: CombatDamageLogEntry[];
+}): MitigatedBeforeEnduranceComponent {
+  const shieldResult = applyShield({
+    component: input.component,
+    componentIndex: input.componentIndex,
+    shield: input.defense.shield,
+    randomInteger: input.randomInteger,
+    log: input.log
+  });
+  const resistanceResult = applyResistance({
+    component: input.component,
+    componentIndex: input.componentIndex,
+    before: shieldResult.afterShield,
+    resistancePercent: input.defense.percentageResistances?.[input.component.type],
+    randomInteger: input.randomInteger,
+    log: input.log
+  });
+  const circumstanceModifier = sumDamageModifiers(
+    input.defense.circumstanceModifiers,
+    input.component.type
+  );
+  const afterCircumstance = clampDamage(resistanceResult.afterResistance + circumstanceModifier);
+
+  input.log.push({
+    step: 'circumstance',
+    componentIndex: input.componentIndex,
+    type: input.component.type,
+    before: resistanceResult.afterResistance,
+    modifier: circumstanceModifier,
+    after: afterCircumstance
+  });
+
+  const protectionResult = applyProtection({
+    component: input.component,
+    componentIndex: input.componentIndex,
+    before: afterCircumstance,
+    protections: input.defense.protections,
+    zoneId: input.zoneId,
+    log: input.log
+  });
+
+  return {
+    ...input.component,
+    ...shieldResult,
+    ...resistanceResult,
+    circumstanceModifier,
+    afterCircumstance,
+    ...protectionResult
+  };
+}
+
+function applyShield(input: {
+  component: RolledDamageComponent;
+  componentIndex: number;
+  shield?: DamageShieldInput;
+  randomInteger: RandomInteger;
+  log: CombatDamageLogEntry[];
+}): {
+  shieldPercent?: number;
+  shieldRoll?: number;
+  shieldDeflected: boolean;
+  afterShield: number;
+} {
+  const percent = input.shield?.percent ?? 0;
+  assertPercent('shield.percent', percent);
+  const usable = input.shield?.usable ?? true;
+  const shouldRoll = input.component.raw > 0 && usable && percent > 0;
+  const roll = shouldRoll ? rollD100(input.randomInteger) : undefined;
+  const deflected = roll !== undefined && roll <= percent;
+  const afterShield = deflected ? 0 : input.component.raw;
+
+  input.log.push({
+    step: 'shield',
+    componentIndex: input.componentIndex,
+    type: input.component.type,
+    before: input.component.raw,
+    percent,
+    roll,
+    deflected,
+    after: afterShield
+  });
+
+  return {
+    shieldPercent: percent,
+    shieldRoll: roll,
+    shieldDeflected: deflected,
+    afterShield
+  };
+}
+
+function applyResistance(input: {
+  component: RolledDamageComponent;
+  componentIndex: number;
+  before: number;
+  resistancePercent?: number;
+  randomInteger: RandomInteger;
+  log: CombatDamageLogEntry[];
+}): {
+  resistancePercent?: number;
+  resistanceRoll?: number;
+  resisted: boolean;
+  afterResistance: number;
+} {
+  const percent = input.resistancePercent ?? 0;
+  assertPercent(`percentageResistances.${input.component.type}`, percent);
+  const shouldRoll = input.before > 0 && percent > 0;
+  const roll = shouldRoll ? rollD100(input.randomInteger) : undefined;
+  const resisted = roll !== undefined && roll <= percent;
+  const afterResistance = resisted ? 0 : input.before;
+
+  input.log.push({
+    step: 'resistance',
+    componentIndex: input.componentIndex,
+    type: input.component.type,
+    before: input.before,
+    percent,
+    roll,
+    resisted,
+    after: afterResistance
+  });
+
+  return {
+    resistancePercent: percent,
+    resistanceRoll: roll,
+    resisted,
+    afterResistance
+  };
+}
+
+function applyProtection(input: {
+  component: RolledDamageComponent;
+  componentIndex: number;
+  before: number;
+  protections?: DamageProtectionLayerInput[];
+  zoneId: string;
+  log: CombatDamageLogEntry[];
+}): {
+  protection: number;
+  protectionLayers: string[];
+  protectionIds: string[];
+  afterProtection: number;
+} {
+  const matchingProtections = (input.protections ?? []).filter(
+    (protection) => protection.enabled !== false && protection.zones.includes(input.zoneId)
+  );
+  const protection = matchingProtections.reduce((sum, current) => {
+    const value = current.values[input.component.type] ?? 0;
+    assertNonNegativeInteger(
+      `protections.${current.id ?? current.layer}.${input.component.type}`,
+      value
+    );
+
+    return sum + value;
+  }, 0);
+  const afterProtection = clampDamage(input.before - protection);
+  const layers = matchingProtections.map((current) => current.layer);
+  const protectionIds = matchingProtections.flatMap((current) =>
+    current.id === undefined ? [] : [current.id]
+  );
+
+  input.log.push({
+    step: 'protection',
+    componentIndex: input.componentIndex,
+    type: input.component.type,
+    before: input.before,
+    protection,
+    layers,
+    protectionIds,
+    after: afterProtection
+  });
+
+  return {
+    protection,
+    protectionLayers: layers,
+    protectionIds,
+    afterProtection
+  };
+}
+
+function applyEndurance(input: {
+  components: MitigatedBeforeEnduranceComponent[];
+  defense: DamageDefenseInput;
+  zone: Required<DamageZoneInput>;
+  randomInteger: RandomInteger;
+  config: RulesConfig;
+  log: CombatDamageLogEntry[];
+}): Array<
+  MitigatedBeforeEnduranceComponent & { enduranceReduction: number; afterEndurance: number }
+> {
+  const damageBeforeEndurance = input.components.reduce(
+    (sum, component) => sum + component.afterProtection,
+    0
+  );
+  const endurance = input.defense.endurance;
+  const enduranceEnabled = endurance?.enabled ?? true;
+  const endurancePool = endurance?.pool ?? 0;
+  const enduranceDifficulty = endurance?.difficulty ?? input.config.combat.staminaRollDifficulty;
+
+  assertNonNegativeInteger('endurance.pool', endurancePool);
+  assertPositiveInteger('endurance.difficulty', enduranceDifficulty);
+
+  const canRoll =
+    damageBeforeEndurance > 0 &&
+    input.zone.allowsEndurance &&
+    enduranceEnabled &&
+    endurancePool > 0;
+  const roll = canRoll
+    ? rollDice(endurancePool, enduranceDifficulty, { randomInteger: input.randomInteger })
+    : undefined;
+  const totalReduction = Math.min(damageBeforeEndurance, roll?.successes ?? 0);
+
+  if (roll !== undefined) {
+    input.log.push({
+      step: 'endurance_roll',
+      pool: endurancePool,
+      difficulty: enduranceDifficulty,
+      successes: roll.successes,
+      roll,
+      before: damageBeforeEndurance,
+      reduction: totalReduction,
+      after: damageBeforeEndurance - totalReduction
+    });
+  }
+
+  let remainingReduction = totalReduction;
+
+  return input.components.map((component, componentIndex) => {
+    const reduction = Math.min(component.afterProtection, remainingReduction);
+    remainingReduction -= reduction;
+    const afterEndurance = component.afterProtection - reduction;
+    const skippedReason = enduranceSkipReason({
+      damageBeforeEndurance: component.afterProtection,
+      zoneAllowsEndurance: input.zone.allowsEndurance,
+      endurancePool,
+      enduranceEnabled
+    });
+
+    input.log.push({
+      step: 'endurance',
+      componentIndex,
+      type: component.type,
+      before: component.afterProtection,
+      reduction,
+      after: afterEndurance,
+      skipped: skippedReason !== undefined,
+      reason: skippedReason
+    });
+
+    return {
+      ...component,
+      enduranceReduction: reduction,
+      afterEndurance
+    };
+  });
+}
+
+function enduranceSkipReason(input: {
+  damageBeforeEndurance: number;
+  zoneAllowsEndurance: boolean;
+  endurancePool: number;
+  enduranceEnabled: boolean;
+}): 'zone_forbids_endurance' | 'no_endurance_pool' | 'no_damage' | undefined {
+  if (input.damageBeforeEndurance <= 0) {
+    return 'no_damage';
+  }
+
+  if (!input.zoneAllowsEndurance) {
+    return 'zone_forbids_endurance';
+  }
+
+  if (!input.enduranceEnabled || input.endurancePool <= 0) {
+    return 'no_endurance_pool';
+  }
+
+  return undefined;
+}
+
+function normalizeZone(zone: DamageZoneInput | undefined): Required<DamageZoneInput> {
+  const normalized = {
+    id: zone?.id ?? 'unspecified',
+    damageMultiplier: zone?.damageMultiplier ?? 1,
+    allowsEndurance: zone?.allowsEndurance ?? true
+  };
+
+  assertPositiveNumber('zone.damageMultiplier', normalized.damageMultiplier);
+
+  return normalized;
+}
+
+function sumDamageModifiers(modifiers: DamageModifier[] | undefined, type: DamageType): number {
+  return (modifiers ?? [])
+    .filter((modifier) => modifier.type === type)
+    .reduce((sum, modifier) => {
+      assertInteger(`damageModifiers.${modifier.source ?? modifier.type}`, modifier.value);
+
+      return sum + modifier.value;
+    }, 0);
+}
+
+function assertWeaponDamage(weaponDamage: WeaponDamageSpec): void {
+  if (weaponDamage.components.length === 0) {
+    throw new Error('weaponDamage.components must contain at least one component');
+  }
+
+  for (const [index, component] of weaponDamage.components.entries()) {
+    assertDamageType(`weaponDamage.components.${index}.type`, component.type);
+    assertInteger(`weaponDamage.components.${index}.flat`, component.flat ?? 0);
+    assertInteger(`weaponDamage.components.${index}.ammoBonus`, component.ammoBonus ?? 0);
+  }
+}
+
+function assertDamageType(name: string, value: string): void {
+  if (!['P', 'E', 'C', 'T'].includes(value)) {
+    throw new Error(`${name} must be one of P, E, C, T`);
+  }
+}
+
+function assertPercent(name: string, value: number): void {
+  if (!Number.isInteger(value) || value < 0 || value > 100) {
+    throw new Error(`${name} must be an integer between 0 and 100`);
+  }
+}
+
+function assertPositiveNumber(name: string, value: number): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number`);
+  }
+}
+
+function assertPositiveInteger(name: string, value: number): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+}
+
+function assertInteger(name: string, value: number): void {
+  if (!Number.isInteger(value)) {
+    throw new Error(`${name} must be an integer`);
+  }
+}
+
+function assertNonNegativeInteger(name: string, value: number): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+}
+
+function clampDamage(value: number): number {
+  return Math.max(0, value);
+}
+
+function rollD100(randomInteger: RandomInteger): number {
+  const value = randomInteger(100);
+
+  if (!Number.isInteger(value) || value < 1 || value > 100) {
+    throw new Error(`randomInteger(100) must return an integer between 1 and 100`);
+  }
+
+  return value;
+}

--- a/packages/rules-core/src/index.ts
+++ b/packages/rules-core/src/index.ts
@@ -1,5 +1,6 @@
 export * from './arbiter.js';
 export * from './character.js';
+export * from './combat-damage.js';
 export * from './combat.js';
 export * from './dice.js';
 export * from './effect-model.js';


### PR DESCRIPTION
## Moteur dégâts / défense (computeAttackDamage)

Implémente la résolution des dégâts documentée (moteurs §4 + §4bis, `09-combat.md` R-9.9→R-9.16) en **fonctions pures testables**, en amont de `applyDamage` (inchangé). **Ne câble pas** encore `resolveAttack` (tâche C2).

### Chaîne
1. **Jet de Force** (R-9.9/9.10) : difficulté `max(1, 7 − réussites nettes de touche)` ; Force incluse **par composante** selon le token `F` de la formule d'arme.
2. **Mitigation** dans l'ordre consolidé **R-9.12** : bouclier (D100) → résistance % (D100) → circonstance → protections P/E/C/T par couche/zone → **endurance** (uniquement si la zone l'autorise) → **×2 zone en dernier**.
3. Sortie : dégât final + composantes typées + **log auditable par étape**.

### Notes
- Fonctions pures, RNG injecté (comme `combat.ts`). Résistances % / protections par couche / bouclier / zone = **inputs typés** (fournis plus tard par l'équipement et le moteur d'effets).
- 128 tests (F+N, arme seule, fronde `F+bille`, couplage difficulté, multi-type torche, ordre endurance/zone, zones sans endurance) + `format:check` + `canonical:check` verts.

Ref : `moteurs-rules-core.md` §4/§4bis, `09-combat.md` R-9.9→R-9.16, épic #122. Roadmap C1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
