### PR TITLE
feat(rules-core): câbler la résolution deux phases (touche/dégâts) dans combat

### DIFF
--- a/packages/rules-core/src/combat.test.ts
+++ b/packages/rules-core/src/combat.test.ts
@@ -7,7 +7,8 @@ import {
   createCombatState,
   getCyclicDT,
   resolveNextAction,
-  resolveStaminaDamage
+  resolveStaminaDamage,
+  type AttackAction
 } from './combat.js';
 
 describe('combat DT timeline', () => {
@@ -259,7 +260,181 @@ describe('combat action resolution', () => {
     expect(target?.vitality.current).toBe(7);
     expect(target?.nextActionAt).toBe(12);
   });
+
+  it('computes F+N weapon damage from net touche successes and applies it', () => {
+    const attacker = combatant({
+      id: 'attacker',
+      speedFactor: 5,
+      pendingAction: {
+        type: 'attack',
+        targetId: 'defender',
+        attack: { pool: 2, difficulty: 7 },
+        damage: {
+          attackerForce: 4,
+          weaponDamage: {
+            components: [{ type: 'C', includesForce: true, flat: 3 }]
+          }
+        }
+      }
+    });
+    const defender = combatant({ id: 'defender', speedFactor: 8 });
+    const state = addCombatant(addCombatant(createCombatState(1), defender), attacker);
+
+    const result = resolveNextAction(state, {
+      randomInteger: scriptedRolls([7, 8, 5, 6, 4, 2])
+    });
+    const target = result.timeline.find((entry) => entry.id === 'defender');
+    const attackEvent = result.log.find((event) => event.type === 'attack_resolved');
+
+    expect(target?.vitality.current).toBe(5);
+    expect(target?.nextActionAt).toBe(14);
+    expect(attackEvent).toMatchObject({
+      type: 'attack_resolved',
+      successes: 2,
+      damageBreakdown: {
+        finalDamage: 5,
+        components: [
+          expect.objectContaining({
+            type: 'C',
+            forceSuccesses: 2,
+            raw: 5,
+            final: 5
+          })
+        ],
+        log: expect.arrayContaining([
+          expect.objectContaining({
+            step: 'force_roll',
+            difficulty: 5,
+            successes: 2
+          })
+        ])
+      }
+    });
+    expect(result.log.at(-1)).toMatchObject({
+      type: 'damage_applied',
+      targetId: 'defender',
+      damage: 5,
+      finalDamage: 5
+    });
+  });
+
+  it('uses defended net touche successes to raise damage difficulty and reduce damage', () => {
+    const withoutDefense = resolveNextAction(
+      attackState({
+        attack: { pool: 3, difficulty: 7 },
+        damage: {
+          attackerForce: 3,
+          weaponDamage: {
+            components: [{ type: 'T', includesForce: true }]
+          }
+        }
+      }),
+      { randomInteger: scriptedRolls([7, 8, 9, 4, 4, 5]) }
+    );
+    const withDefense = resolveNextAction(
+      attackState({
+        attack: { pool: 3, difficulty: 7 },
+        defense: { pool: 2, difficulty: 7 },
+        damage: {
+          attackerForce: 3,
+          weaponDamage: {
+            components: [{ type: 'T', includesForce: true }]
+          }
+        }
+      }),
+      { randomInteger: scriptedRolls([7, 8, 9, 7, 2, 4, 4, 5]) }
+    );
+    const undefendedAttack = withoutDefense.log.find((event) => event.type === 'attack_resolved');
+    const defendedAttack = withDefense.log.find((event) => event.type === 'attack_resolved');
+
+    expect(undefendedAttack).toMatchObject({
+      successes: 3,
+      damageBreakdown: {
+        finalDamage: 3,
+        log: expect.arrayContaining([
+          expect.objectContaining({ step: 'force_roll', difficulty: 4, successes: 3 })
+        ])
+      }
+    });
+    expect(defendedAttack).toMatchObject({
+      successes: 2,
+      damageBreakdown: {
+        finalDamage: 1,
+        log: expect.arrayContaining([
+          expect.objectContaining({ step: 'force_roll', difficulty: 5, successes: 1 })
+        ])
+      }
+    });
+  });
+
+  it('applies x2 zone damage from the structured damage path', () => {
+    const result = resolveNextAction(
+      attackState({
+        attack: { pool: 1, difficulty: 7 },
+        damage: {
+          attackerForce: 0,
+          weaponDamage: {
+            components: [{ type: 'P', includesForce: false, flat: 4 }]
+          },
+          zone: { id: 'tete', damageMultiplier: 2, allowsEndurance: true }
+        }
+      }),
+      { randomInteger: scriptedRolls([7]) }
+    );
+    const target = result.timeline.find((entry) => entry.id === 'defender');
+    const attackEvent = result.log.find((event) => event.type === 'attack_resolved');
+
+    expect(target?.vitality.current).toBe(2);
+    expect(attackEvent).toMatchObject({
+      damageBreakdown: {
+        finalDamage: 8,
+        components: [
+          expect.objectContaining({
+            zoneMultiplier: 2,
+            final: 8
+          })
+        ]
+      }
+    });
+  });
+
+  it('keeps legacy damageOnHit behavior when structured damage is absent', () => {
+    const result = resolveNextAction(
+      attackState({
+        attack: { pool: 2, difficulty: 7 },
+        damageOnHit: 3
+      }),
+      { randomInteger: scriptedRolls([7, 8]) }
+    );
+    const target = result.timeline.find((entry) => entry.id === 'defender');
+    const attackEvent = result.log.find((event) => event.type === 'attack_resolved');
+
+    expect(target?.vitality.current).toBe(7);
+    expect(target?.nextActionAt).toBe(12);
+    expect(attackEvent).not.toHaveProperty('damageBreakdown');
+    expect(result.log.at(-1)).toMatchObject({
+      type: 'damage_applied',
+      targetId: 'defender',
+      damage: 3,
+      finalDamage: 3
+    });
+  });
 });
