### PR TITLE
feat(rules-core): statuts composites (E3 #141)

### DIFF
--- a/packages/rules-core/src/effects.ts
+++ b/packages/rules-core/src/effects.ts
@@ -12,6 +12,11 @@ import {
   type EffectValueContext
 } from './effect-model.js';
 import { type PredilectionSlots } from './predilection.js';
+import {
+  expandActiveStatuses,
+  type ActiveStatusEntry,
+  type CompositeStatusRegistry
+} from './status-effects.js';
 
 export const GLOBAL_EFFECT_SCOPE = '__global__';
 
@@ -34,6 +39,8 @@ export type EffectApplicationContext = EffectConditionContext &
     elapsedDT?: number;
     includeEphemeral?: boolean;
     predilection?: PredilectionSlots;
+    activeStatuses?: readonly ActiveStatusEntry[];
+    statusRegistry?: CompositeStatusRegistry;
   };
 
 export interface EffectModifierApplication {
@@ -85,8 +92,10 @@ export function computeEffectiveModifiers(
   ctx: EffectApplicationContext
 ): EffectiveModifiers {
   const modifiers = createEmptyModifiers();
+  const statusEffects = expandActiveStatuses(ctx.activeStatuses, ctx.statusRegistry, ctx);
+  const effects = statusEffects.length === 0 ? activeEffects : [...activeEffects, ...statusEffects];
 
-  for (const activeEffect of activeEffects) {
+  for (const activeEffect of effects) {
     const effect = parseEffectModel(activeEffect);
 
     if (!isEffectActive(effect.spec, ctx)) {

--- a/packages/rules-core/src/index.ts
+++ b/packages/rules-core/src/index.ts
@@ -11,3 +11,4 @@ export * from './predilection.js';
 export * from './progression.js';
 export * from './rules-config.js';
 export * from './session.js';
+export * from './status-effects.js';

--- a/packages/rules-core/src/status-effects.test.ts
+++ b/packages/rules-core/src/status-effects.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeEffectiveModifiers, effectiveAttribute } from './effects.js';
+import {
+  canActivate,
+  COMPOSITE_STATUS_REGISTRY,
+  defineCompositeStatusRegistry,
+  expandActiveStatuses,
+  isStatusActive
+} from './status-effects.js';
+
+describe('composite status effects', () => {
+  it('expands folie-furieuse while active into pool and aptitude bundle effects', () => {
+    const ctx = { activeStatuses: ['fou_furieux'], elapsedDT: 74, level: 3 };
+
+    const expanded = expandActiveStatuses(ctx.activeStatuses, COMPOSITE_STATUS_REGISTRY, ctx);
+
+    expect(expanded).toHaveLength(4);
+    expect(expanded.map((effect) => effect.spec)).toEqual([
+      {
+        target: 'pool',
+        op: 'add',
+        value: 'level',
+        condition: { aptitude: ['force', 'endurance'] },
+        activation: 'passive',
+        duration: 'permanent'
+      },
+      {
+        target: 'aptitude',
+        scope: 'empathie',
+        op: 'set',
+        value: 1,
+        activation: 'passive',
+        duration: 'permanent'
+      },
+      {
+        target: 'aptitude',
+        scope: 'intelligence',
+        op: 'set',
+        value: 1,
+        activation: 'passive',
+        duration: 'permanent'
+      },
+      {
+        target: 'aptitude',
+        scope: 'perception',
+        op: 'set',
+        value: 1,
+        activation: 'passive',
+        duration: 'permanent'
+      }
+    ]);
+  });
+
+  it('folds active status effects into computed modifiers without changing callers that omit statuses', () => {
+    const forceModifiers = computeEffectiveModifiers([], {
+      activeStatuses: ['fou_furieux'],
+      aptitude: 'force',
+      elapsedDT: 74,
+      level: 3
+    });
+    const perceptionModifiers = computeEffectiveModifiers([], {
+      activeStatuses: ['fou_furieux'],
+      aptitude: 'perception',
+      elapsedDT: 74,
+      level: 3
+    });
+    const inactiveModifiers = computeEffectiveModifiers([], {
+      aptitude: 'force',
+      elapsedDT: 74,
+      level: 3
+    });
+
+    expect(forceModifiers.pool.__global__.add).toBe(3);
+    expect(forceModifiers.aptitude.empathie.set).toBe(1);
+    expect(forceModifiers.aptitude.intelligence.set).toBe(1);
+    expect(forceModifiers.aptitude.perception.set).toBe(1);
+    expect(perceptionModifiers.pool).toEqual({});
+    expect(inactiveModifiers.pool).toEqual({});
+    expect(inactiveModifiers.aptitude).toEqual({});
+  });
+
+  it('resolves folie-furieuse aptitude set operations to one', () => {
+    const ctx = { activeStatuses: ['fou_furieux'], elapsedDT: 12, level: 2 };
+
+    expect(effectiveAttribute(5, 'empathie', [], ctx)).toBe(1);
+    expect(effectiveAttribute(4, 'intelligence', [], ctx)).toBe(1);
+    expect(effectiveAttribute(3, 'perception', [], ctx)).toBe(1);
+  });
+
+  it('expires folie-furieuse after its locked 25 DT per level duration', () => {
+    const statusEntry = {
+      id: 'fou_furieux',
+      duration: COMPOSITE_STATUS_REGISTRY.fou_furieux.duration
+    };
+
+    expect(isStatusActive(statusEntry, 74, { level: 3 })).toBe(true);
+    expect(isStatusActive(statusEntry, 75, { level: 3 })).toBe(false);
+    expect(
+      expandActiveStatuses(
+        [{ id: 'fou_furieux', duration: { dt: 1 } }],
+        COMPOSITE_STATUS_REGISTRY,
+        { elapsedDT: 2, level: 3 }
+      )
+    ).toHaveLength(4);
+  });
+
+  it('guards activation sources per status registry entry', () => {
+    const registry = defineCompositeStatusRegistry({
+      gm_only: {
+        activationSources: ['mj_imposed'],
+        effects: [
+          {
+            target: 'pool',
+            op: 'add',
+            value: 1,
+            activation: 'passive',
+            duration: 'permanent'
+          }
+        ]
+      }
+    });
+
+    expect(canActivate('mj_imposed', 'gm_only', registry)).toBe(true);
+    expect(canActivate('player_toggle', 'gm_only', registry)).toBe(false);
+    expect(canActivate('player_toggle', 'missing_status', registry)).toBe(false);
+  });
+});

--- a/packages/rules-core/src/status-effects.ts
+++ b/packages/rules-core/src/status-effects.ts
@@ -1,0 +1,259 @@
+import {
+  evaluateValue,
+  parseEffectModel,
+  type EffectDuration,
+  type EffectModel,
+  type EffectSpec,
+  type EffectValueContext
+} from './effect-model.js';
+
+export const ACTIVATION_SOURCES = ['player_toggle', 'mj_validated', 'mj_imposed'] as const;
+
+export type ActivationSource = (typeof ACTIVATION_SOURCES)[number];
+
+export interface CompositeStatusDefinition {
+  effects: readonly EffectSpec[];
+  activationSources: readonly ActivationSource[];
+  duration?: EffectDuration;
+}
+
+export type CompositeStatusRegistry = Readonly<Record<string, CompositeStatusDefinition>>;
+
+interface ActiveStatusBase {
+  duration?: EffectDuration;
+  elapsedDT?: number;
+}
+
+export type ActiveStatusEntry =
+  | string
+  | (ActiveStatusBase & { id: string; statusId?: never })
+  | (ActiveStatusBase & { id?: never; statusId: string });
+
+export type StatusExpansionContext = EffectValueContext & {
+  elapsedDT?: number;
+};
+
+export const COMPOSITE_STATUS_REGISTRY = defineCompositeStatusRegistry({
+  fou_furieux: {
+    activationSources: ['player_toggle', 'mj_validated', 'mj_imposed'],
+    duration: { dt: '25*level', locked: true },
+    effects: [
+      {
+        target: 'pool',
+        op: 'add',
+        value: 'level',
+        condition: { aptitude: ['force', 'endurance'] },
+        activation: 'passive',
+        duration: 'permanent'
+      },
+      {
+        target: 'aptitude',
+        scope: 'empathie',
+        op: 'set',
+        value: 1,
+        activation: 'passive',
+        duration: 'permanent'
+      },
+      {
+        target: 'aptitude',
+        scope: 'intelligence',
+        op: 'set',
+        value: 1,
+        activation: 'passive',
+        duration: 'permanent'
+      },
+      {
+        target: 'aptitude',
+        scope: 'perception',
+        op: 'set',
+        value: 1,
+        activation: 'passive',
+        duration: 'permanent'
+      }
+    ]
+  }
+} satisfies CompositeStatusRegistry);
+
+export function defineCompositeStatusRegistry<T extends CompositeStatusRegistry>(registry: T): T {
+  for (const [statusId, definition] of Object.entries(registry)) {
+    validateCompositeStatusDefinition(statusId, definition);
+  }
+
+  return registry;
+}
+
+export function expandActiveStatuses(
+  activeStatuses: readonly ActiveStatusEntry[] | undefined,
+  registry: CompositeStatusRegistry = COMPOSITE_STATUS_REGISTRY,
+  ctx: StatusExpansionContext = {}
+): EffectModel[] {
+  if (activeStatuses === undefined || activeStatuses.length === 0) {
+    return [];
+  }
+
+  const expanded: EffectModel[] = [];
+
+  for (const activeStatus of activeStatuses) {
+    const statusId = statusIdFor(activeStatus);
+    const definition = registry[statusId];
+
+    if (definition === undefined) {
+      continue;
+    }
+
+    const statusEntry = statusEntryForExpansion(statusId, activeStatus, definition);
+    const elapsedDT = elapsedDTFor(activeStatus, ctx);
+
+    if (!isStatusActive(statusEntry, elapsedDT, ctx)) {
+      continue;
+    }
+
+    for (const [index, spec] of definition.effects.entries()) {
+      expanded.push(effectModelForStatus(statusId, index, spec));
+    }
+  }
+
+  return expanded;
+}
+
+export function canActivate(
+  source: ActivationSource,
+  statusId: string,
+  registry: CompositeStatusRegistry = COMPOSITE_STATUS_REGISTRY
+): boolean {
+  return registry[statusId]?.activationSources.includes(source) ?? false;
+}
+
+export function isStatusActive(
+  statusEntry: ActiveStatusEntry,
+  elapsedDT?: number,
+  ctx: EffectValueContext = {}
+): boolean {
+  if (typeof statusEntry === 'string') {
+    return true;
+  }
+
+  const duration = statusEntry.duration;
+
+  if (duration === undefined || duration === 'permanent' || duration === 'until_dispel') {
+    return true;
+  }
+
+  if (duration === 'ephemeral') {
+    return true;
+  }
+
+  if (elapsedDT === undefined) {
+    return true;
+  }
+
+  if (!Number.isFinite(elapsedDT) || elapsedDT < 0) {
+    throw new Error('Status elapsedDT must be a non-negative finite number');
+  }
+
+  const dt = typeof duration.dt === 'number' ? duration.dt : evaluateValue(duration.dt, ctx);
+
+  return elapsedDT < dt;
+}
+
+function validateCompositeStatusDefinition(
+  statusId: string,
+  definition: CompositeStatusDefinition
+): void {
+  if (definition.activationSources.length === 0) {
+    throw new Error(`Composite status "${statusId}" must declare at least one activation source`);
+  }
+
+  for (const source of definition.activationSources) {
+    if (!isActivationSource(source)) {
+      throw new Error(`Composite status "${statusId}" has unknown activation source "${source}"`);
+    }
+  }
+
+  if (definition.duration !== undefined) {
+    validateStatusDuration(statusId, definition.duration);
+  }
+
+  if (definition.effects.length === 0) {
+    throw new Error(`Composite status "${statusId}" must declare at least one bundled effect`);
+  }
+
+  for (const [index, spec] of definition.effects.entries()) {
+    effectModelForStatus(statusId, index, spec);
+  }
+}
+
+function validateStatusDuration(statusId: string, duration: EffectDuration): void {
+  parseEffectModel({
+    source: {
+      prose: `Composite status ${statusId} duration.`,
+      ref: `status:${statusId}#duration`
+    },
+    spec: {
+      target: 'status',
+      scope: statusId,
+      op: 'grant',
+      value: 1,
+      activation: 'passive',
+      duration
+    },
+    fidelity: 'covered'
+  });
+}
+
+function effectModelForStatus(statusId: string, index: number, spec: EffectSpec): EffectModel {
+  return parseEffectModel({
+    source: {
+      prose: `Composite status ${statusId} bundled effect ${index + 1}.`,
+      ref: `status:${statusId}#effect:${index + 1}`
+    },
+    spec: cloneEffectSpec(spec),
+    fidelity: 'covered'
+  });
+}
+
+function statusEntryForExpansion(
+  statusId: string,
+  activeStatus: ActiveStatusEntry,
+  definition: CompositeStatusDefinition
+): ActiveStatusEntry {
+  const activeDuration = typeof activeStatus === 'string' ? undefined : activeStatus.duration;
+  const definitionDuration = definition.duration;
+  const duration = isLockedDuration(definitionDuration)
+    ? definitionDuration
+    : (activeDuration ?? definitionDuration);
+
+  return duration === undefined ? { id: statusId } : { id: statusId, duration };
+}
+
+function elapsedDTFor(
+  activeStatus: ActiveStatusEntry,
+  ctx: StatusExpansionContext
+): number | undefined {
+  return typeof activeStatus === 'string'
+    ? ctx.elapsedDT
+    : (activeStatus.elapsedDT ?? ctx.elapsedDT);
+}
+
+function statusIdFor(activeStatus: ActiveStatusEntry): string {
+  const statusId =
+    typeof activeStatus === 'string' ? activeStatus : (activeStatus.id ?? activeStatus.statusId);
+
+  if (statusId.length === 0) {
+    throw new Error('Active status id must not be empty');
+  }
+
+  return statusId;
+}
+
+function isLockedDuration(duration: EffectDuration | undefined): boolean {
+  return typeof duration === 'object' && duration.locked === true;
+}
+
+function isActivationSource(source: string): source is ActivationSource {
+  return (ACTIVATION_SOURCES as readonly string[]).includes(source);
+}
+
+function cloneEffectSpec(spec: EffectSpec): EffectSpec {
+  return JSON.parse(JSON.stringify(spec)) as EffectSpec;
+}


### PR DESCRIPTION
## Statuts composites (E3 / #141)

Un effet qui accorde un `status` (op: grant, target: status) porte un **bundle** d'effets appliqués tant que le statut est actif. Active `folie-furieuse` (était `pending` en E4) + base des futurs buffs / potions.

- **`status-effects.ts`** : `CompositeStatusRegistry` typé ; entrée `fou_furieux` conforme §4ter (`pool +level` si force/endurance ; `aptitude set 1` sur empathie/intelligence/perception ; durée `{ dt: "25*level", locked: true }`) ; `expandActiveStatuses`, `canActivate`, `isStatusActive` ; validation de chaque spec via `parseEffectModel`.
- Sources d'activation : `player_toggle | mj_validated | mj_imposed`.
- **Intégration** : `computeEffectiveModifiers` plie les bundles des statuts actifs (`ctx.activeStatuses` + `statusRegistry`) ; **backward-compat total** (sans statuts → comportement inchangé).
- 154 tests + `format:check` + `canonical:check` verts.

Ref : `moteurs-rules-core.md` §4ter, #141. Roadmap E3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
