### PR TITLE
feat(session): fil en direct temps reel par room WebSocket (E-N)

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,6 +19,7 @@
     "knowledge:dry-run": "tsx src/knowledge/dry-run.ts"
   },
   "dependencies": {
+    "@fastify/websocket": "^11.2.0",
     "@knightandwizard/catalogs": "workspace:*",
     "@knightandwizard/rules-core": "workspace:*",
     "@mastra/core": "^1.29.1",

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -4,6 +4,7 @@ import { registerCharacterDraftRoutes } from './routes/character-drafts.js';
 import { registerGameMasterRoutes } from './routes/game-master.js';
 import { registerHealthRoute } from './routes/health.js';
 import { registerReadyRoute } from './routes/ready.js';
+import { registerSessionLiveRoutes } from './routes/sessions-live.js';
 import { registerSessionRoutes } from './routes/sessions.js';
 import { registerTrpcRoutes } from './trpc/fastify.js';
 
@@ -27,6 +28,7 @@ export function buildApp(options: FastifyServerOptions = {}): FastifyInstance {
   app.register(registerGameMasterRoutes);
   app.register(registerHealthRoute);
   app.register(registerReadyRoute);
+  app.register(registerSessionLiveRoutes);
   app.register(registerSessionRoutes);
   app.register(registerTrpcRoutes);
 

--- a/apps/server/src/routes/sessions-live.ts
+++ b/apps/server/src/routes/sessions-live.ts
@@ -1,0 +1,41 @@
+import websocket from '@fastify/websocket';
+import type { FastifyInstance } from 'fastify';
+
+import { sessionHub } from '../sessions/hub.js';
+
+interface LiveParams {
+  slug: string;
+}
+
+/**
+ * Live feed for a session room (E-N). Clients open one socket per session and
+ * receive committed journal events broadcast by the write routes. The server
+ * stays authoritative: this socket only fans out events, it never resolves rules.
+ */
+export async function registerSessionLiveRoutes(app: FastifyInstance): Promise<void> {
+  await app.register(websocket);
+
+  app.get<{ Params: LiveParams }>(
+    '/sessions/:slug/live',
+    { websocket: true },
+    (socket, request) => {
+      const { slug } = request.params;
+
+      sessionHub.subscribe(slug, socket);
+      sessionHub.broadcast(slug, {
+        count: sessionHub.presence(slug),
+        kind: 'session.presence',
+        slug
+      });
+
+      socket.on('close', () => {
+        sessionHub.unsubscribe(slug, socket);
+        sessionHub.broadcast(slug, {
+          count: sessionHub.presence(slug),
+          kind: 'session.presence',
+          slug
+        });
+      });
+    }
+  );
+}

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -15,6 +15,7 @@ import {
 } from '@knightandwizard/rules-core';
 import type postgres from 'postgres';
 import { createSqlClient } from '../db/client.js';
+import { sessionHub } from '../sessions/hub.js';
 
 interface CreateSessionRequestBody {
   metadata?: unknown;
@@ -319,6 +320,12 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
           return reply.code(404).send({ status: 'not_found' });
         }
 
+        sessionHub.broadcast(request.params.slug, {
+          event: toEventResponse(result.event),
+          kind: 'session.event',
+          slug: request.params.slug
+        });
+
         return reply.code(201).send({
           event: toEventResponse(result.event),
           status: 'created'
@@ -460,6 +467,12 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
           return reply.code(404).send({ status: 'not_found' });
         }
 
+        sessionHub.broadcast(request.params.slug, {
+          event: toEventResponse(result.event),
+          kind: 'session.event',
+          slug: request.params.slug
+        });
+
         return reply.code(201).send({
           decision: toDecisionResponse(result.decision),
           event: toEventResponse(result.event),
@@ -599,6 +612,12 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
         if (result.status === 'decision_not_found') {
           return reply.code(404).send({ status: 'decision_not_found' });
         }
+
+        sessionHub.broadcast(request.params.slug, {
+          event: toEventResponse(result.event),
+          kind: 'session.event',
+          slug: request.params.slug
+        });
 
         return {
           decision: toDecisionResponse(result.decision),
@@ -770,6 +789,12 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
           result.decisionRows
         );
         const revertedState = revertSessionToSequence(priorState, result.targetSequence);
+
+        sessionHub.broadcast(request.params.slug, {
+          event: toEventResponse(result.event),
+          kind: 'session.event',
+          slug: request.params.slug
+        });
 
         return reply.code(201).send({
           event: toEventResponse(result.event),

--- a/apps/server/src/sessions/hub.test.ts
+++ b/apps/server/src/sessions/hub.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { SessionHub } from './hub.js';
+
+function fakeConnection(readyState = 1) {
+  return { readyState, send: vi.fn() };
+}
+
+describe('SessionHub', () => {
+  it('broadcasts a committed event to every subscriber of the room', () => {
+    const hub = new SessionHub();
+    const a = fakeConnection();
+    const b = fakeConnection();
+
+    hub.subscribe('brumeval', a);
+    hub.subscribe('brumeval', b);
+    hub.broadcast('brumeval', { kind: 'session.event', slug: 'brumeval', event: { sequence: 1 } });
+
+    const payload = JSON.stringify({
+      kind: 'session.event',
+      slug: 'brumeval',
+      event: { sequence: 1 }
+    });
+    expect(a.send).toHaveBeenCalledWith(payload);
+    expect(b.send).toHaveBeenCalledWith(payload);
+  });
+
+  it('isolates rooms by slug', () => {
+    const hub = new SessionHub();
+    const brumeval = fakeConnection();
+    const other = fakeConnection();
+
+    hub.subscribe('brumeval', brumeval);
+    hub.subscribe('autre-table', other);
+    hub.broadcast('brumeval', { kind: 'session.presence', slug: 'brumeval', count: 1 });
+
+    expect(brumeval.send).toHaveBeenCalledTimes(1);
+    expect(other.send).not.toHaveBeenCalled();
+  });
+
+  it('stops delivering once a connection unsubscribes and tracks presence', () => {
+    const hub = new SessionHub();
+    const a = fakeConnection();
+    const b = fakeConnection();
+
+    hub.subscribe('brumeval', a);
+    hub.subscribe('brumeval', b);
+    expect(hub.presence('brumeval')).toBe(2);
+
+    hub.unsubscribe('brumeval', a);
+    expect(hub.presence('brumeval')).toBe(1);
+
+    hub.broadcast('brumeval', { kind: 'session.event', slug: 'brumeval', event: { sequence: 2 } });
+    expect(a.send).not.toHaveBeenCalled();
+    expect(b.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips connections that are not open', () => {
+    const hub = new SessionHub();
+    const closing = fakeConnection(2);
+
+    hub.subscribe('brumeval', closing);
+    hub.broadcast('brumeval', { kind: 'session.event', slug: 'brumeval', event: { sequence: 3 } });
+
+    expect(closing.send).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/sessions/hub.ts
+++ b/apps/server/src/sessions/hub.ts
@@ -1,0 +1,86 @@
+/**
+ * In-process fan-out for the live session feed (E-N).
+ *
+ * One "room" per session slug. A committed journal event is broadcast to every
+ * connected client of that room; clients apply events by `sequence` and resync
+ * via `GET /sessions/:slug` on a gap. This is the single-instance MVP transport:
+ * scaling to many instances is an additive step (publish the same payloads over
+ * Redis pub/sub) that does not change this contract.
+ */
+
+const WS_OPEN = 1;
+
+/** Minimal surface we need from a live connection (a `ws` WebSocket satisfies it). */
+export interface LiveConnection {
+  readonly readyState?: number;
+  send(data: string): void;
+}
+
+export type SessionBroadcastKind = 'session.event' | 'session.presence';
+
+export interface SessionBroadcast {
+  readonly kind: SessionBroadcastKind;
+  readonly slug: string;
+  readonly [key: string]: unknown;
+}
+
+export class SessionHub {
+  private readonly rooms = new Map<string, Set<LiveConnection>>();
+
+  subscribe(slug: string, connection: LiveConnection): void {
+    let room = this.rooms.get(slug);
+
+    if (!room) {
+      room = new Set<LiveConnection>();
+      this.rooms.set(slug, room);
+    }
+
+    room.add(connection);
+  }
+
+  unsubscribe(slug: string, connection: LiveConnection): void {
+    const room = this.rooms.get(slug);
+
+    if (!room) {
+      return;
+    }
+
+    room.delete(connection);
+
+    if (room.size === 0) {
+      this.rooms.delete(slug);
+    }
+  }
+
+  /** Number of currently connected clients in a room (presence). */
+  presence(slug: string): number {
+    return this.rooms.get(slug)?.size ?? 0;
+  }
+
+  /** Sends `message` to every open connection of the room. Closed sockets are skipped. */
+  broadcast(slug: string, message: SessionBroadcast): void {
+    const room = this.rooms.get(slug);
+
+    if (!room) {
+      return;
+    }
+
+    const data = JSON.stringify(message);
+
+    for (const connection of room) {
+      if (connection.readyState !== undefined && connection.readyState !== WS_OPEN) {
+        continue;
+      }
+
+      try {
+        connection.send(data);
+      } catch {
+        // A failed send must never break the authoritative request path; the
+        // client will resync from Postgres via GET /sessions/:slug.
+      }
+    }
+  }
+}
+
+/** Shared single-instance hub used by the routes and the live WebSocket feed. */
+export const sessionHub = new SessionHub();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
 
   apps/server:
     dependencies:
+      '@fastify/websocket':
+        specifier: ^11.2.0
+        version: 11.2.0
       '@knightandwizard/catalogs':
         specifier: workspace:*
         version: link:../../packages/catalogs
@@ -932,6 +935,9 @@ packages:
 
   '@fastify/proxy-addr@5.1.0':
     resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/websocket@11.2.0':
+    resolution: {integrity: sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==}
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -2386,6 +2392,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -2576,6 +2585,9 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastify-plugin@5.1.0:
+    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
 
   fastify@5.8.5:
     resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
@@ -3686,6 +3698,10 @@ packages:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -3744,6 +3760,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-regex2@5.1.1:
     resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
@@ -3884,9 +3903,15 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -4100,6 +4125,9 @@ packages:
 
   utf8-byte-length@1.0.5:
     resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -4804,6 +4832,15 @@ snapshots:
     dependencies:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.3.0
+
+  '@fastify/websocket@11.2.0':
+    dependencies:
+      duplexify: 4.1.3
+      fastify-plugin: 5.1.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -6249,6 +6286,13 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   ee-first@1.1.1: {}
 
   encodeurl@2.0.0: {}
@@ -6556,6 +6600,8 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
+
+  fastify-plugin@5.1.0: {}
 
   fastify@5.8.5:
     dependencies:
@@ -7856,6 +7902,12 @@ snapshots:
 
   react@19.2.5: {}
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
@@ -7953,6 +8005,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
 
   safe-regex2@5.1.1:
     dependencies:
@@ -8121,7 +8175,13 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  stream-shift@1.0.3: {}
+
   streamsearch@1.1.0: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   stringify-entities@4.0.4:
     dependencies:
@@ -8316,6 +8376,8 @@ snapshots:
       '@types/react': 19.2.14
 
   utf8-byte-length@1.0.5: {}
+
+  util-deprecate@1.0.2: {}
 
   uuid@11.1.0: {}
 


### PR DESCRIPTION
## Résumé

E-N — **fil en direct temps réel** (jeu en réseau), conforme à l'ADR `docs/architecture/realtime-mvp.md`.

- `@fastify/websocket` (v11, Fastify 5) + un **`SessionHub`** en mémoire : **une room par slug de session**.
- Chaque **événement de journal committé** (action joueur, dé, décision MJ, résolution, rollback) est **diffusé** à tous les clients de la room, depuis le chemin transactionnel existant (`append → rules-core résout → commit → broadcast`).
- Les clients appliquent les événements **par `sequence`** et **resynchronisent** via `GET /sessions/:slug` sur trou. **Présence** (compteur) diffusée à la connexion/déconnexion.
- **MVP mono-instance** : le multi-instances est un ajout **additif** (mêmes payloads via Redis pub/sub), pas une réécriture.

**Invariant préservé** : le serveur (`rules-core`) reste autoritaire ; le socket ne fait que **diffuser** des événements déjà résolus, il ne calcule **jamais** de règle.

> Branché sur E-C (`feat/ec-session-journal`). Le câblage des surfaces client (`<SessionLiveProvider>` + store) est **E-S**. L'auth par token de capacité suit la posture REST actuelle (sans auth) — à ajouter de façon transverse ultérieurement.

## Test plan

- [x] `pnpm --filter @knightandwizard/server typecheck` — vert
- [x] `pnpm --filter @knightandwizard/server lint` — vert
- [x] Tests unitaires `SessionHub` (rooms, broadcast, présence, sockets fermés) — 4/4 verts
- [ ] CI Validate (build + tests + e2e) — le e2e session reste inchangé (pas d'abonnement WS côté client à ce stade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
