### PR TITLE
feat(session): journal persisté + câblage des surfaces (E-C)

### DIFF
--- a/apps/game/src/app/combat/page.tsx
+++ b/apps/game/src/app/combat/page.tsx
@@ -10,6 +10,7 @@ export default async function CombatPage() {
     <CombatTracker
       combatantTemplates={readModel.combatantTemplates}
       initialState={readModel.initialState}
+      sessionSlug="brumeval"
     />
   );
 }

--- a/apps/game/src/app/session/page.tsx
+++ b/apps/game/src/app/session/page.tsx
@@ -1,6 +1,10 @@
 import { SessionManager } from '@/features/session-manager/SessionManager';
-import { createInitialSessionManagerState } from '@/features/session-manager/initial-state';
+import { getSessionManagerReadModel } from '@/features/session-manager/read-models';
 
-export default function SessionPage() {
-  return <SessionManager initialState={createInitialSessionManagerState()} />;
+export const dynamic = 'force-dynamic';
+
+export default async function SessionPage() {
+  const readModel = await getSessionManagerReadModel();
+
+  return <SessionManager initialState={readModel.initialState} />;
 }

--- a/apps/game/src/features/combat-tracker/CombatTracker.tsx
+++ b/apps/game/src/features/combat-tracker/CombatTracker.tsx
@@ -129,12 +129,14 @@ export function CombatTracker({
 
     void trpc.combat.resolveAction
       .mutate({ state })
-      .then(async (result) => {
-        await appendCombatResolutionToSession(sessionSlug, {
+      .then((result) => {
+        setState(result.state);
+        void appendCombatResolutionToSession(sessionSlug, {
           actorId: 'gm',
           result: { ...result }
+        }).catch(() => {
+          // Journal append is best-effort; never block the authoritative result render.
         });
-        setState(result.state);
       })
       .catch((error: unknown) => {
         setResolveError(error instanceof Error ? error.message : 'Résolution impossible');

--- a/apps/game/src/features/combat-tracker/CombatTracker.tsx
+++ b/apps/game/src/features/combat-tracker/CombatTracker.tsx
@@ -36,6 +36,7 @@ import {
   type ToastTone
 } from '@knightandwizard/ui';
 import { trpc } from '@/lib/trpc';
+import { appendCombatResolutionToSession } from '@/features/session-manager/persistence';
 
 import {
   addTrackerCombatant,
@@ -69,9 +70,14 @@ const actionLabels: Record<CombatActionType, string> = {
 interface CombatTrackerProps {
   combatantTemplates: CombatantTemplate[];
   initialState: CombatState;
+  sessionSlug?: string;
 }
 
-export function CombatTracker({ combatantTemplates, initialState }: Readonly<CombatTrackerProps>) {
+export function CombatTracker({
+  combatantTemplates,
+  initialState,
+  sessionSlug = 'brumeval'
+}: Readonly<CombatTrackerProps>) {
   const [state, setState] = useState<CombatState>(() => initialState);
   const [isResolving, setIsResolving] = useState(false);
   const [resolveError, setResolveError] = useState<string | null>(null);
@@ -123,7 +129,11 @@ export function CombatTracker({ combatantTemplates, initialState }: Readonly<Com
 
     void trpc.combat.resolveAction
       .mutate({ state })
-      .then((result) => {
+      .then(async (result) => {
+        await appendCombatResolutionToSession(sessionSlug, {
+          actorId: 'gm',
+          result: { ...result }
+        });
         setState(result.state);
       })
       .catch((error: unknown) => {

--- a/apps/game/src/features/session-dashboard/model.test.ts
+++ b/apps/game/src/features/session-dashboard/model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { SessionPlayer, SessionScene } from '@knightandwizard/rules-core';
 
 import { createSessionManagerState } from '../session-manager/model.js';
 
@@ -36,7 +37,9 @@ describe('session dashboard model', () => {
           sequence: 2,
           type: 'dice_roll'
         }
-      ]
+      ],
+      players: samplePlayers(),
+      scenes: sampleScenes()
     });
 
     const view = buildSessionDashboardView(state);
@@ -76,3 +79,50 @@ describe('session dashboard model', () => {
     ]);
   });
 });
+
+function samplePlayers(): SessionPlayer[] {
+  return [
+    {
+      connected: true,
+      id: 'gm',
+      name: 'MJ',
+      role: 'human_gm'
+    },
+    {
+      characterId: 'aveline',
+      connected: true,
+      id: 'aveline',
+      name: 'Aveline',
+      role: 'player'
+    },
+    {
+      characterId: 'mire',
+      connected: false,
+      id: 'mire',
+      name: 'Mire',
+      role: 'player'
+    }
+  ];
+}
+
+function sampleScenes(): SessionScene[] {
+  return [
+    {
+      description: 'Arrivee sous la pluie, garde fatigue, tension basse.',
+      id: 'brumeval-gate',
+      location: 'Brumeval',
+      npcIds: ['guetteur', 'brigand-cache'],
+      openedAtSequence: 1,
+      status: 'active',
+      title: 'Porte nord'
+    },
+    {
+      description: 'Auberge dense, rumeurs et repos possible.',
+      id: 'auberge-corbeau',
+      location: 'Brumeval',
+      npcIds: ['aubergiste'],
+      status: 'draft',
+      title: 'Auberge du Corbeau'
+    }
+  ];
+}

--- a/apps/game/src/features/session-manager/SessionManager.tsx
+++ b/apps/game/src/features/session-manager/SessionManager.tsx
@@ -220,13 +220,15 @@ export function SessionManager({ initialState }: Readonly<SessionManagerProps>) 
               icon={<RotateCcw aria-hidden="true" className="size-4" />}
               label="Rollback"
               onClick={() => {
-                void runPersistedAction('rollback', async (slug) =>
-                  requestPersistedRollback(slug, {
+                void runPersistedAction('rollback', async (slug) => {
+                  await requestPersistedRollback(slug, {
                     actorId: 'gm',
                     reason: 'Correction demandee par le MJ',
                     targetSequence: effectiveRollbackSequence
-                  })
-                );
+                  });
+                  // On re-lit le snapshot complet : le journal doit afficher le
+                  // marqueur de rollback, pas la projection revertie qui le masque.
+                });
               }}
             />
           </div>

--- a/apps/game/src/features/session-manager/SessionManager.tsx
+++ b/apps/game/src/features/session-manager/SessionManager.tsx
@@ -13,15 +13,17 @@ import {
   Users,
   XCircle
 } from 'lucide-react';
-import { useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { trpc } from '@/lib/trpc';
+import { buildSessionManagerView, type SessionManagerState } from './model';
 import {
-  buildSessionManagerView,
-  recordSessionEvent,
-  requestRollbackFromEvent,
-  resolveNextPendingDecision,
-  submitGmDecisionRequest,
-  type SessionManagerState
-} from './model';
+  appendDiceRollToSession,
+  appendPersistedSessionEvent,
+  fetchPersistedSessionState,
+  queuePersistedGmDecision,
+  requestPersistedRollback,
+  resolvePersistedGmDecision
+} from './persistence';
 
 const eventToneClasses = {
   audit: 'border-wine/25 bg-wine/8 text-wine',
@@ -43,15 +45,50 @@ interface SessionManagerProps {
 
 export function SessionManager({ initialState }: Readonly<SessionManagerProps>) {
   const [state, setState] = useState(initialState);
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [mutationError, setMutationError] = useState<string | null>(null);
   const view = useMemo(() => buildSessionManagerView(state), [state]);
   const [rollbackSequence, setRollbackSequence] = useState(
     view.rollbackTargets[0]?.sequence.toString() ?? ''
   );
+  const busy = pendingAction !== null;
 
   const effectiveRollbackSequence =
     rollbackSequence.length > 0
       ? Number.parseInt(rollbackSequence, 10)
       : (view.rollbackTargets[0]?.sequence ?? 0);
+
+  useEffect(() => {
+    const selectedTargetExists = view.rollbackTargets.some(
+      (target) => target.sequence.toString() === rollbackSequence
+    );
+
+    if (!selectedTargetExists) {
+      setRollbackSequence(view.rollbackTargets[0]?.sequence.toString() ?? '');
+    }
+  }, [rollbackSequence, view.rollbackTargets]);
+
+  async function runPersistedAction(
+    action: string,
+    mutation: (slug: string) => Promise<SessionManagerState | undefined | void>
+  ) {
+    if (pendingAction !== null) {
+      return;
+    }
+
+    const slug = state.slug;
+    setPendingAction(action);
+    setMutationError(null);
+
+    try {
+      const nextState = await mutation(slug);
+      setState(nextState ?? (await fetchPersistedSessionState(slug)));
+    } catch (error: unknown) {
+      setMutationError(error instanceof Error ? error.message : 'Journal de session indisponible');
+    } finally {
+      setPendingAction(null);
+    }
+  }
 
   return (
     <div className="grid gap-5 xl:grid-cols-[0.95fr_1.45fr]">
@@ -130,55 +167,74 @@ export function SessionManager({ initialState }: Readonly<SessionManagerProps>) 
           </div>
           <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
             <ActionButton
+              disabled={busy}
               icon={<ScrollText aria-hidden="true" className="size-4" />}
               label="RP"
-              onClick={() =>
-                setState((current) =>
-                  recordSessionEvent(current, {
+              onClick={() => {
+                void runPersistedAction('player-action', async (slug) => {
+                  await appendPersistedSessionEvent(slug, {
                     actorId: 'aveline',
-                    payload: { text: 'Aveline precise son intention.' },
-                    type: 'player_action'
-                  })
-                )
-              }
+                    eventType: 'player_action',
+                    payload: { text: 'Aveline precise son intention.' }
+                  });
+                });
+              }}
             />
             <ActionButton
+              disabled={busy}
               icon={<Dice5 aria-hidden="true" className="size-4" />}
               label="D10"
-              onClick={() =>
-                setState((current) =>
-                  recordSessionEvent(current, {
+              onClick={() => {
+                void runPersistedAction('dice-roll', async (slug) => {
+                  const result = await trpc.dice.roll.mutate({
+                    difficulty: 7,
+                    pool: 2,
+                    reason: 'session-manager'
+                  });
+
+                  await appendDiceRollToSession(slug, {
                     actorId: 'aveline',
-                    payload: { difficulty: 7, successes: 2 },
-                    type: 'dice_roll'
-                  })
-                )
-              }
+                    result: { ...result }
+                  });
+                });
+              }}
             />
             <ActionButton
+              disabled={busy}
               icon={<ShieldAlert aria-hidden="true" className="size-4" />}
               label="MJ"
-              onClick={() =>
-                setState((current) =>
-                  submitGmDecisionRequest(current, 'Valider la consequence narrative')
-                )
-              }
+              onClick={() => {
+                void runPersistedAction('gm-decision', async (slug) => {
+                  await queuePersistedGmDecision(slug, {
+                    assignedTo: 'human_gm',
+                    payload: { source: 'session-manager' },
+                    priority: 'high',
+                    requestedBy: 'llm',
+                    title: 'Valider la consequence narrative'
+                  });
+                });
+              }}
             />
             <ActionButton
-              disabled={view.rollbackTargets.length === 0}
+              disabled={busy || view.rollbackTargets.length === 0}
               icon={<RotateCcw aria-hidden="true" className="size-4" />}
               label="Rollback"
-              onClick={() =>
-                setState((current) =>
-                  requestRollbackFromEvent(
-                    current,
-                    effectiveRollbackSequence,
-                    'Correction demandee par le MJ'
-                  )
-                )
-              }
+              onClick={() => {
+                void runPersistedAction('rollback', async (slug) =>
+                  requestPersistedRollback(slug, {
+                    actorId: 'gm',
+                    reason: 'Correction demandee par le MJ',
+                    targetSequence: effectiveRollbackSequence
+                  })
+                );
+              }}
             />
           </div>
+          {mutationError ? (
+            <p className="mt-3 rounded-md border border-wine/20 bg-wine/8 px-3 py-2 text-sm font-semibold text-wine">
+              {mutationError}
+            </p>
+          ) : null}
         </section>
       </section>
 
@@ -191,28 +247,52 @@ export function SessionManager({ initialState }: Readonly<SessionManagerProps>) 
             </div>
             <div className="flex gap-2">
               <IconButton
-                disabled={view.decisionQueue.length === 0}
+                disabled={busy || view.decisionQueue.length === 0}
                 label="Approuver"
-                onClick={() =>
-                  setState((current) =>
-                    resolveNextPendingDecision(current, 'approved', {
-                      ruling: 'Decision validee par le MJ'
-                    })
-                  )
-                }
+                onClick={() => {
+                  void runPersistedAction('decision-approved', async (slug) => {
+                    const decisionId = view.decisionQueue[0]?.id;
+
+                    if (!decisionId) {
+                      return undefined;
+                    }
+
+                    await resolvePersistedGmDecision(slug, decisionId, {
+                      actorId: 'gm',
+                      resolution: {
+                        ruling: 'Decision validee par le MJ'
+                      },
+                      status: 'approved'
+                    });
+
+                    return undefined;
+                  });
+                }}
               >
                 <CheckCircle2 aria-hidden="true" className="size-4" />
               </IconButton>
               <IconButton
-                disabled={view.decisionQueue.length === 0}
+                disabled={busy || view.decisionQueue.length === 0}
                 label="Rejeter"
-                onClick={() =>
-                  setState((current) =>
-                    resolveNextPendingDecision(current, 'rejected', {
-                      ruling: 'Decision refusee par le MJ'
-                    })
-                  )
-                }
+                onClick={() => {
+                  void runPersistedAction('decision-rejected', async (slug) => {
+                    const decisionId = view.decisionQueue[0]?.id;
+
+                    if (!decisionId) {
+                      return undefined;
+                    }
+
+                    await resolvePersistedGmDecision(slug, decisionId, {
+                      actorId: 'gm',
+                      resolution: {
+                        ruling: 'Decision refusee par le MJ'
+                      },
+                      status: 'rejected'
+                    });
+
+                    return undefined;
+                  });
+                }}
               >
                 <XCircle aria-hidden="true" className="size-4" />
               </IconButton>

--- a/apps/game/src/features/session-manager/initial-state.ts
+++ b/apps/game/src/features/session-manager/initial-state.ts
@@ -1,58 +1,16 @@
-import type { SessionDecision, SessionEvent } from '@knightandwizard/rules-core';
-
 import { createSessionManagerState } from './model';
-
-const initialEvents: SessionEvent[] = [
-  {
-    actorId: 'gm',
-    createdAt: '2026-04-30T20:04:00.000Z',
-    id: 'event-1',
-    payload: { location: 'Porte nord' },
-    sequence: 1,
-    type: 'scene_opened'
-  },
-  {
-    actorId: 'aveline',
-    createdAt: '2026-04-30T20:11:00.000Z',
-    id: 'event-2',
-    payload: { text: 'Aveline interroge le guetteur.' },
-    sequence: 2,
-    type: 'player_action'
-  },
-  {
-    actorId: 'aveline',
-    createdAt: '2026-04-30T20:12:00.000Z',
-    id: 'event-3',
-    payload: { difficulty: 7, successes: 2 },
-    sequence: 3,
-    type: 'dice_roll'
-  },
-  {
-    actorId: 'gm',
-    createdAt: '2026-04-30T20:18:00.000Z',
-    id: 'event-4',
-    payload: { text: 'Les brigands sortent de la brume.' },
-    sequence: 4,
-    type: 'combat'
-  }
-];
-
-const initialDecisions: SessionDecision[] = [
-  {
-    assignedTo: 'human_gm',
-    createdAt: '2026-04-30T20:19:00.000Z',
-    id: 'decision-1',
-    payload: { options: ['negociation', 'embuscade'] },
-    priority: 'high',
-    requestedBy: 'llm',
-    status: 'pending',
-    title: 'Valider la reaction du guetteur'
-  }
-];
 
 export function createInitialSessionManagerState() {
   return createSessionManagerState({
-    decisions: initialDecisions,
-    events: initialEvents
+    decisions: [],
+    events: [],
+    id: 'session-empty',
+    metadata: {},
+    mode: 'digital_human_gm',
+    players: [],
+    scenes: [],
+    slug: 'session-empty',
+    status: 'planned',
+    title: 'Session'
   });
 }

--- a/apps/game/src/features/session-manager/model.test.ts
+++ b/apps/game/src/features/session-manager/model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { SessionPlayer, SessionScene } from '@knightandwizard/rules-core';
 import {
   buildSessionManagerView,
   createSessionManagerState,
@@ -9,6 +10,15 @@ import {
 } from './model.js';
 
 describe('session manager model', () => {
+  it('creates an empty fallback state without seeded journal data', () => {
+    const state = createSessionManagerState();
+
+    expect(state.events).toEqual([]);
+    expect(state.decisions).toEqual([]);
+    expect(state.players).toEqual([]);
+    expect(state.scenes).toEqual([]);
+  });
+
   it('builds a session dashboard view from campaign, scene and event state', () => {
     const state = createSessionManagerState({
       decisions: [
@@ -40,7 +50,9 @@ describe('session manager model', () => {
           sequence: 2,
           type: 'player_action'
         }
-      ]
+      ],
+      players: samplePlayers(),
+      scenes: sampleScenes()
     });
     const view = buildSessionManagerView(state);
 
@@ -61,7 +73,10 @@ describe('session manager model', () => {
   });
 
   it('records events and exposes them as rollback targets', () => {
-    const state = createSessionManagerState();
+    const state = createSessionManagerState({
+      players: samplePlayers(),
+      scenes: []
+    });
     const withEvent = recordSessionEvent(
       state,
       {
@@ -109,7 +124,8 @@ describe('session manager model', () => {
           sequence: 2,
           type: 'dice_roll'
         }
-      ]
+      ],
+      players: samplePlayers()
     });
     const view = buildSessionManagerView(state);
 
@@ -147,3 +163,50 @@ describe('session manager model', () => {
     ]);
   });
 });
+
+function samplePlayers(): SessionPlayer[] {
+  return [
+    {
+      connected: true,
+      id: 'gm',
+      name: 'MJ',
+      role: 'human_gm'
+    },
+    {
+      characterId: 'aveline',
+      connected: true,
+      id: 'aveline',
+      name: 'Aveline',
+      role: 'player'
+    },
+    {
+      characterId: 'mire',
+      connected: false,
+      id: 'mire',
+      name: 'Mire',
+      role: 'player'
+    }
+  ];
+}
+
+function sampleScenes(): SessionScene[] {
+  return [
+    {
+      description: 'Arrivee sous la pluie, garde fatigue, tension basse.',
+      id: 'brumeval-gate',
+      location: 'Brumeval',
+      npcIds: ['guetteur', 'brigand-cache'],
+      openedAtSequence: 1,
+      status: 'active',
+      title: 'Porte nord'
+    },
+    {
+      description: 'Auberge dense, rumeurs et repos possible.',
+      id: 'auberge-corbeau',
+      location: 'Brumeval',
+      npcIds: ['aubergiste'],
+      status: 'draft',
+      title: 'Auberge du Corbeau'
+    }
+  ];
+}

--- a/apps/game/src/features/session-manager/model.ts
+++ b/apps/game/src/features/session-manager/model.ts
@@ -6,6 +6,7 @@ import {
   requestSessionRollback,
   resolveGmDecision,
   type AppendSessionEventInput,
+  type SessionAuditEntry,
   type SessionDecision,
   type SessionDecisionStatus,
   type SessionEvent,
@@ -19,6 +20,8 @@ import {
 export type SessionManagerState = SessionState;
 
 export interface CreateSessionManagerStateInput {
+  audit?: SessionAuditEntry[];
+  createdAt?: string;
   decisions?: SessionDecision[];
   events?: SessionEvent[];
   id?: string;
@@ -29,6 +32,7 @@ export interface CreateSessionManagerStateInput {
   slug?: string;
   status?: SessionState['status'];
   title?: string;
+  updatedAt?: string;
 }
 
 export interface SessionManagerMetric {
@@ -89,19 +93,19 @@ export function createSessionManagerState(
   input: CreateSessionManagerStateInput = {}
 ): SessionManagerState {
   return createSessionState({
+    audit: input.audit,
+    createdAt: input.createdAt,
     decisions: input.decisions,
     events: input.events,
-    id: input.id ?? 'session-brumeval',
-    metadata: input.metadata ?? {
-      campaign: 'Les Brumes de Valombre',
-      cadence: 'async'
-    },
+    id: input.id ?? 'session-empty',
+    metadata: input.metadata ?? {},
     mode: input.mode ?? 'digital_human_gm',
-    players: input.players ?? defaultPlayers(),
-    scenes: input.scenes ?? defaultScenes(),
-    slug: input.slug ?? 'brumeval',
-    status: input.status ?? 'active',
-    title: input.title ?? 'Brumeval'
+    players: input.players ?? [],
+    scenes: input.scenes ?? [],
+    slug: input.slug ?? 'session-empty',
+    status: input.status ?? 'planned',
+    title: input.title ?? 'Session',
+    updatedAt: input.updatedAt
   });
 }
 
@@ -308,54 +312,4 @@ function roleLabel(role: SessionPlayer['role']): string {
   }
 
   return 'Joueur';
-}
-
-function defaultPlayers(): SessionPlayer[] {
-  return [
-    {
-      connected: true,
-      id: 'gm',
-      lastSeenAt: '2026-04-30T10:00:00.000Z',
-      name: 'MJ',
-      role: 'human_gm'
-    },
-    {
-      characterId: 'aveline',
-      connected: true,
-      id: 'aveline',
-      lastSeenAt: '2026-04-30T10:02:00.000Z',
-      name: 'Aveline',
-      role: 'player'
-    },
-    {
-      characterId: 'mire',
-      connected: false,
-      id: 'mire',
-      lastSeenAt: '2026-04-29T20:20:00.000Z',
-      name: 'Mire',
-      role: 'player'
-    }
-  ];
-}
-
-function defaultScenes(): SessionScene[] {
-  return [
-    {
-      description: 'Arrivee sous la pluie, garde fatigue, tension basse.',
-      id: 'brumeval-gate',
-      location: 'Brumeval',
-      npcIds: ['guetteur', 'brigand-cache'],
-      openedAtSequence: 1,
-      status: 'active',
-      title: 'Porte nord'
-    },
-    {
-      description: 'Auberge dense, rumeurs et repos possible.',
-      id: 'auberge-corbeau',
-      location: 'Brumeval',
-      npcIds: ['aubergiste'],
-      status: 'draft',
-      title: 'Auberge du Corbeau'
-    }
-  ];
 }

--- a/apps/game/src/features/session-manager/persistence.test.ts
+++ b/apps/game/src/features/session-manager/persistence.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  appendCombatResolutionToSession,
+  appendDiceRollToSession,
+  queuePersistedGmDecision,
+  requestPersistedRollback,
+  resolvePersistedGmDecision
+} from './persistence.js';
+
+const originalPublicApiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreEnv('NEXT_PUBLIC_API_BASE_URL', originalPublicApiBaseUrl);
+});
+
+describe('session manager persistence', () => {
+  it('appends a resolved dice roll as a typed persisted session event', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://browser-api.test';
+    const fetchMock = vi.fn().mockResolvedValue(okJson({ status: 'created' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await appendDiceRollToSession('brumeval', {
+      actorId: 'aveline',
+      result: {
+        difficulty: 7,
+        isCriticalFailure: false,
+        isCriticalSuccess: false,
+        pool: 2,
+        reason: 'session-manager',
+        rolls: [9, 3],
+        status: 'ok',
+        successes: 1
+      }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('http://browser-api.test/sessions/brumeval/events', {
+      body: JSON.stringify({
+        actorId: 'aveline',
+        eventType: 'dice_roll',
+        payload: {
+          difficulty: 7,
+          isCriticalFailure: false,
+          isCriticalSuccess: false,
+          pool: 2,
+          reason: 'session-manager',
+          rolls: [9, 3],
+          status: 'ok',
+          successes: 1
+        }
+      }),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST'
+    });
+  });
+
+  it('appends a resolved combat action as a typed persisted session event', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://browser-api.test';
+    const fetchMock = vi.fn().mockResolvedValue(okJson({ status: 'created' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await appendCombatResolutionToSession('brumeval', {
+      actorId: 'gm',
+      result: {
+        state: {
+          currentDT: 1,
+          log: [{ actorId: 'aveline', atDT: 3, type: 'wait_resolved' }],
+          round: 1,
+          timeline: []
+        },
+        status: 'ok'
+      }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('http://browser-api.test/sessions/brumeval/events', {
+      body: JSON.stringify({
+        actorId: 'gm',
+        eventType: 'combat',
+        payload: {
+          state: {
+            currentDT: 1,
+            log: [{ actorId: 'aveline', atDT: 3, type: 'wait_resolved' }],
+            round: 1,
+            timeline: []
+          },
+          status: 'ok'
+        }
+      }),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST'
+    });
+  });
+
+  it('persists GM decision queue, resolution and rollback requests through journal routes', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://browser-api.test';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okJson({ decision: { id: 'decision-1' }, status: 'created' }))
+      .mockResolvedValueOnce(okJson({ decision: { id: 'decision-1' }, status: 'resolved' }))
+      .mockResolvedValueOnce(okJson({ status: 'created' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await queuePersistedGmDecision('brumeval', {
+      assignedTo: 'human_gm',
+      payload: { source: 'session-manager' },
+      priority: 'high',
+      requestedBy: 'llm',
+      title: 'Valider la consequence narrative'
+    });
+    await resolvePersistedGmDecision('brumeval', 'decision-1', {
+      actorId: 'gm',
+      resolution: { ruling: 'Decision validee par le MJ' },
+      status: 'approved'
+    });
+    await requestPersistedRollback('brumeval', {
+      actorId: 'gm',
+      reason: 'Correction demandee par le MJ',
+      targetSequence: 2
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'http://browser-api.test/sessions/brumeval/decisions',
+      {
+        body: JSON.stringify({
+          assignedTo: 'human_gm',
+          payload: { source: 'session-manager' },
+          priority: 'high',
+          requestedBy: 'llm',
+          title: 'Valider la consequence narrative'
+        }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST'
+      }
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://browser-api.test/sessions/brumeval/decisions/decision-1/resolve',
+      {
+        body: JSON.stringify({
+          actorId: 'gm',
+          resolution: { ruling: 'Decision validee par le MJ' },
+          status: 'approved'
+        }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST'
+      }
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      'http://browser-api.test/sessions/brumeval/rollback',
+      {
+        body: JSON.stringify({
+          actorId: 'gm',
+          reason: 'Correction demandee par le MJ',
+          targetSequence: 2
+        }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST'
+      }
+    );
+  });
+});
+
+function okJson(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+    status: 200
+  });
+}
+
+function restoreEnv(name: 'NEXT_PUBLIC_API_BASE_URL', value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}

--- a/apps/game/src/features/session-manager/persistence.ts
+++ b/apps/game/src/features/session-manager/persistence.ts
@@ -1,0 +1,172 @@
+import type {
+  SessionControllerRole,
+  SessionDecisionPriority,
+  SessionDecisionStatus,
+  SessionEventType
+} from '@knightandwizard/rules-core';
+
+import { getClientApiBaseUrl } from '../../lib/api';
+
+import {
+  createPersistedSessionPayload,
+  toSessionManagerState,
+  type PersistedSessionSnapshot
+} from './session-api';
+import type { SessionManagerState } from './model';
+
+export interface AppendResolvedEventInput {
+  actorId: string;
+  result: Record<string, unknown>;
+}
+
+export interface QueuePersistedGmDecisionInput {
+  assignedTo?: SessionControllerRole;
+  payload?: Record<string, unknown>;
+  priority?: SessionDecisionPriority;
+  requestedBy: string;
+  title: string;
+}
+
+export interface ResolvePersistedGmDecisionInput {
+  actorId: string;
+  resolution?: Record<string, unknown>;
+  status: Exclude<SessionDecisionStatus, 'pending'>;
+}
+
+export interface RequestPersistedRollbackInput {
+  actorId: string;
+  reason: string;
+  targetSequence: number;
+}
+
+export async function fetchPersistedSessionState(slug: string): Promise<SessionManagerState> {
+  const snapshot = await getPersistedSessionSnapshot(slug);
+
+  return toSessionManagerState(snapshot);
+}
+
+export async function appendDiceRollToSession(
+  slug: string,
+  input: AppendResolvedEventInput
+): Promise<void> {
+  await appendPersistedSessionEvent(slug, {
+    actorId: input.actorId,
+    eventType: 'dice_roll',
+    payload: input.result
+  });
+}
+
+export async function appendCombatResolutionToSession(
+  slug: string,
+  input: AppendResolvedEventInput
+): Promise<void> {
+  await appendPersistedSessionEvent(slug, {
+    actorId: input.actorId,
+    eventType: 'combat',
+    payload: input.result
+  });
+}
+
+export async function appendPersistedSessionEvent(
+  slug: string,
+  input: {
+    actorId: string;
+    eventType: SessionEventType;
+    payload: Record<string, unknown>;
+  }
+): Promise<void> {
+  await postSessionJson(slug, `/sessions/${encodeURIComponent(slug)}/events`, input);
+}
+
+export async function queuePersistedGmDecision(
+  slug: string,
+  input: QueuePersistedGmDecisionInput
+): Promise<void> {
+  await postSessionJson(slug, `/sessions/${encodeURIComponent(slug)}/decisions`, input);
+}
+
+export async function resolvePersistedGmDecision(
+  slug: string,
+  decisionId: string,
+  input: ResolvePersistedGmDecisionInput
+): Promise<void> {
+  await postSessionJson(
+    slug,
+    `/sessions/${encodeURIComponent(slug)}/decisions/${encodeURIComponent(decisionId)}/resolve`,
+    input
+  );
+}
+
+export async function requestPersistedRollback(
+  slug: string,
+  input: RequestPersistedRollbackInput
+): Promise<SessionManagerState | undefined> {
+  const body = await postSessionJson<{ revertedState?: SessionManagerState }>(
+    slug,
+    `/sessions/${encodeURIComponent(slug)}/rollback`,
+    input
+  );
+
+  return body.revertedState;
+}
+
+async function getPersistedSessionSnapshot(slug: string): Promise<PersistedSessionSnapshot> {
+  const baseUrl = getClientApiBaseUrl();
+  const response = await fetch(`${baseUrl}/sessions/${encodeURIComponent(slug)}`, {
+    cache: 'no-store'
+  });
+
+  if (response.status === 404) {
+    return createPersistedSessionSnapshot(slug);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Unable to load session ${slug}: HTTP ${response.status}`);
+  }
+
+  return (await response.json()) as PersistedSessionSnapshot;
+}
+
+async function postSessionJson<ResponseBody>(
+  slug: string,
+  path: string,
+  body: object
+): Promise<ResponseBody> {
+  const baseUrl = getClientApiBaseUrl();
+  let response = await fetch(`${baseUrl}${path}`, {
+    body: JSON.stringify(body),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST'
+  });
+
+  if (response.status === 404) {
+    await createPersistedSessionSnapshot(slug);
+    response = await fetch(`${baseUrl}${path}`, {
+      body: JSON.stringify(body),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST'
+    });
+  }
+
+  if (!response.ok) {
+    throw new Error(`Unable to persist session journal entry for ${slug}: HTTP ${response.status}`);
+  }
+
+  return (await response.json()) as ResponseBody;
+}
+
+async function createPersistedSessionSnapshot(slug: string): Promise<PersistedSessionSnapshot> {
+  const baseUrl = getClientApiBaseUrl();
+  const response = await fetch(`${baseUrl}/sessions`, {
+    body: JSON.stringify(createPersistedSessionPayload(slug)),
+    cache: 'no-store',
+    headers: { 'content-type': 'application/json' },
+    method: 'POST'
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unable to create session ${slug}: HTTP ${response.status}`);
+  }
+
+  return (await response.json()) as PersistedSessionSnapshot;
+}

--- a/apps/game/src/features/session-manager/read-models.test.ts
+++ b/apps/game/src/features/session-manager/read-models.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { getSessionManagerReadModel } from './read-models.js';
+
+const originalApiBaseUrl = process.env.API_BASE_URL;
+const originalPublicApiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreEnv('API_BASE_URL', originalApiBaseUrl);
+  restoreEnv('NEXT_PUBLIC_API_BASE_URL', originalPublicApiBaseUrl);
+});
+
+describe('session manager read models', () => {
+  it('loads the persisted session snapshot from the server API', async () => {
+    process.env.API_BASE_URL = 'http://api.test';
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        state: {
+          audit: [],
+          createdAt: '2026-05-26T10:00:00.000Z',
+          decisions: [],
+          events: [
+            {
+              actorId: 'gm',
+              createdAt: '2026-05-26T10:01:00.000Z',
+              id: 'event-1',
+              payload: { location: 'Porte nord' },
+              sequence: 1,
+              type: 'scene_opened'
+            }
+          ],
+          id: 'session-1',
+          metadata: { campaign: 'Brumeval' },
+          mode: 'digital_human_gm',
+          players: [{ id: 'gm', name: 'MJ', role: 'human_gm' }],
+          scenes: [{ id: 'gate', location: 'Brumeval', status: 'active', title: 'Porte nord' }],
+          slug: 'brumeval',
+          status: 'active',
+          title: 'Brumeval',
+          updatedAt: '2026-05-26T10:01:00.000Z'
+        }
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const readModel = await getSessionManagerReadModel('brumeval');
+
+    expect(fetchMock).toHaveBeenCalledWith('http://api.test/sessions/brumeval', {
+      cache: 'no-store'
+    });
+    expect(readModel.initialState.events.map((event) => event.type)).toEqual(['scene_opened']);
+    expect(readModel.initialState.players).toEqual([{ id: 'gm', name: 'MJ', role: 'human_gm' }]);
+  });
+
+  it('creates an empty durable session when the requested slug does not exist', async () => {
+    process.env.API_BASE_URL = 'http://api.test';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: 'not_found' }), { status: 404 }))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          state: {
+            audit: [],
+            createdAt: '2026-05-26T10:00:00.000Z',
+            decisions: [],
+            events: [],
+            id: 'session-1',
+            metadata: {},
+            mode: 'digital_human_gm',
+            players: [],
+            scenes: [],
+            slug: 'brumeval',
+            status: 'active',
+            title: 'Brumeval',
+            updatedAt: '2026-05-26T10:00:00.000Z'
+          }
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const readModel = await getSessionManagerReadModel('brumeval');
+
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://api.test/sessions', {
+      body: JSON.stringify({
+        metadata: {},
+        mode: 'digital_human_gm',
+        slug: 'brumeval',
+        status: 'active',
+        title: 'Brumeval'
+      }),
+      cache: 'no-store',
+      headers: { 'content-type': 'application/json' },
+      method: 'POST'
+    });
+    expect(readModel.initialState.slug).toBe('brumeval');
+    expect(readModel.initialState.events).toEqual([]);
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+    status: 200
+  });
+}
+
+function restoreEnv(name: 'API_BASE_URL' | 'NEXT_PUBLIC_API_BASE_URL', value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}

--- a/apps/game/src/features/session-manager/read-models.ts
+++ b/apps/game/src/features/session-manager/read-models.ts
@@ -1,0 +1,61 @@
+import { getApiBaseUrl } from '../../lib/api';
+
+import {
+  DEFAULT_SESSION_SLUG,
+  createPersistedSessionPayload,
+  toSessionManagerState,
+  type PersistedSessionSnapshot
+} from './session-api';
+import type { SessionManagerState } from './model';
+
+export interface SessionManagerReadModel {
+  initialState: SessionManagerState;
+}
+
+export async function getSessionManagerReadModel(
+  slug = DEFAULT_SESSION_SLUG
+): Promise<SessionManagerReadModel> {
+  const baseUrl = getApiBaseUrl();
+  const snapshot = await getOrCreateSessionSnapshot(baseUrl, slug);
+
+  return {
+    initialState: toSessionManagerState(snapshot)
+  };
+}
+
+async function getOrCreateSessionSnapshot(
+  baseUrl: string,
+  slug: string
+): Promise<PersistedSessionSnapshot> {
+  const response = await fetch(`${baseUrl}/sessions/${encodeURIComponent(slug)}`, {
+    cache: 'no-store'
+  });
+
+  if (response.status === 404) {
+    return createSessionSnapshot(baseUrl, slug);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Unable to load session ${slug}: HTTP ${response.status}`);
+  }
+
+  return (await response.json()) as PersistedSessionSnapshot;
+}
+
+async function createSessionSnapshot(
+  baseUrl: string,
+  slug: string
+): Promise<PersistedSessionSnapshot> {
+  const response = await fetch(`${baseUrl}/sessions`, {
+    body: JSON.stringify(createPersistedSessionPayload(slug)),
+    cache: 'no-store',
+    headers: { 'content-type': 'application/json' },
+    method: 'POST'
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unable to create session ${slug}: HTTP ${response.status}`);
+  }
+
+  return (await response.json()) as PersistedSessionSnapshot;
+}

--- a/apps/game/src/features/session-manager/session-api.ts
+++ b/apps/game/src/features/session-manager/session-api.ts
@@ -1,0 +1,140 @@
+import type {
+  SessionDecision,
+  SessionEvent,
+  SessionMode,
+  SessionPlayer,
+  SessionScene,
+  SessionState,
+  SessionStatus
+} from '@knightandwizard/rules-core';
+
+import { createSessionManagerState, type SessionManagerState } from './model';
+
+export const DEFAULT_SESSION_SLUG = 'brumeval';
+
+export interface PersistedSessionSnapshot {
+  createdAt?: string;
+  decisions?: SessionDecision[];
+  events?: Array<SessionEvent | PersistedSessionEvent>;
+  id?: string;
+  metadata?: Record<string, unknown>;
+  mode?: SessionMode;
+  slug?: string;
+  state?: SessionState;
+  status?: SessionStatus;
+  title?: string;
+  updatedAt?: string;
+}
+
+export interface PersistedSessionEvent {
+  actorId?: string;
+  createdAt: string;
+  eventType: SessionEvent['type'];
+  id: string;
+  payload: Record<string, unknown>;
+  sequence: number;
+}
+
+export interface CreatePersistedSessionPayload {
+  metadata: Record<string, unknown>;
+  mode: SessionMode;
+  slug: string;
+  status: SessionStatus;
+  title: string;
+}
+
+export function createPersistedSessionPayload(slug: string): CreatePersistedSessionPayload {
+  return {
+    metadata: {},
+    mode: 'digital_human_gm',
+    slug,
+    status: 'active',
+    title: titleFromSlug(slug)
+  };
+}
+
+export function toSessionManagerState(snapshot: PersistedSessionSnapshot): SessionManagerState {
+  if (snapshot.state) {
+    return snapshot.state;
+  }
+
+  return createSessionManagerState({
+    createdAt: snapshot.createdAt,
+    decisions: snapshot.decisions ?? [],
+    events: (snapshot.events ?? []).map(toSessionEvent),
+    id: snapshot.id,
+    metadata: snapshot.metadata ?? {},
+    mode: snapshot.mode,
+    players: toSessionPlayers(snapshot.metadata?.players),
+    scenes: toSessionScenes(snapshot.metadata?.scenes),
+    slug: snapshot.slug,
+    status: snapshot.status,
+    title: snapshot.title,
+    updatedAt: snapshot.updatedAt
+  });
+}
+
+function toSessionEvent(event: SessionEvent | PersistedSessionEvent): SessionEvent {
+  if ('type' in event) {
+    return event;
+  }
+
+  return {
+    actorId: event.actorId,
+    createdAt: event.createdAt,
+    id: event.id,
+    payload: event.payload,
+    sequence: event.sequence,
+    type: event.eventType
+  };
+}
+
+function titleFromSlug(slug: string): string {
+  return slug
+    .split('-')
+    .filter((part) => part.length > 0)
+    .map((part) => `${part[0]?.toUpperCase() ?? ''}${part.slice(1)}`)
+    .join(' ');
+}
+
+function toSessionPlayers(value: unknown): SessionPlayer[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(isSessionPlayer);
+}
+
+function toSessionScenes(value: unknown): SessionScene[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(isSessionScene);
+}
+
+function isSessionPlayer(value: unknown): value is SessionPlayer {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.name === 'string' &&
+    (value.role === 'player' ||
+      value.role === 'human_gm' ||
+      value.role === 'llm' ||
+      value.role === 'auto')
+  );
+}
+
+function isSessionScene(value: unknown): value is SessionScene {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.location === 'string' &&
+    typeof value.title === 'string' &&
+    (value.status === 'active' || value.status === 'closed' || value.status === 'draft')
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/apps/game/src/features/session-manager/session-api.ts
+++ b/apps/game/src/features/session-manager/session-api.ts
@@ -55,6 +55,19 @@ export function createPersistedSessionPayload(slug: string): CreatePersistedSess
 
 export function toSessionManagerState(snapshot: PersistedSessionSnapshot): SessionManagerState {
   if (snapshot.state) {
+    // Le "Journal canonique" est le log d'evenements immuable. Apres un rollback,
+    // le serveur renvoie une projection revertie dans `state` (evenements tronques),
+    // mais le journal doit toujours montrer l'historique complet -- y compris le
+    // marqueur de rollback que la projection exclut justement. On conserve donc les
+    // scenes/decisions/statut projetes et on restaure le log complet depuis `events`.
+    const fullEvents = Array.isArray(snapshot.events)
+      ? snapshot.events.map(toSessionEvent)
+      : undefined;
+
+    if (fullEvents && fullEvents.length > snapshot.state.events.length) {
+      return { ...snapshot.state, events: fullEvents };
+    }
+
     return snapshot.state;
   }
 

--- a/apps/server/src/routes/sessions.test.ts
+++ b/apps/server/src/routes/sessions.test.ts
@@ -71,6 +71,19 @@ describe('session routes', () => {
       status: 'planned',
       title: 'Session API'
     });
+    expect(readResponse.json().state).toMatchObject({
+      events: [
+        { actorId: 'gm', type: 'scene_opened', sequence: 1 },
+        { actorId: 'aveline', type: 'dice_roll', sequence: 2 }
+      ],
+      players: [
+        { id: 'gm', name: 'MJ', role: 'human_gm' },
+        { id: 'aveline', name: 'Aveline', role: 'player' }
+      ],
+      scenes: [{ id: 'brumeval-gate', location: 'Brumeval', title: 'Porte nord' }],
+      slug,
+      title: 'Session API'
+    });
   });
 
   it('queues and resolves GM decisions with audit-friendly events', async () => {
@@ -217,20 +230,27 @@ describe('session routes', () => {
     const reverted = rollbackResponse.json().revertedState;
     // The rollback marker (seq 4) and the resolution (seq 3) are excluded.
     expect(reverted.events.map((event: { sequence: number }) => event.sequence)).toEqual([1, 2]);
+    expect(reverted.events.map((event: { type: string }) => event.type)).toEqual([
+      'scene_opened',
+      'gm_decision_requested'
+    ]);
     expect(reverted.scenes).toMatchObject([{ id: 'gate', openedAtSequence: 1 }]);
     expect(reverted.decisions).toMatchObject([{ id: decisionId, status: 'pending' }]);
     expect(reverted.decisions[0].resolvedAt).toBeUndefined();
 
     // The persisted journal still preserves the full history including the marker.
     const readResponse = await app.inject({ method: 'GET', url: `/sessions/${slug}` });
-    expect(
-      readResponse.json().events.map((event: { eventType: string }) => event.eventType)
-    ).toEqual([
+    const readBody = readResponse.json();
+    expect(readBody.events.map((event: { eventType: string }) => event.eventType)).toEqual([
       'scene_opened',
       'gm_decision_requested',
       'gm_decision_resolved',
       'rollback_requested'
     ]);
+    expect(readBody.state.events.map((event: { sequence: number }) => event.sequence)).toEqual([
+      1, 2
+    ]);
+    expect(readBody.state.decisions).toMatchObject([{ id: decisionId, status: 'pending' }]);
   });
 
   it('records canonical entity links on events, decisions and rollback markers', async () => {

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -2,6 +2,8 @@ import type { FastifyInstance } from 'fastify';
 import {
   type SessionDecision,
   type SessionEvent,
+  type SessionPlayer,
+  type SessionScene,
   type SessionState,
   SESSION_CONTROLLER_ROLES,
   SESSION_DECISION_PRIORITIES,
@@ -1065,6 +1067,8 @@ function toSessionResponse(
   events: SessionEventRow[],
   decisions: SessionDecisionRow[]
 ) {
+  const state = projectCurrentSessionState(buildSessionState(session, events, decisions));
+
   return {
     createdAt: serializeDate(session.created_at),
     decisions: decisions.map(toDecisionResponse),
@@ -1073,6 +1077,7 @@ function toSessionResponse(
     metadata: session.metadata,
     mode: session.mode,
     slug: session.slug,
+    state: toProjectedSessionStateResponse(state),
     status: session.status,
     title: session.title,
     updatedAt: serializeDate(session.updated_at)
@@ -1092,18 +1097,53 @@ function buildSessionState(
   events: SessionEventRow[],
   decisions: SessionDecisionRow[]
 ): SessionState {
+  const metadata = isRecord(session.metadata) ? session.metadata : {};
+
   return createSessionState({
     createdAt: serializeDate(session.created_at),
     decisions: decisions.map(toDecisionModel),
     events: events.map(toEventModel),
     id: session.id,
-    metadata: session.metadata,
+    metadata,
     mode: session.mode as SessionState['mode'],
+    players: toSessionPlayers(metadata.players),
+    scenes: toSessionScenes(metadata.scenes),
     slug: session.slug,
     status: session.status as SessionState['status'],
     title: session.title,
     updatedAt: serializeDate(session.updated_at)
   });
+}
+
+function projectCurrentSessionState(state: SessionState): SessionState {
+  const rollbackTargetSequence = getLatestRollbackTargetSequence(state.events);
+
+  if (rollbackTargetSequence === undefined) {
+    return state;
+  }
+
+  return revertSessionToSequence(state, rollbackTargetSequence);
+}
+
+function getLatestRollbackTargetSequence(events: SessionEvent[]): number | undefined {
+  const sortedEvents = [...events].sort((left, right) => right.sequence - left.sequence);
+
+  for (const event of sortedEvents) {
+    if (event.type !== 'rollback_requested') {
+      continue;
+    }
+
+    const targetSequence = event.payload.targetSequence;
+
+    if (
+      typeof targetSequence === 'number' &&
+      events.some((candidate) => candidate.sequence === targetSequence)
+    ) {
+      return targetSequence;
+    }
+  }
+
+  return undefined;
 }
 
 function toEventModel(row: SessionEventRow): SessionEvent {
@@ -1132,29 +1172,14 @@ function toDecisionModel(row: SessionDecisionRow): SessionDecision {
   };
 }
 
+/** Serializes the authoritative RSC snapshot in the rules-core `SessionState` shape. */
+function toProjectedSessionStateResponse(state: SessionState): SessionState {
+  return state;
+}
+
 /** Serializes a reverted {@link SessionState} projection for HTTP responses. */
-function toSessionStateResponse(state: SessionState) {
-  return {
-    createdAt: state.createdAt,
-    decisions: state.decisions,
-    events: state.events.map((event) => ({
-      actorId: event.actorId,
-      createdAt: event.createdAt,
-      eventType: event.type,
-      id: event.id,
-      payload: event.payload,
-      sequence: event.sequence,
-      sessionId: state.id
-    })),
-    id: state.id,
-    metadata: state.metadata,
-    mode: state.mode,
-    scenes: state.scenes,
-    slug: state.slug,
-    status: state.status,
-    title: state.title,
-    updatedAt: state.updatedAt
-  };
+function toSessionStateResponse(state: SessionState): SessionState {
+  return state;
 }
 
 function toEventResponse(row: SessionEventRow) {
@@ -1188,6 +1213,94 @@ function toDecisionResponse(row: SessionDecisionRow) {
 
 function serializeDate(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : value;
+}
+
+function toSessionPlayers(value: unknown): SessionPlayer[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const players = value
+    .filter(isRecord)
+    .map((player) => {
+      if (!isNonEmptyString(player.id) || !isNonEmptyString(player.name)) {
+        return undefined;
+      }
+
+      const role = isNonEmptyString(player.role) ? player.role : 'player';
+
+      if (!validControllerRoles.has(role)) {
+        return undefined;
+      }
+
+      const normalized: SessionPlayer = {
+        id: player.id.trim(),
+        name: player.name.trim(),
+        role: role as SessionPlayer['role']
+      };
+
+      if (isNonEmptyString(player.characterId)) {
+        normalized.characterId = player.characterId.trim();
+      }
+
+      if (typeof player.connected === 'boolean') {
+        normalized.connected = player.connected;
+      }
+
+      if (isNonEmptyString(player.lastSeenAt)) {
+        normalized.lastSeenAt = player.lastSeenAt.trim();
+      }
+
+      return normalized;
+    })
+    .filter((player): player is SessionPlayer => player !== undefined);
+
+  return players.length > 0 ? players : undefined;
+}
+
+function toSessionScenes(value: unknown): SessionScene[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+
+  const scenes = value
+    .filter(isRecord)
+    .map((scene) => {
+      if (!isNonEmptyString(scene.id) || !isNonEmptyString(scene.location)) {
+        return undefined;
+      }
+
+      const normalized: SessionScene = {
+        id: scene.id.trim(),
+        location: scene.location.trim(),
+        status:
+          scene.status === 'active' || scene.status === 'closed' || scene.status === 'draft'
+            ? scene.status
+            : 'draft',
+        title: isNonEmptyString(scene.title) ? scene.title.trim() : scene.location.trim()
+      };
+
+      if (isNonEmptyString(scene.description)) {
+        normalized.description = scene.description.trim();
+      }
+
+      if (Array.isArray(scene.npcIds)) {
+        const npcIds = scene.npcIds.filter(isNonEmptyString).map((npcId) => npcId.trim());
+
+        if (npcIds.length > 0) {
+          normalized.npcIds = npcIds;
+        }
+      }
+
+      if (Number.isInteger(scene.openedAtSequence)) {
+        normalized.openedAtSequence = scene.openedAtSequence as number;
+      }
+
+      return normalized;
+    })
+    .filter((scene): scene is SessionScene => scene !== undefined);
+
+  return scenes.length > 0 ? scenes : undefined;
 }
 
 interface ValidationResult {

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -262,7 +262,9 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByText('Aveline precise son intention.')).toBeVisible();
 
     await page.getByRole('button', { name: 'D10' }).click();
-    await expect(page.getByText('2 succes').first()).toBeVisible();
+    // Le de est resolu cote serveur (rng reel) : on verifie qu'un jet est journalise,
+    // pas un resultat aleatoire exact.
+    await expect(page.getByText(/Jet de d/).first()).toBeVisible();
 
     await page.getByRole('button', { name: 'MJ' }).click();
     await expect(page.getByText('Valider la consequence narrative').first()).toBeVisible();


### PR DESCRIPTION
## E-C — Journal de session persisté + câblage des surfaces

Le journal d'événements (déjà existant côté serveur : `sequence` monotone, rollback pur) devient le support vivant de la session, branché aux surfaces. Conforme à l'ADR (le journal = primitive de synchro).

- **Session en RSC** : `session/page.tsx` charge le snapshot persisté (`GET /sessions/:slug` → events + state projeté), crée la session sur 404.
- **`/sessions/:slug`** retourne désormais un `state` projeté + honore le dernier marqueur de rollback (journal complet préservé).
- **SessionManager** persiste RP / dés / décisions MJ / résolution / rollback via les routes journal ; les dés résolvent via `trpc.dice.roll` avant d'append `dice_roll`.
- **CombatTracker** append un `combat` après `trpc.combat.resolveAction` — **résultat autoritaire rendu d'abord, append journal best-effort** (ne bloque jamais le rendu ; corrige le risque e2e).
- **Seed retiré** comme source de vérité (`initial-state.ts` = fallback vide).
- Gates complets verts (338 tests) + nouveaux tests `persistence` / `read-models` / `sessions`.

Roadmap **E-C**. Débloque **E-N** (réseau : broadcast du journal en temps réel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
