### PR TITLE
feat(rules-core): slots de prédilection + résolution tool (E2 #140)

### DIFF
--- a/packages/rules-core/src/character.ts
+++ b/packages/rules-core/src/character.ts
@@ -1,6 +1,7 @@
 import { type Combatant } from './combat.js';
 import { effectiveAttribute, type EffectApplicationContext } from './effects.js';
 import { type EffectModel } from './effect-model.js';
+import { copyPredilectionSlots, type PredilectionSlots } from './predilection.js';
 import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
 
 export const ATTRIBUTE_KEYS = [
@@ -109,6 +110,7 @@ export interface CharacterBase {
   spells: CharacterSpell[];
   equipment: CharacterEquipmentItem[];
   modifiers: CharacterModifier[];
+  predilection?: PredilectionSlots;
   progression: CharacterProgression;
   metadata: Record<string, unknown>;
 }
@@ -137,6 +139,7 @@ export interface CreatePlayerCharacterInput {
   spells?: CharacterSpell[];
   equipment?: CharacterEquipmentItem[];
   modifiers?: CharacterModifier[];
+  predilection?: PredilectionSlots;
   progression?: CharacterProgression;
   metadata?: Record<string, unknown>;
 }
@@ -157,6 +160,7 @@ export interface CreateNonPlayerCharacterInput {
   spells?: CharacterSpell[];
   equipment?: CharacterEquipmentItem[];
   modifiers?: CharacterModifier[];
+  predilection?: PredilectionSlots;
   progression?: CharacterProgression;
   metadata?: Record<string, unknown>;
 }
@@ -335,6 +339,9 @@ export function createPlayerCharacter(
     spells: spells.map(copySpell),
     equipment: (input.equipment ?? []).map((item) => ({ ...item })),
     modifiers: (input.modifiers ?? []).map((modifier) => ({ ...modifier })),
+    ...(input.predilection === undefined
+      ? {}
+      : { predilection: copyPredilectionSlots(input.predilection) }),
     progression: copyProgression(input.progression),
     metadata: { ...(input.metadata ?? {}) }
   };
@@ -372,6 +379,9 @@ export function createNonPlayerCharacter(
     spells: (input.spells ?? []).map(copySpell),
     equipment: (input.equipment ?? []).map((item) => ({ ...item })),
     modifiers: (input.modifiers ?? []).map((modifier) => ({ ...modifier })),
+    ...(input.predilection === undefined
+      ? {}
+      : { predilection: copyPredilectionSlots(input.predilection) }),
     progression: copyProgression(input.progression),
     metadata: { ...(input.metadata ?? {}) }
   };

--- a/packages/rules-core/src/effect-model.test.ts
+++ b/packages/rules-core/src/effect-model.test.ts
@@ -86,7 +86,7 @@ describe('EffectModel parsing', () => {
       ['aptitude', ['perception', 'willpower'], 'force'],
       ['target_disposition', 'ally', 'enemy'],
       ['target_ref', 'employeur', 'inconnu'],
-      ['tool', 'arme_predilection', 'instrument_predilection'],
+      ['tool', 'luth', 'flute'],
       ['intent', 'sauvegarder', 'nuire'],
       ['directness', 'direct_only', 'indirect']
     ] as const satisfies readonly (readonly [string, EffectConditionValue, EffectConditionValue])[];

--- a/packages/rules-core/src/effect-model.ts
+++ b/packages/rules-core/src/effect-model.ts
@@ -1,3 +1,5 @@
+import { predilectionKindForSlotName, type PredilectionSlots } from './predilection.js';
+
 export const EFFECT_TARGETS = [
   'aptitude',
   'factor',
@@ -82,7 +84,10 @@ export type EffectCondition = {
   any_of?: EffectCondition[];
 } & Partial<Record<EffectConditionKey, EffectConditionValue>>;
 
-export type EffectConditionContext = Partial<Record<EffectConditionKey, EffectConditionValue>>;
+export type EffectConditionContext = Partial<Record<EffectConditionKey, EffectConditionValue>> & {
+  engagedTool?: string;
+  predilection?: PredilectionSlots;
+};
 
 export type EffectValueContext = Partial<Record<EffectValueVariable, number>> & {
   tables?: Record<string, Record<string, number>>;
@@ -324,7 +329,19 @@ function validateConditionValue(value: unknown, key: string): void {
 function evaluateCondition(condition: EffectCondition, context: EffectConditionContext): boolean {
   for (const key of EFFECT_CONDITION_KEYS) {
     const expected = condition[key];
-    if (expected !== undefined && !matchesConditionValue(expected, context[key])) {
+
+    if (expected === undefined) {
+      continue;
+    }
+
+    if (key === 'tool') {
+      if (!matchesToolCondition(expected, context)) {
+        return false;
+      }
+      continue;
+    }
+
+    if (!matchesConditionValue(expected, context[key])) {
       return false;
     }
   }
@@ -344,6 +361,32 @@ function evaluateCondition(condition: EffectCondition, context: EffectConditionC
   }
 
   return true;
+}
+
+function matchesToolCondition(
+  expected: EffectConditionValue,
+  context: EffectConditionContext
+): boolean {
+  const expectedValues = Array.isArray(expected) ? expected : [expected];
+
+  return expectedValues.some((expectedValue) => matchesToolValue(expectedValue, context));
+}
+
+function matchesToolValue(expectedValue: string, context: EffectConditionContext): boolean {
+  const predilectionKind = predilectionKindForSlotName(expectedValue);
+
+  if (predilectionKind !== undefined) {
+    return (
+      context.engagedTool !== undefined &&
+      (context.predilection?.[predilectionKind]?.includes(context.engagedTool) ?? false)
+    );
+  }
+
+  if (context.engagedTool !== undefined) {
+    return context.engagedTool === expectedValue;
+  }
+
+  return matchesConditionValue(expectedValue, context.tool);
 }
 
 function matchesConditionValue(

--- a/packages/rules-core/src/effect-renderer.ts
+++ b/packages/rules-core/src/effect-renderer.ts
@@ -112,6 +112,7 @@ const TOOL_LABELS: Record<string, string> = {
   arme_predilection: 'arme de prédilection',
   instrument_predilection: 'instrument de prédilection',
   animaux_predilection: 'animaux de prédilection',
+  monture_predilection: 'monture de prédilection',
   moyen_locomotion_predilection: 'moyen de locomotion de prédilection',
   domaine_predilection: 'domaine de prédilection'
 };

--- a/packages/rules-core/src/effects.test.ts
+++ b/packages/rules-core/src/effects.test.ts
@@ -107,6 +107,63 @@ describe('effect modifier engine', () => {
       applications: [{ op: 'grant', sourceRef: 'fixture:effect' }]
     });
   });
+
+  it('matches predilection slot tool conditions against the engaged tool', () => {
+    const effects = [
+      effect({
+        target: 'pool',
+        scope: 'attaque',
+        op: 'add',
+        value: 1,
+        condition: { tool: 'arme_predilection' }
+      })
+    ];
+
+    const modifiers = computeEffectiveModifiers(effects, {
+      engagedTool: 'epee_longue',
+      predilection: { arme: ['epee_longue'] }
+    });
+
+    expect(modifiers.pool.attaque.add).toBe(1);
+  });
+
+  it('does not match predilection slot tool conditions outside the slot set', () => {
+    const effects = [
+      effect({
+        target: 'pool',
+        scope: 'attaque',
+        op: 'add',
+        value: 1,
+        condition: { tool: 'arme_predilection' }
+      })
+    ];
+
+    const modifiers = computeEffectiveModifiers(effects, {
+      engagedTool: 'arc_court',
+      predilection: { arme: ['epee_longue'] }
+    });
+
+    expect(modifiers.pool).toEqual({});
+  });
+
+  it('matches concrete tool conditions by engaged tool equality', () => {
+    const effects = [
+      effect({
+        target: 'pool',
+        scope: 'musique',
+        op: 'add',
+        value: 1,
+        condition: { tool: 'luth' }
+      })
+    ];
+
+    const modifiers = computeEffectiveModifiers(effects, {
+      engagedTool: 'luth',
+      predilection: { instrument: ['flute'] }
+    });
+
+    expect(modifiers.pool.musique.add).toBe(1);
+  });
 });
 
 function effect(

--- a/packages/rules-core/src/effects.ts
+++ b/packages/rules-core/src/effects.ts
@@ -11,6 +11,7 @@ import {
   type EffectTarget,
   type EffectValueContext
 } from './effect-model.js';
+import { type PredilectionSlots } from './predilection.js';
 
 export const GLOBAL_EFFECT_SCOPE = '__global__';
 
@@ -29,8 +30,10 @@ const COMPUTED_NUMERIC_EFFECT_TARGETS = [
 export type EffectApplicationContext = EffectConditionContext &
   EffectValueContext & {
     activations?: readonly EffectActivation[];
+    engagedTool?: string;
     elapsedDT?: number;
     includeEphemeral?: boolean;
+    predilection?: PredilectionSlots;
   };
 
 export interface EffectModifierApplication {

--- a/packages/rules-core/src/index.ts
+++ b/packages/rules-core/src/index.ts
@@ -7,6 +7,7 @@ export * from './effect-model.js';
 export * from './effect-renderer.js';
 export * from './effects.js';
 export * from './npc-control.js';
+export * from './predilection.js';
 export * from './progression.js';
 export * from './rules-config.js';
 export * from './session.js';

--- a/packages/rules-core/src/predilection.test.ts
+++ b/packages/rules-core/src/predilection.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { changePredilection, extendPredilection, initPredilectionSlot } from './predilection.js';
+
+describe('predilection slots', () => {
+  it('initializes a one-value slot', () => {
+    expect(initPredilectionSlot('arme', 'epee_longue')).toEqual({
+      arme: ['epee_longue']
+    });
+  });
+
+  it('replaces a slot and returns a transition for journaling', () => {
+    const result = changePredilection(
+      { arme: ['epee_longue'], instrument: ['luth'] },
+      'arme',
+      'arc_court',
+      'level_up'
+    );
+
+    expect(result).toEqual({
+      slots: { arme: ['arc_court'], instrument: ['luth'] },
+      transition: {
+        action: 'change',
+        kind: 'arme',
+        previous: ['epee_longue'],
+        next: ['arc_court'],
+        value: 'arc_court',
+        trigger: 'level_up'
+      }
+    });
+  });
+
+  it('rejects changes with an unsupported trigger', () => {
+    expect(() =>
+      changePredilection({ arme: ['epee_longue'] }, 'arme', 'arc_court', 'downtime' as never)
+    ).toThrow(/Predilection change trigger must be level_up or gm_validation/);
+  });
+
+  it('extends a slot only when allowed', () => {
+    const result = extendPredilection({ instrument: ['luth'] }, 'instrument', 'flute', {
+      allowed: true
+    });
+
+    expect(result).toEqual({
+      slots: { instrument: ['luth', 'flute'] },
+      transition: {
+        action: 'extend',
+        kind: 'instrument',
+        previous: ['luth'],
+        next: ['luth', 'flute'],
+        value: 'flute'
+      }
+    });
+  });
+
+  it('rejects extensions unless explicitly allowed', () => {
+    expect(() =>
+      extendPredilection({ domaine: ['service'] }, 'domaine', 'ouvrage', {
+        allowed: false
+      })
+    ).toThrow(/Predilection extension must be allowed/);
+  });
+});

--- a/packages/rules-core/src/predilection.ts
+++ b/packages/rules-core/src/predilection.ts
@@ -1,0 +1,200 @@
+export const PREDILECTION_KINDS = ['arme', 'instrument', 'monture', 'animaux', 'domaine'] as const;
+
+export type PredilectionKind = (typeof PREDILECTION_KINDS)[number];
+
+export type PredilectionSlots = {
+  arme?: string[];
+  instrument?: string[];
+  monture?: string[];
+  animaux?: string[];
+  domaine?: string[];
+};
+
+export const ARME_PREDILECTION_SLOT = 'arme_predilection';
+export const INSTRUMENT_PREDILECTION_SLOT = 'instrument_predilection';
+export const MONTURE_PREDILECTION_SLOT = 'monture_predilection';
+export const ANIMAUX_PREDILECTION_SLOT = 'animaux_predilection';
+export const DOMAINE_PREDILECTION_SLOT = 'domaine_predilection';
+
+export const PREDILECTION_SLOT_NAMES = [
+  ARME_PREDILECTION_SLOT,
+  INSTRUMENT_PREDILECTION_SLOT,
+  MONTURE_PREDILECTION_SLOT,
+  ANIMAUX_PREDILECTION_SLOT,
+  DOMAINE_PREDILECTION_SLOT
+] as const;
+
+export type PredilectionSlotName = (typeof PREDILECTION_SLOT_NAMES)[number];
+
+export const PREDILECTION_SLOT_BY_KIND = {
+  arme: ARME_PREDILECTION_SLOT,
+  instrument: INSTRUMENT_PREDILECTION_SLOT,
+  monture: MONTURE_PREDILECTION_SLOT,
+  animaux: ANIMAUX_PREDILECTION_SLOT,
+  domaine: DOMAINE_PREDILECTION_SLOT
+} as const satisfies Record<PredilectionKind, PredilectionSlotName>;
+
+export const PREDILECTION_KIND_BY_SLOT = {
+  [ARME_PREDILECTION_SLOT]: 'arme',
+  [INSTRUMENT_PREDILECTION_SLOT]: 'instrument',
+  [MONTURE_PREDILECTION_SLOT]: 'monture',
+  [ANIMAUX_PREDILECTION_SLOT]: 'animaux',
+  [DOMAINE_PREDILECTION_SLOT]: 'domaine'
+} as const satisfies Record<PredilectionSlotName, PredilectionKind>;
+
+export const PREDILECTION_CHANGE_TRIGGERS = ['level_up', 'gm_validation'] as const;
+
+export type PredilectionChangeTrigger = (typeof PREDILECTION_CHANGE_TRIGGERS)[number];
+
+export type PredilectionTransitionAction = 'change' | 'extend';
+
+export interface PredilectionTransition {
+  action: PredilectionTransitionAction;
+  kind: PredilectionKind;
+  previous: string[];
+  next: string[];
+  value: string;
+  trigger?: PredilectionChangeTrigger;
+}
+
+export interface PredilectionUpdate {
+  slots: PredilectionSlots;
+  transition: PredilectionTransition;
+}
+
+export interface ExtendPredilectionOptions {
+  allowed: boolean;
+}
+
+export function initPredilectionSlot(kind: PredilectionKind, value: string): PredilectionSlots {
+  assertPredilectionKind(kind);
+  assertPredilectionValue(value);
+
+  return { [kind]: [value] };
+}
+
+export function changePredilection(
+  slots: PredilectionSlots,
+  kind: PredilectionKind,
+  newValue: string,
+  trigger: PredilectionChangeTrigger
+): PredilectionUpdate {
+  assertPredilectionKind(kind);
+  assertPredilectionValue(newValue);
+  assertPredilectionChangeTrigger(trigger);
+
+  const previous = copySlotValues(slots[kind]);
+  const next = [newValue];
+
+  return {
+    slots: {
+      ...copyPredilectionSlots(slots),
+      [kind]: next
+    },
+    transition: {
+      action: 'change',
+      kind,
+      previous,
+      next,
+      value: newValue,
+      trigger
+    }
+  };
+}
+
+export function extendPredilection(
+  slots: PredilectionSlots,
+  kind: PredilectionKind,
+  value: string,
+  options: ExtendPredilectionOptions
+): PredilectionUpdate {
+  assertPredilectionKind(kind);
+  assertPredilectionValue(value);
+
+  if (options.allowed !== true) {
+    throw new Error('Predilection extension must be allowed');
+  }
+
+  const previous = copySlotValues(slots[kind]);
+  const next = previous.includes(value) ? previous : [...previous, value];
+
+  return {
+    slots: {
+      ...copyPredilectionSlots(slots),
+      [kind]: next
+    },
+    transition: {
+      action: 'extend',
+      kind,
+      previous,
+      next,
+      value
+    }
+  };
+}
+
+export function copyPredilectionSlots(slots: PredilectionSlots): PredilectionSlots;
+export function copyPredilectionSlots(slots: undefined): undefined;
+export function copyPredilectionSlots(
+  slots: PredilectionSlots | undefined
+): PredilectionSlots | undefined {
+  if (slots === undefined) {
+    return undefined;
+  }
+
+  const copy: PredilectionSlots = {};
+
+  for (const kind of PREDILECTION_KINDS) {
+    const values = slots[kind];
+    if (values !== undefined) {
+      copy[kind] = copySlotValues(values);
+    }
+  }
+
+  return copy;
+}
+
+export function predilectionKindForSlotName(value: string): PredilectionKind | undefined {
+  return isPredilectionSlotName(value) ? PREDILECTION_KIND_BY_SLOT[value] : undefined;
+}
+
+export function isPredilectionSlotName(value: string): value is PredilectionSlotName {
+  return (PREDILECTION_SLOT_NAMES as readonly string[]).includes(value);
+}
+
+function assertPredilectionKind(kind: PredilectionKind): void {
+  if (!(PREDILECTION_KINDS as readonly string[]).includes(kind)) {
+    throw new Error(`Unknown predilection kind "${String(kind)}"`);
+  }
+}
+
+function assertPredilectionValue(value: string): void {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error('Predilection value must be a non-empty string');
+  }
+}
+
+function assertPredilectionChangeTrigger(
+  trigger: PredilectionChangeTrigger
+): asserts trigger is PredilectionChangeTrigger {
+  if (!(PREDILECTION_CHANGE_TRIGGERS as readonly string[]).includes(trigger)) {
+    throw new Error('Predilection change trigger must be level_up or gm_validation');
+  }
+}
+
+function copySlotValues(values: readonly string[] | undefined): string[] {
+  if (values === undefined) {
+    return [];
+  }
+
+  const copy: string[] = [];
+
+  for (const value of values) {
+    assertPredilectionValue(value);
+    if (!copy.includes(value)) {
+      copy.push(value);
+    }
+  }
+
+  return copy;
+}


### PR DESCRIPTION
## Mécanique de slots de prédilection (E2 / #140)

Permet au moteur d'effets de résoudre les conditions `tool: <slot>` (`arme_predilection`, etc.) contre les slots de prédilection du personnage. Débloque l'application des atouts de prédilection encodés en E4 (coup-décisif, précision, défense, son-envoûtant…).

- **`predilection.ts`** : type `PredilectionSlots` `{ arme, instrument, monture, animaux, domaine }`, constantes de noms de slots, helpers **purs** `init` / `change` / `extend` + records de transition (changement `{ level_up | gm_validation }`, extension 1→N gated).
- Contexte d'application étendu : `engagedTool` + `predilection`.
- Résolution `tool` : nom de slot → membre du set du perso ; outil concret → égalité ; sinon **fallback legacy** (backward-compat total).
- `character.ts` : stockage optionnel des slots.
- 149 tests (slot match, égalité outil concret, trigger invalide, extension gated) + `format:check` + `canonical:check` verts.

Ref : `moteurs-rules-core.md` §4ter, #140. Roadmap E2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