+
+function attackState(pendingAction: Omit<AttackAction, 'type' | 'targetId'>) {
+  const attacker = combatant({
+    id: 'attacker',
+    speedFactor: 5,
+    pendingAction: {
+      type: 'attack',
+      targetId: 'defender',
+      ...pendingAction
+    }
+  });
+  const defender = combatant({ id: 'defender', speedFactor: 8 });
+
+  return addCombatant(addCombatant(createCombatState(1), defender), attacker);
+}
 
 function combatant(overrides: Partial<ReturnType<typeof baseCombatant>> = {}) {
   return {

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -1,3 +1,11 @@
+import {
+  computeAttackDamage,
+  type CombatDamageResult,
+  type DamageDefenseInput,
+  type DamageModifier,
+  type DamageZoneInput,
+  type WeaponDamageSpec
+} from './combat-damage.js';
 import { type DiceRollResult, type RandomInteger, rollDice } from './dice.js';
 import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
 
@@ -33,11 +41,20 @@ export interface CombatRollRequest {
   difficulty: number;
 }
 
+export interface AttackDamageInput {
+  attackerForce: number;
+  weaponDamage: WeaponDamageSpec;
+  damageModifiers?: DamageModifier[];
+  defense?: DamageDefenseInput;
+  zone?: DamageZoneInput;
+}
+
 export interface AttackAction {
   type: 'attack';
   targetId: string;
   attack: CombatRollRequest;
   defense?: CombatRollRequest;
+  damage?: AttackDamageInput;
   damageOnHit?: number;
   costDT?: number;
 }
@@ -63,6 +80,8 @@ export interface WaitAction {
 }
 
 export type CombatAction = AttackAction | DefenseAction | SpellAction | MoveAction | WaitAction;
+
+export type CombatDamageBreakdown = CombatDamageResult;
 
 export interface Combatant {
   id: string;
@@ -95,6 +114,7 @@ export interface CombatEvent {
   damage?: number;
   preventedDamage?: number;
   finalDamage?: number;
+  damageBreakdown?: CombatDamageBreakdown;
   successes?: number;
   attackRoll?: DiceRollResult;
   defenseRoll?: DiceRollResult;
@@ -357,12 +377,23 @@ function resolveAttack(
   options: CombatResolutionOptions,
   config: RulesConfig
 ): CombatState {
-  const attackRoll = rollDice(action.attack.pool, action.attack.difficulty, options);
+  const randomInteger = randomIntegerForResolution(options);
+  const rollOptions = { randomInteger };
+  const attackRoll = rollDice(action.attack.pool, action.attack.difficulty, rollOptions);
   const defenseRoll = action.defense
-    ? rollDice(action.defense.pool, action.defense.difficulty, options)
+    ? rollDice(action.defense.pool, action.defense.difficulty, rollOptions)
     : undefined;
   const defenseSuccesses = defenseRoll?.successes ?? 0;
   const successes = Math.max(0, attackRoll.successes - defenseSuccesses);
+  const damageBreakdown =
+    action.damage !== undefined && successes > 0
+      ? computeAttackDamage({
+          ...action.damage,
+          netToucheSuccesses: successes,
+          randomInteger,
+          config
+        })
+      : undefined;
   const event: CombatEvent = {
     type: 'attack_resolved',
     atDT: state.currentDT,
@@ -373,12 +404,17 @@ function resolveAttack(
     nextActionAt: timing.nextActionAt,
     successes,
     attackRoll,
-    defenseRoll
+    defenseRoll,
+    ...(damageBreakdown !== undefined ? { damageBreakdown } : {})
   };
   const withAttackLog = {
     ...state,
     log: [...state.log, event]
   };
+
+  if (damageBreakdown !== undefined) {
+    return applyDamage(withAttackLog, action.targetId, damageBreakdown.finalDamage, config);
+  }
 
   if (successes > 0 && action.damageOnHit !== undefined && action.damageOnHit > 0) {
     return applyDamage(withAttackLog, action.targetId, action.damageOnHit, config);
@@ -400,6 +436,14 @@ function rescheduleActor(state: CombatState, actorId: string, action: CombatActi
 
 function actionCostDT(actor: Combatant, action: CombatAction): number {
   return action.costDT ?? actor.speedFactor;
+}
+
+function randomIntegerForResolution(options: CombatResolutionOptions): RandomInteger {
+  return options.randomInteger ?? defaultRandomInteger;
+}
+
+function defaultRandomInteger(sides: number): number {
+  return Math.floor(Math.random() * sides) + 1;
 }
 
 function normalizeCombatant(


### PR DESCRIPTION
## Câblage de la résolution deux phases dans le combat (C2)

Branche le moteur de dégâts (`computeAttackDamage`, C1 / #144) dans `combat.resolveAttack` selon §4bis : les **réussites nettes de touche** (attaque − défense) alimentent le jet de dégâts.

- `AttackAction.damage?` (nouveau) : inputs statiques `{ attackerForce, weaponDamage, damageModifiers?, defense?, zone? }`.
- `resolveAttack` : si `action.damage` présent **et** touche réussie → `computeAttackDamage({ ...damage, netToucheSuccesses, randomInteger, config })`, applique `finalDamage` via `applyDamage` (inchangé).
- `CombatEvent.damageBreakdown?` : composantes typées + log auditable attachés à l'événement.
- **Backward-compat** : sans `action.damage`, le comportement legacy `damageOnHit` est strictement préservé.
- RNG partagé (attaque / défense / dégâts) via `options.randomInteger`.
- 141 tests (F+N, défense réduisant les nets, zone ×2, fallback legacy) + `format:check` + `canonical:check` verts.

Ref : `moteurs-rules-core.md` §4bis, `09-combat.md` R-9.9/9.10/9.12. Roadmap C2.

> Jalon : le moteur de combat est désormais complet de bout en bout — timeline + touche (Dextérité) + dégâts (Force par formule) + chaîne de défense R-9.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
