### PR TITLE
feat(server,game): API typée tRPC — résolution autoritaire + persistance perso (E-B)

### DIFF
--- a/apps/game/package.json
+++ b/apps/game/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@knightandwizard/rules-core": "workspace:*",
     "@knightandwizard/ui": "workspace:*",
+    "@trpc/client": "^11.17.0",
     "lucide-react": "^1.14.0",
     "next": "15.5.15",
     "react": "^19.2.5",

--- a/apps/game/src/features/combat-tracker/CombatTracker.tsx
+++ b/apps/game/src/features/combat-tracker/CombatTracker.tsx
@@ -35,6 +35,7 @@ import {
   type ProgressTone,
   type ToastTone
 } from '@knightandwizard/ui';
+import { trpc } from '@/lib/trpc';
 
 import {
   addTrackerCombatant,
@@ -42,7 +43,6 @@ import {
   buildCombatTrackerView,
   queueTrackerAction,
   removeTrackerCombatant,
-  resolveTrackerNextAction,
   type CombatantTemplate,
   type CombatLogRow,
   type CombatRosterRow,
@@ -73,6 +73,8 @@ interface CombatTrackerProps {
 
 export function CombatTracker({ combatantTemplates, initialState }: Readonly<CombatTrackerProps>) {
   const [state, setState] = useState<CombatState>(() => initialState);
+  const [isResolving, setIsResolving] = useState(false);
+  const [resolveError, setResolveError] = useState<string | null>(null);
   const view = useMemo(() => buildCombatTrackerView(state), [state]);
   const activeCombatant = view.nextActor
     ? state.timeline.find((combatant) => combatant.id === view.nextActor?.id)
@@ -112,7 +114,24 @@ export function CombatTracker({ combatantTemplates, initialState }: Readonly<Com
   }
 
   function resolveNext() {
-    setState((current) => resolveTrackerNextAction(current));
+    if (isResolving) {
+      return;
+    }
+
+    setIsResolving(true);
+    setResolveError(null);
+
+    void trpc.combat.resolveAction
+      .mutate({ state })
+      .then((result) => {
+        setState(result.state);
+      })
+      .catch((error: unknown) => {
+        setResolveError(error instanceof Error ? error.message : 'Résolution impossible');
+      })
+      .finally(() => {
+        setIsResolving(false);
+      });
   }
 
   function damageTarget(damage: number) {
@@ -187,7 +206,9 @@ export function CombatTracker({ combatantTemplates, initialState }: Readonly<Com
           <ActionPanel
             activeCombatant={activeCombatant}
             effectiveTargetId={effectiveTargetId}
+            isResolving={isResolving}
             queueAction={queueAction}
+            resolveError={resolveError}
             resolveNext={resolveNext}
             setTargetId={setTargetId}
             targetId={targetId}
@@ -221,7 +242,9 @@ export function CombatTracker({ combatantTemplates, initialState }: Readonly<Com
 function ActionPanel({
   activeCombatant,
   effectiveTargetId,
+  isResolving,
   queueAction,
+  resolveError,
   resolveNext,
   setTargetId,
   targetId,
@@ -230,7 +253,9 @@ function ActionPanel({
 }: Readonly<{
   activeCombatant: Combatant | undefined;
   effectiveTargetId: string;
+  isResolving: boolean;
   queueAction: (type: CombatActionType) => void;
+  resolveError: string | null;
   resolveNext: () => void;
   setTargetId: (targetId: string) => void;
   targetId: string;
@@ -245,11 +270,16 @@ function ActionPanel({
           <h2>{viewNextActor?.name ?? 'NA'}</h2>
           <p>{viewNextActor?.intent ?? 'Timeline vide'}</p>
         </div>
-        <Button disabled={!activeCombatant} onClick={resolveNext}>
+        <Button disabled={!activeCombatant || isResolving} onClick={resolveNext}>
           <Activity aria-hidden="true" className="kw-combat__button-icon" />
           Résoudre
         </Button>
       </div>
+      {resolveError ? (
+        <Toast title="Résolution impossible" tone="danger">
+          {resolveError}
+        </Toast>
+      ) : null}
 
       <div className="kw-combat__action-grid">
         <SelectField

--- a/apps/game/src/lib/api.ts
+++ b/apps/game/src/lib/api.ts
@@ -21,6 +21,10 @@ export function getApiBaseUrl(): string {
   return process.env.API_BASE_URL ?? process.env.NEXT_PUBLIC_API_BASE_URL ?? DEFAULT_API_BASE_URL;
 }
 
+export function getClientApiBaseUrl(): string {
+  return process.env.NEXT_PUBLIC_API_BASE_URL ?? DEFAULT_API_BASE_URL;
+}
+
 export async function getApiHealth(): Promise<ApiHealthStatus> {
   const baseUrl = getApiBaseUrl();
 

--- a/apps/game/src/lib/trpc.test.ts
+++ b/apps/game/src/lib/trpc.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { getTrpcEndpoint } from './trpc.js';
+
+const originalApiBaseUrl = process.env.API_BASE_URL;
+const originalPublicApiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+afterEach(() => {
+  restoreEnv('API_BASE_URL', originalApiBaseUrl);
+  restoreEnv('NEXT_PUBLIC_API_BASE_URL', originalPublicApiBaseUrl);
+});
+
+describe('tRPC client endpoint', () => {
+  it('uses the public browser API base URL instead of the server-only API base URL', () => {
+    process.env.API_BASE_URL = 'http://server-only.example';
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://browser.example';
+
+    expect(getTrpcEndpoint()).toBe('http://browser.example/trpc');
+  });
+});
+
+function restoreEnv(name: 'API_BASE_URL' | 'NEXT_PUBLIC_API_BASE_URL', value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}

--- a/apps/game/src/lib/trpc.ts
+++ b/apps/game/src/lib/trpc.ts
@@ -1,11 +1,15 @@
 import { createTRPCClient, httpLink } from '@trpc/client';
 import type { AppRouter } from '@knightandwizard/server/trpc';
-import { getApiBaseUrl } from './api';
+import { getClientApiBaseUrl } from './api';
+
+export function getTrpcEndpoint(): string {
+  return `${getClientApiBaseUrl()}/trpc`;
+}
 
 export const trpc = createTRPCClient<AppRouter>({
   links: [
     httpLink({
-      url: `${getApiBaseUrl()}/trpc`
+      url: getTrpcEndpoint()
     })
   ]
 });

--- a/apps/game/src/lib/trpc.ts
+++ b/apps/game/src/lib/trpc.ts
@@ -1,0 +1,11 @@
+import { createTRPCClient, httpLink } from '@trpc/client';
+import type { AppRouter } from '@knightandwizard/server/trpc';
+import { getApiBaseUrl } from './api';
+
+export const trpc = createTRPCClient<AppRouter>({
+  links: [
+    httpLink({
+      url: `${getApiBaseUrl()}/trpc`
+    })
+  ]
+});

--- a/apps/game/tsconfig.json
+++ b/apps/game/tsconfig.json
@@ -13,6 +13,7 @@
     "paths": {
       "@/*": ["./src/*"],
       "@knightandwizard/rules-core": ["../../packages/rules-core/src/index.ts"],
+      "@knightandwizard/server/trpc": ["../server/src/trpc/router.ts"],
       "@knightandwizard/ui": ["../../packages/ui/src/index.ts"]
     },
     "plugins": [

--- a/apps/server/drizzle/0006_characters.sql
+++ b/apps/server/drizzle/0006_characters.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS characters (
+  id text PRIMARY KEY,
+  user_id text NOT NULL DEFAULT 'local-dev',
+  draft_id text REFERENCES character_drafts (id) ON DELETE SET NULL,
+  kind text NOT NULL,
+  name text NOT NULL,
+  payload jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS characters_draft_id_idx ON characters (draft_id);
+CREATE INDEX IF NOT EXISTS characters_user_id_idx ON characters (user_id);
+CREATE INDEX IF NOT EXISTS characters_kind_idx ON characters (kind);
+CREATE INDEX IF NOT EXISTS characters_updated_at_idx ON characters (updated_at);

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -22,6 +22,7 @@
     "@knightandwizard/catalogs": "workspace:*",
     "@knightandwizard/rules-core": "workspace:*",
     "@mastra/core": "^1.29.1",
+    "@trpc/server": "^11.17.0",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "fastify": "^5.8.5",
@@ -30,6 +31,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@trpc/client": "^11.17.0",
     "drizzle-kit": "^0.31.10",
     "tsx": "^4.21.0"
   }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -16,6 +16,10 @@ export function buildApp(options: FastifyServerOptions = {}): FastifyInstance {
     reply.header('access-control-allow-origin', origin);
     reply.header('access-control-allow-methods', 'GET,PUT,POST,OPTIONS');
     reply.header('access-control-allow-headers', 'content-type,authorization');
+
+    if (request.method === 'OPTIONS') {
+      return reply.code(204).send();
+    }
   });
 
   app.register(registerCatalogRoutes);

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -5,6 +5,7 @@ import { registerGameMasterRoutes } from './routes/game-master.js';
 import { registerHealthRoute } from './routes/health.js';
 import { registerReadyRoute } from './routes/ready.js';
 import { registerSessionRoutes } from './routes/sessions.js';
+import { registerTrpcRoutes } from './trpc/fastify.js';
 
 export function buildApp(options: FastifyServerOptions = {}): FastifyInstance {
   const app = Fastify(options);
@@ -23,6 +24,7 @@ export function buildApp(options: FastifyServerOptions = {}): FastifyInstance {
   app.register(registerHealthRoute);
   app.register(registerReadyRoute);
   app.register(registerSessionRoutes);
+  app.register(registerTrpcRoutes);
 
   return app;
 }

--- a/apps/server/src/characters/finalize.ts
+++ b/apps/server/src/characters/finalize.ts
@@ -1,0 +1,364 @@
+import {
+  loadValidatedCatalog,
+  type ClassesCatalog,
+  type OrientationsCatalog,
+  type PotionsCatalog,
+  type ProtectionsCatalog,
+  type RacesCatalog,
+  type WeaponsCatalog
+} from '@knightandwizard/catalogs';
+import {
+  ATTRIBUTE_KEYS,
+  createPlayerCharacter,
+  type AttributeKey,
+  type Character,
+  type CharacterAttributes,
+  type CharacterClassProfile,
+  type CharacterEquipmentItem,
+  type CharacterOrientationProfile,
+  type CharacterSkill,
+  type CharacterSpell,
+  type RaceProfile
+} from '@knightandwizard/rules-core';
+import { eq, sql as drizzleSql } from 'drizzle-orm';
+import { z } from 'zod';
+import { createDbClient, createSqlClient } from '../db/client.js';
+import { characterDrafts, characters } from '../db/schema.js';
+
+export class CharacterDraftNotFoundError extends Error {
+  constructor(draftId: string) {
+    super(`Character draft not found: ${draftId}`);
+    this.name = 'CharacterDraftNotFoundError';
+  }
+}
+
+export class CharacterNotFoundError extends Error {
+  constructor(characterId: string) {
+    super(`Character not found: ${characterId}`);
+    this.name = 'CharacterNotFoundError';
+  }
+}
+
+export interface CharacterPersistenceResult {
+  character: Character;
+}
+
+interface CharacterCreationCatalog {
+  classes: CharacterClassProfile[];
+  equipment: Array<{ id: string; name: string }>;
+  orientations: CharacterOrientationProfile[];
+  races: RaceProfile[];
+}
+
+interface CharacterCreationDraftSnapshot {
+  currentStep: CharacterCreationStepId;
+  id: string;
+  payload: CharacterCreationDraftPayload;
+}
+
+type CharacterCreationStepId =
+  | 'identity'
+  | 'attributes'
+  | 'path'
+  | 'spells'
+  | 'skills'
+  | 'assets'
+  | 'equipment'
+  | 'story'
+  | 'review';
+
+interface CharacterCreationDraftPayload {
+  attributes: CharacterAttributes;
+  background: string;
+  classId: string;
+  deity: string;
+  equipmentIds: string[];
+  extraSpellPoints: number;
+  genderId: string;
+  name: string;
+  orientationId: string;
+  psychology: string;
+  quote: string;
+  raceId: string;
+  skills: CharacterSkill[];
+  spells: CharacterSpell[];
+}
+
+const CharacterCreationStepIdSchema = z.enum([
+  'identity',
+  'attributes',
+  'path',
+  'spells',
+  'skills',
+  'assets',
+  'equipment',
+  'story',
+  'review'
+]);
+
+const CharacterAttributesSchema = z.object(
+  Object.fromEntries(ATTRIBUTE_KEYS.map((key) => [key, z.number().int().nonnegative()])) as Record<
+    AttributeKey,
+    z.ZodNumber
+  >
+) as z.ZodType<CharacterAttributes>;
+
+const CharacterSkillSchema: z.ZodType<CharacterSkill> = z.object({
+  id: z.string().min(1),
+  isMain: z.boolean().optional(),
+  parentId: z.string().min(1).nullable().optional(),
+  points: z.number().int().nonnegative()
+});
+
+const CharacterSpellSchema: z.ZodType<CharacterSpell> = z.object({
+  id: z.string().min(1),
+  points: z.number().int().nonnegative()
+});
+
+const CharacterCreationDraftPayloadSchema: z.ZodType<CharacterCreationDraftPayload> = z
+  .object({
+    attributes: CharacterAttributesSchema,
+    background: z.string(),
+    classId: z.string().min(1),
+    deity: z.string(),
+    equipmentIds: z.array(z.string().min(1)),
+    extraSpellPoints: z.number().int().nonnegative(),
+    genderId: z.string(),
+    name: z.string().min(1),
+    orientationId: z.string().min(1),
+    psychology: z.string(),
+    quote: z.string(),
+    raceId: z.string().min(1),
+    skills: z.array(CharacterSkillSchema),
+    spells: z.array(CharacterSpellSchema)
+  })
+  .passthrough();
+
+const CharacterCreationDraftSnapshotSchema: z.ZodType<CharacterCreationDraftSnapshot> = z.object({
+  currentStep: CharacterCreationStepIdSchema,
+  id: z.string().min(1),
+  payload: CharacterCreationDraftPayloadSchema
+});
+
+export async function finalizeCharacterDraft(draftId: string): Promise<CharacterPersistenceResult> {
+  const sql = createSqlClient();
+  const db = createDbClient(sql);
+
+  try {
+    const draftRows = await db
+      .select()
+      .from(characterDrafts)
+      .where(eq(characterDrafts.id, draftId))
+      .limit(1);
+    const row = draftRows[0];
+
+    if (row === undefined) {
+      throw new CharacterDraftNotFoundError(draftId);
+    }
+
+    const draft = CharacterCreationDraftSnapshotSchema.parse({
+      currentStep: row.currentStep,
+      id: row.id,
+      payload: row.payload
+    });
+    const catalog = await loadCharacterCreationCatalog();
+    const character = buildCharacterFromDraft(draft, catalog, row.userId);
+    const persistedRows = await db
+      .insert(characters)
+      .values({
+        draftId: draft.id,
+        id: character.id,
+        kind: character.kind,
+        name: character.name,
+        payload: character,
+        userId: row.userId
+      })
+      .onConflictDoUpdate({
+        set: {
+          draftId: draft.id,
+          kind: character.kind,
+          name: character.name,
+          payload: character,
+          updatedAt: drizzleSql`now()`,
+          userId: row.userId
+        },
+        target: characters.id
+      })
+      .returning({ character: characters.payload });
+
+    return {
+      character: persistedRows[0]!.character
+    };
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+export async function getPersistedCharacter(id: string): Promise<CharacterPersistenceResult> {
+  const sql = createSqlClient();
+  const db = createDbClient(sql);
+
+  try {
+    const rows = await db
+      .select({ character: characters.payload })
+      .from(characters)
+      .where(eq(characters.id, id))
+      .limit(1);
+    const row = rows[0];
+
+    if (row === undefined) {
+      throw new CharacterNotFoundError(id);
+    }
+
+    return {
+      character: row.character
+    };
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+async function loadCharacterCreationCatalog(): Promise<CharacterCreationCatalog> {
+  const [races, orientations, classes, weapons, protections, potions] = await Promise.all([
+    loadValidatedCatalog('races.yaml'),
+    loadValidatedCatalog('orientations.yaml'),
+    loadValidatedCatalog('classes.yaml'),
+    loadValidatedCatalog('armes.yaml'),
+    loadValidatedCatalog('protections.yaml'),
+    loadValidatedCatalog('potions.yaml')
+  ]);
+
+  return {
+    classes: toClassProfiles(classes),
+    equipment: toEquipmentOptions(weapons, protections, potions),
+    orientations: toOrientationProfiles(orientations),
+    races: toRaceProfiles(races)
+  };
+}
+
+function buildCharacterFromDraft(
+  draft: CharacterCreationDraftSnapshot,
+  catalog: CharacterCreationCatalog,
+  userId: string
+): Character {
+  const race = requireSelection(
+    catalog.races.find((entry) => entry.id === draft.payload.raceId),
+    'race'
+  );
+  const orientation = requireSelection(
+    catalog.orientations.find((entry) => entry.id === draft.payload.orientationId),
+    'orientation'
+  );
+  const classProfile = requireSelection(
+    catalog.classes.find((entry) => entry.id === draft.payload.classId),
+    'class'
+  );
+  const primarySkillIds = new Set(classProfile.primarySkillIds ?? []);
+  const equipment = draft.payload.equipmentIds.map((equipmentId): CharacterEquipmentItem => {
+    const option = catalog.equipment.find((entry) => entry.id === equipmentId);
+
+    return {
+      id: equipmentId,
+      name: option?.name,
+      quantity: 1
+    };
+  });
+
+  return createPlayerCharacter({
+    attributes: draft.payload.attributes,
+    classProfile,
+    equipment,
+    id: draft.id,
+    metadata: {
+      background: draft.payload.background,
+      deity: draft.payload.deity,
+      genderId: draft.payload.genderId,
+      psychology: draft.payload.psychology,
+      quote: draft.payload.quote
+    },
+    name: draft.payload.name.trim(),
+    orientation,
+    race,
+    skills: draft.payload.skills.map((skill) => ({
+      ...skill,
+      isMain: skill.isMain ?? primarySkillIds.has(skill.id)
+    })),
+    spells: draft.payload.spells.map((spell) => ({ ...spell })),
+    userId
+  });
+}
+
+function toRaceProfiles(catalog: RacesCatalog): RaceProfile[] {
+  return catalog.races
+    .filter(
+      (entry) => entry.status === 'active' && entry.playable === true && entry.id && entry.name
+    )
+    .map((entry) => ({
+      attributeMax: Object.fromEntries(
+        ATTRIBUTE_KEYS.map((key) => [key, Math.max(1, entry.attribute_max[key] ?? 5)])
+      ) as CharacterAttributes,
+      category: entry.xp_category,
+      id: entry.id,
+      name: cleanName(entry.name),
+      speedFactor: entry.speed_factor_base,
+      vitality: entry.vitality_base,
+      willFactor: entry.will_factor_base
+    }));
+}
+
+function toOrientationProfiles(catalog: OrientationsCatalog): CharacterOrientationProfile[] {
+  return catalog.orientations
+    .filter((entry) => entry.status === 'active' && entry.id && entry.name)
+    .map((entry) => ({
+      id: entry.id,
+      isMagical: entry.is_magical,
+      name: entry.name
+    }));
+}
+
+function toClassProfiles(catalog: ClassesCatalog): CharacterClassProfile[] {
+  return catalog.classes
+    .filter((entry) => entry.status === 'active' && entry.id && entry.name && entry.orientation_id)
+    .map((entry) => ({
+      id: entry.id,
+      name: entry.name,
+      orientationId: entry.orientation_id,
+      primarySkillIds: entry.primary_skill_id ? [entry.primary_skill_id] : []
+    }));
+}
+
+function toEquipmentOptions(
+  weapons: WeaponsCatalog,
+  protections: ProtectionsCatalog,
+  potions: PotionsCatalog
+): Array<{ id: string; name: string }> {
+  return [
+    ...weapons.weapons.map((entry) => toEquipmentOption(entry)),
+    ...protections.shields.map((entry) => toEquipmentOption(entry)),
+    ...protections.armor_pieces.map((entry) => toEquipmentOption(entry)),
+    ...potions.potions.map((entry) => toEquipmentOption(entry))
+  ].filter((entry): entry is { id: string; name: string } => entry !== null);
+}
+
+function toEquipmentOption(entry: { id?: string; name?: string; status?: string }) {
+  if (!entry.id || !entry.name || (entry.status !== undefined && entry.status !== 'active')) {
+    return null;
+  }
+
+  return { id: entry.id, name: entry.name };
+}
+
+function requireSelection<T>(value: T | undefined, label: string): T {
+  if (value === undefined) {
+    throw new Error(`Unknown character ${label} in draft`);
+  }
+
+  return value;
+}
+
+function cleanName(name: string): string {
+  return name
+    .replace(/,\s*-.*/, '')
+    .replace(/\s*\/.*$/, '')
+    .trim();
+}

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -11,6 +11,7 @@ import {
   uuid,
   varchar
 } from 'drizzle-orm/pg-core';
+import type { Character } from '@knightandwizard/rules-core';
 
 const vector = customType<{ data: number[] | null; driverData: string | null }>({
   dataType() {
@@ -31,6 +32,7 @@ const updatedNow = () => timestamp('updated_at', { withTimezone: true }).notNull
 export const REQUIRED_APP_TABLES = [
   'catalog_documents',
   'character_drafts',
+  'characters',
   'game_sessions',
   'session_events',
   'session_decisions',
@@ -74,6 +76,26 @@ export const characterDrafts = pgTable(
   (table) => ({
     updatedAtIdx: index('character_drafts_updated_at_idx').on(table.updatedAt),
     userIdIdx: index('character_drafts_user_id_idx').on(table.userId)
+  })
+);
+
+export const characters = pgTable(
+  'characters',
+  {
+    id: text('id').primaryKey(),
+    userId: text('user_id').notNull().default('local-dev'),
+    draftId: text('draft_id').references(() => characterDrafts.id, { onDelete: 'set null' }),
+    kind: text('kind').notNull(),
+    name: text('name').notNull(),
+    payload: jsonb('payload').$type<Character>().notNull(),
+    createdAt: now(),
+    updatedAt: updatedNow()
+  },
+  (table) => ({
+    draftIdIdx: uniqueIndex('characters_draft_id_idx').on(table.draftId),
+    kindIdx: index('characters_kind_idx').on(table.kind),
+    updatedAtIdx: index('characters_updated_at_idx').on(table.updatedAt),
+    userIdIdx: index('characters_user_id_idx').on(table.userId)
   })
 );
 

--- a/apps/server/src/llm/rules-tools.ts
+++ b/apps/server/src/llm/rules-tools.ts
@@ -138,7 +138,7 @@ export function normalizeRuleToolResult<T extends object>(
   };
 }
 
-const RollDiceInputSchema = z.object({
+export const RollDiceInputSchema = z.object({
   pool: z.number().int().positive(),
   difficulty: z.number().int().positive(),
   reason: z.string().optional()
@@ -185,7 +185,7 @@ const CombatantSchema: z.ZodType<Combatant> = z
   })
   .passthrough() as z.ZodType<Combatant>;
 
-const CombatStateSchema: z.ZodType<CombatState> = z
+export const CombatStateSchema: z.ZodType<CombatState> = z
   .object({
     currentDT: z.number().int().positive(),
     log: z.array(z.unknown()),
@@ -331,7 +331,10 @@ export function createGameMasterRulesTools(
     advanceCombatTimeline: createTool({
       description:
         'Avance la timeline DT en resolvant la prochaine action planifiee avec le moteur combat rules-core.',
-      execute: async (inputData) => executeAdvanceCombatTimelineTool(inputData),
+      execute: async (inputData) =>
+        executeAdvanceCombatTimelineTool(inputData, {
+          randomInteger: options.randomInteger
+        }),
       id: 'advanceCombatTimeline',
       inputSchema: AdvanceCombatTimelineInputSchema
     }),
@@ -429,13 +432,16 @@ export async function executeGetCharacterStatusTool(
 }
 
 export async function executeAdvanceCombatTimelineTool(
-  input: unknown
+  input: unknown,
+  options: Pick<GameMasterRuleToolOptions, 'randomInteger'> = {}
 ): Promise<RuleToolResult<AdvanceCombatTimelineToolResult>> {
   return safeRuleToolExecution(() => {
     const normalizedInput = AdvanceCombatTimelineInputSchema.parse(input);
 
     return {
-      state: resolveNextAction(normalizedInput.state),
+      state: resolveNextAction(normalizedInput.state, {
+        randomInteger: options.randomInteger
+      }),
       status: 'ok'
     };
   });

--- a/apps/server/src/trpc/context.ts
+++ b/apps/server/src/trpc/context.ts
@@ -1,0 +1,5 @@
+export type TrpcContext = Record<string, never>;
+
+export async function createTrpcContext(): Promise<TrpcContext> {
+  return {};
+}

--- a/apps/server/src/trpc/fastify.ts
+++ b/apps/server/src/trpc/fastify.ts
@@ -1,0 +1,16 @@
+import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
+import type { FastifyInstance } from 'fastify';
+import { createTrpcContext } from './context.js';
+import { appRouter } from './router.js';
+
+export async function registerTrpcRoutes(app: FastifyInstance): Promise<void> {
+  app.options('/trpc/*', async (_request, reply) => reply.code(204).send());
+
+  await app.register(fastifyTRPCPlugin, {
+    prefix: '/trpc',
+    trpcOptions: {
+      createContext: createTrpcContext,
+      router: appRouter
+    }
+  });
+}

--- a/apps/server/src/trpc/random.ts
+++ b/apps/server/src/trpc/random.ts
@@ -1,0 +1,57 @@
+import type { RandomInteger } from '@knightandwizard/rules-core';
+
+export interface DeterministicRandomInput {
+  randomInteger?: number[];
+  seed?: number | string;
+}
+
+export function toRandomInteger(input: DeterministicRandomInput): RandomInteger | undefined {
+  if (input.randomInteger !== undefined) {
+    return sequenceRandomInteger(input.randomInteger);
+  }
+
+  if (input.seed !== undefined) {
+    return seededRandomInteger(String(input.seed));
+  }
+
+  return undefined;
+}
+
+function sequenceRandomInteger(values: number[]): RandomInteger {
+  let index = 0;
+
+  return (sides) => {
+    const value = values[index];
+
+    if (value === undefined) {
+      throw new Error('Deterministic randomInteger sequence exhausted');
+    }
+
+    if (!Number.isInteger(value) || value < 1 || value > sides) {
+      throw new Error(`Deterministic randomInteger value ${value} is outside 1..${sides}`);
+    }
+
+    index += 1;
+    return value;
+  };
+}
+
+function seededRandomInteger(seed: string): RandomInteger {
+  let state = hashSeed(seed);
+
+  return (sides) => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return (state % sides) + 1;
+  };
+}
+
+function hashSeed(seed: string): number {
+  let hash = 2166136261;
+
+  for (const character of seed) {
+    hash ^= character.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}

--- a/apps/server/src/trpc/router.test.ts
+++ b/apps/server/src/trpc/router.test.ts
@@ -1,0 +1,225 @@
+import { randomUUID } from 'node:crypto';
+import { createTRPCClient, httpLink } from '@trpc/client';
+import type { FastifyInstance } from 'fastify';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildApp } from '../app.js';
+import { runMigrations } from '../db/migrate.js';
+import type { AppRouter } from './router.js';
+
+const app = buildApp({ logger: false });
+const trpc = createTestTrpcClient(app);
+
+beforeAll(async () => {
+  await runMigrations();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('tRPC rules and character procedures', () => {
+  it('rolls dice through rules-core with deterministic test rolls', async () => {
+    const result = await trpc.dice.roll.mutate({
+      difficulty: 7,
+      pool: 2,
+      randomInteger: [7, 6],
+      reason: 'procedure-test'
+    });
+
+    expect(result).toMatchObject({
+      difficulty: 7,
+      isCriticalFailure: false,
+      isCriticalSuccess: false,
+      pool: 2,
+      reason: 'procedure-test',
+      rolls: [7, 6],
+      status: 'ok',
+      successes: 1
+    });
+  });
+
+  it('resolves combat actions on the server via the rules-core tool wrapper', async () => {
+    const result = await trpc.combat.resolveAction.mutate({
+      randomInteger: [7, 8],
+      state: {
+        currentDT: 1,
+        log: [],
+        round: 1,
+        timeline: [
+          {
+            attributes: { dexterity: 3, stamina: 3, strength: 4 },
+            id: 'aveline',
+            name: 'Aveline',
+            nextActionAt: 3,
+            pendingAction: {
+              attack: { difficulty: 7, pool: 2 },
+              damageOnHit: 3,
+              targetId: 'brigand',
+              type: 'attack'
+            },
+            reflexes: 4,
+            skills: { sword: 2 },
+            speedFactor: 4,
+            statuses: [],
+            vitality: { current: 18, max: 18 }
+          },
+          {
+            attributes: { dexterity: 2, stamina: 2, strength: 3 },
+            id: 'brigand',
+            name: 'Brigand',
+            nextActionAt: 5,
+            reflexes: 2,
+            skills: { axe: 1 },
+            speedFactor: 5,
+            statuses: [],
+            vitality: { current: 12, max: 12 }
+          }
+        ]
+      }
+    });
+
+    const target = result.state.timeline.find((combatant) => combatant.id === 'brigand');
+
+    expect(result.status).toBe('ok');
+    expect(target?.vitality.current).toBe(9);
+    expect(result.state.log.map((event) => event.type)).toEqual([
+      'attack_resolved',
+      'damage_applied'
+    ]);
+    expect(result.state.log[0]).toMatchObject({
+      actorId: 'aveline',
+      attackRoll: { rolls: [7, 8], successes: 2 },
+      successes: 2,
+      targetId: 'brigand'
+    });
+  });
+
+  it('finalizes saved character drafts into persisted characters and reads them back', async () => {
+    const draftId = `draft-${randomUUID()}`;
+    const draft = {
+      currentStep: 'review',
+      payload: {
+        attributes: {
+          aestheticism: 1,
+          charisma: 2,
+          dexterity: 3,
+          empathy: 1,
+          intelligence: 2,
+          perception: 2,
+          reflexes: 2,
+          stamina: 3,
+          strength: 4
+        },
+        background: 'Garde de la porte nord.',
+        classId: 'garde',
+        deity: 'Les Trois Flammes',
+        equipmentIds: ['epee_batarde'],
+        extraSpellPoints: 0,
+        genderId: 'unspecified',
+        name: 'Aveline API',
+        orientationId: 'guerrier',
+        psychology: 'calme',
+        quote: 'La lame engage.',
+        raceId: 'humain',
+        skills: [
+          { id: 'epee-a-une-main', points: 4 },
+          { id: 'stoicisme', points: 4 },
+          { id: 'commandement', points: 4 },
+          { id: 'observation-du-terrain', points: 4 },
+          { id: 'bouclier', points: 4 }
+        ],
+        spells: []
+      }
+    };
+
+    const saveResponse = await app.inject({
+      method: 'PUT',
+      payload: draft,
+      url: `/character-drafts/${draftId}`
+    });
+
+    const finalized = await trpc.characters.finalize.mutate({ draftId });
+    const readBack = await trpc.characters.get.query({ id: finalized.character.id });
+
+    expect(saveResponse.statusCode).toBe(200);
+    expect(finalized.character).toMatchObject({
+      id: draftId,
+      kind: 'player',
+      metadata: {
+        background: 'Garde de la porte nord.',
+        deity: 'Les Trois Flammes'
+      },
+      name: 'Aveline API',
+      race: { id: 'humain' }
+    });
+    expect(readBack.character).toEqual(finalized.character);
+  });
+});
+
+function createTestTrpcClient(
+  app: FastifyInstance
+): ReturnType<typeof createTRPCClient<AppRouter>> {
+  return createTRPCClient<AppRouter>({
+    links: [
+      httpLink({
+        fetch: async (input, init) => {
+          const requestUrl = new URL(String(input));
+          const response = await app.inject({
+            headers: toHeaderRecord(init?.headers),
+            method: toHttpMethod(init?.method),
+            payload: await toPayload(init?.body),
+            url: `${requestUrl.pathname}${requestUrl.search}`
+          });
+          const headers = new Headers();
+
+          for (const [key, value] of Object.entries(response.headers)) {
+            if (Array.isArray(value)) {
+              for (const item of value) {
+                headers.append(key, String(item));
+              }
+            } else if (value !== undefined) {
+              headers.set(key, String(value));
+            }
+          }
+
+          return new Response(response.body, {
+            headers,
+            status: response.statusCode
+          });
+        },
+        url: 'http://test.local/trpc'
+      })
+    ]
+  });
+}
+
+function toHeaderRecord(headers: HeadersInit | undefined): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  if (headers === undefined) {
+    return result;
+  }
+
+  new Headers(headers).forEach((value, key) => {
+    result[key] = value;
+  });
+
+  return result;
+}
+
+function toHttpMethod(method: string | undefined): 'GET' | 'POST' {
+  return method === 'POST' ? 'POST' : 'GET';
+}
+
+async function toPayload(body: BodyInit | null | undefined): Promise<string | undefined> {
+  if (body === null || body === undefined) {
+    return undefined;
+  }
+
+  if (typeof body === 'string') {
+    return body;
+  }
+
+  return new Response(body).text();
+}

--- a/apps/server/src/trpc/router.ts
+++ b/apps/server/src/trpc/router.ts
@@ -1,0 +1,117 @@
+import { initTRPC, TRPCError } from '@trpc/server';
+import { z } from 'zod';
+import {
+  CharacterDraftNotFoundError,
+  CharacterNotFoundError,
+  finalizeCharacterDraft,
+  getPersistedCharacter
+} from '../characters/finalize.js';
+import {
+  CombatStateSchema,
+  RollDiceInputSchema,
+  executeAdvanceCombatTimelineTool,
+  executeRollDiceTool,
+  type RuleToolResult,
+  type ToolErrorResult
+} from '../llm/rules-tools.js';
+import type { TrpcContext } from './context.js';
+import { toRandomInteger } from './random.js';
+
+const t = initTRPC.context<TrpcContext>().create();
+
+const DeterministicRandomSchema = z.object({
+  randomInteger: z.array(z.number().int().positive()).optional(),
+  seed: z.union([z.number(), z.string().min(1)]).optional()
+});
+
+const RollDiceProcedureInputSchema = RollDiceInputSchema.merge(DeterministicRandomSchema);
+
+const ResolveActionProcedureInputSchema = DeterministicRandomSchema.extend({
+  state: CombatStateSchema
+});
+
+const CharacterIdInputSchema = z.object({
+  id: z.string().min(1)
+});
+
+const FinalizeCharacterInputSchema = z.object({
+  draftId: z.string().min(1)
+});
+
+export const appRouter = t.router({
+  characters: t.router({
+    finalize: t.procedure.input(FinalizeCharacterInputSchema).mutation(async ({ input }) => {
+      try {
+        return await finalizeCharacterDraft(input.draftId);
+      } catch (error) {
+        throw toCharacterProcedureError(error);
+      }
+    }),
+    get: t.procedure.input(CharacterIdInputSchema).query(async ({ input }) => {
+      try {
+        return await getPersistedCharacter(input.id);
+      } catch (error) {
+        throw toCharacterProcedureError(error);
+      }
+    })
+  }),
+  combat: t.router({
+    resolveAction: t.procedure
+      .input(ResolveActionProcedureInputSchema)
+      .mutation(async ({ input }) =>
+        unwrapRuleToolResult(
+          await executeAdvanceCombatTimelineTool(
+            { state: input.state },
+            { randomInteger: toRandomInteger(input) }
+          )
+        )
+      )
+  }),
+  dice: t.router({
+    roll: t.procedure.input(RollDiceProcedureInputSchema).mutation(async ({ input }) =>
+      unwrapRuleToolResult(
+        await executeRollDiceTool(input, {
+          randomInteger: toRandomInteger(input)
+        })
+      )
+    )
+  })
+});
+
+export type AppRouter = typeof appRouter;
+
+function unwrapRuleToolResult<T extends object>(result: RuleToolResult<T>): T {
+  if (isToolError(result)) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: result.message
+    });
+  }
+
+  return result;
+}
+
+function isToolError<T extends object>(result: RuleToolResult<T>): result is ToolErrorResult {
+  return 'status' in result && result.status === 'error';
+}
+
+function toCharacterProcedureError(error: unknown): TRPCError {
+  if (error instanceof CharacterDraftNotFoundError || error instanceof CharacterNotFoundError) {
+    return new TRPCError({
+      code: 'NOT_FOUND',
+      message: error.message
+    });
+  }
+
+  if (error instanceof z.ZodError) {
+    return new TRPCError({
+      code: 'BAD_REQUEST',
+      message: error.issues.map((issue) => issue.message).join('; ')
+    });
+  }
+
+  return new TRPCError({
+    code: 'BAD_REQUEST',
+    message: error instanceof Error ? error.message : 'Character persistence failed'
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@knightandwizard/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@trpc/client':
+        specifier: ^11.17.0
+        version: 11.17.0(@trpc/server@11.17.0(typescript@5.9.3))(typescript@5.9.3)
       lucide-react:
         specifier: ^1.14.0
         version: 1.14.0(react@19.2.5)
@@ -158,6 +161,9 @@ importers:
       '@mastra/core':
         specifier: ^1.29.1
         version: 1.29.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(zod@4.3.6)
+      '@trpc/server':
+        specifier: ^11.17.0
+        version: 11.17.0(typescript@5.9.3)
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -177,6 +183,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@trpc/client':
+        specifier: ^11.17.0
+        version: 11.17.0(@trpc/server@11.17.0(typescript@5.9.3))(typescript@5.9.3)
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
@@ -1766,6 +1775,19 @@ packages:
 
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@trpc/client@11.17.0':
+    resolution: {integrity: sha512-KpJBFrbKTDeVCFv/3ckL1XBBH5Yssn8hethI/rUy7GIpTj+VzjtPjykDqJpzobuVOz+d26cXCSu1t4I6MYI5Zg==}
+    hasBin: true
+    peerDependencies:
+      '@trpc/server': 11.17.0
+      typescript: '>=5.7.2'
+
+  '@trpc/server@11.17.0':
+    resolution: {integrity: sha512-jbAOUe0PpUTCYqziyu+8vYXZdDXPudZgnEhWCQ2NjKnVEjfE93RqHTt1oycZJv/HNf51YlRXfEEwSIAbb161rw==}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.7.2'
 
   '@turbo/darwin-64@2.9.6':
     resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
@@ -5679,6 +5701,15 @@ snapshots:
       - supports-color
 
   '@tokenizer/token@0.3.0': {}
+
+  '@trpc/client@11.17.0(@trpc/server@11.17.0(typescript@5.9.3))(typescript@5.9.3)':
+    dependencies:
+      '@trpc/server': 11.17.0(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@trpc/server@11.17.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
 
   '@turbo/darwin-64@2.9.6':
     optional: true


### PR DESCRIPTION
## E-B — Résolution autoritaire via API typée (tRPC) + persistance perso

Fondation du MVP réseau, **conforme à l'ADR** (`docs/architecture/realtime-mvp.md`). Le serveur devient **autoritaire** : l'UI **appelle** le moteur, elle ne calcule plus.

- **tRPC** monté sur Fastify (`/trpc`) ; **REST conservé** (surface outils LLM intacte). Types Zod partagés bout-en-bout.
- Procédures : `dice.roll`, `combat.resolveAction` (réutilisent les wrappers **purs** `rules-tools.ts` → `rules-core` autoritaire), `characters.finalize(draftId)`, `characters.get(id)`. Support `randomInteger` / `seed` déterministe pour les tests.
- **Persistance perso** : table `characters` (Drizzle + migration `0006_characters.sql`) + service de finalisation de draft.
- **Client tRPC** typé côté `apps/game` ; le **combat tracker « Résoudre » passe par `combat.resolveAction`** (serveur-autoritaire) au lieu de la résolution client-side — avec états `isResolving` / `resolveError`.
- Gates **complets** verts : `canonical:check`, `lint`, `format:check`, `typecheck`, `build:shared`, **`test` (331 tests / 51 fichiers)**. (`e2e`/`map`/`devlab` nécessitent des services externes → couverts par la CI.)

Roadmap **E-B**. Débloque E-C (journal), E-N (temps réel), E-S (surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
