### PR TITLE
ci: enforce Strict Canonical Gate on dev (P0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,8 @@ jobs:
     needs: validate
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      github.ref_name == 'dev' ||
+      github.base_ref == 'dev' ||
       github.ref_name == 'staging' ||
       github.ref_name == 'main' ||
       github.base_ref == 'staging' ||


### PR DESCRIPTION
## P0 — durcir le Strict Canonical Gate sur `dev`

Le job `strict-canonical` ne se déclenchait que sur `workflow_dispatch` + `staging`/`main` (design GitFlow ; « skipping » sur dev). Or `pnpm canonical:check:strict` **passe** déjà sur dev (artefacts canoniques à jour, plus de `sample.ts`).

On ajoute `dev` au `if:` du job → **conformité canonique verrouillée dès l'intégration** : toute régression non-canonique sur une PR/push `dev` échouera désormais (au lieu d'attendre staging/main).

- `+ github.ref_name == 'dev'` et `+ github.base_ref == 'dev'`.
- Sûr : strict est vert sur dev. Cette PR (base = dev) **auto-valide** le nouveau gate.

Roadmap **P0** / #35. (Réf : la cible P0 « gate strict vert » est atteinte ; ceci la verrouille aussi à l'intégration.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
