### PR TITLE
feat(session): surface Session en direct cote client (E-S etape 1)

### DIFF
--- a/apps/game/src/features/session-manager/SessionManager.tsx
+++ b/apps/game/src/features/session-manager/SessionManager.tsx
@@ -13,9 +13,9 @@ import {
   Users,
   XCircle
 } from 'lucide-react';
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { trpc } from '@/lib/trpc';
-import { buildSessionManagerView, type SessionManagerState } from './model';
+import { applyLiveSessionEvent, buildSessionManagerView, type SessionManagerState } from './model';
 import {
   appendDiceRollToSession,
   appendPersistedSessionEvent,
@@ -24,6 +24,8 @@ import {
   requestPersistedRollback,
   resolvePersistedGmDecision
 } from './persistence';
+import { toSessionEvent } from './session-api';
+import { useSessionLiveFeed } from './useSessionLiveFeed';
 
 const eventToneClasses = {
   audit: 'border-wine/25 bg-wine/8 text-wine',
@@ -52,6 +54,21 @@ export function SessionManager({ initialState }: Readonly<SessionManagerProps>) 
     view.rollbackTargets[0]?.sequence.toString() ?? ''
   );
   const busy = pendingAction !== null;
+
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const { connections: liveConnections, status: liveStatus } = useSessionLiveFeed(state.slug, {
+    onEvent: (persisted) => {
+      const outcome = applyLiveSessionEvent(stateRef.current, toSessionEvent(persisted));
+
+      if (outcome.kind === 'applied') {
+        setState(outcome.state);
+      } else if (outcome.kind === 'gap') {
+        void fetchPersistedSessionState(stateRef.current.slug).then(setState).catch(() => {});
+      }
+    }
+  });
 
   const effectiveRollbackSequence =
     rollbackSequence.length > 0
@@ -99,6 +116,14 @@ export function SessionManager({ initialState }: Readonly<SessionManagerProps>) 
             <h1 className="mt-1 text-3xl font-semibold text-ink">{state.title}</h1>
             <p className="mt-2 text-sm font-medium text-ink/62">
               {modeLabel(state.mode)} · {statusLabel(state.status)}
+            </p>
+            <p
+              className="mt-1 text-xs font-semibold text-forest"
+              data-testid="session-live-status"
+            >
+              {liveStatus === 'online'
+                ? `En direct · ${liveConnections} connecte${liveConnections > 1 ? 's' : ''}`
+                : 'Hors ligne'}
             </p>
           </div>
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-2">

--- a/apps/game/src/features/session-manager/SessionManager.tsx
+++ b/apps/game/src/features/session-manager/SessionManager.tsx
@@ -65,7 +65,9 @@ export function SessionManager({ initialState }: Readonly<SessionManagerProps>) 
       if (outcome.kind === 'applied') {
         setState(outcome.state);
       } else if (outcome.kind === 'gap') {
-        void fetchPersistedSessionState(stateRef.current.slug).then(setState).catch(() => {});
+        void fetchPersistedSessionState(stateRef.current.slug)
+          .then(setState)
+          .catch(() => {});
       }
     }
   });
@@ -117,10 +119,7 @@ export function SessionManager({ initialState }: Readonly<SessionManagerProps>) 
             <p className="mt-2 text-sm font-medium text-ink/62">
               {modeLabel(state.mode)} · {statusLabel(state.status)}
             </p>
-            <p
-              className="mt-1 text-xs font-semibold text-forest"
-              data-testid="session-live-status"
-            >
+            <p className="mt-1 text-xs font-semibold text-forest" data-testid="session-live-status">
               {liveStatus === 'online'
                 ? `En direct · ${liveConnections} connecte${liveConnections > 1 ? 's' : ''}`
                 : 'Hors ligne'}

--- a/apps/game/src/features/session-manager/model.test.ts
+++ b/apps/game/src/features/session-manager/model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { SessionPlayer, SessionScene } from '@knightandwizard/rules-core';
 import {
+  applyLiveSessionEvent,
   buildSessionManagerView,
   createSessionManagerState,
   recordSessionEvent,
@@ -210,3 +211,61 @@ function sampleScenes(): SessionScene[] {
     }
   ];
 }
+
+describe('applyLiveSessionEvent', () => {
+  const base = createSessionManagerState({
+    events: [
+      {
+        actorId: 'gm',
+        createdAt: '2026-04-30T10:00:00.000Z',
+        id: 'event-1',
+        payload: { location: 'Porte nord' },
+        sequence: 1,
+        type: 'scene_opened'
+      }
+    ]
+  });
+
+  it('appends the next sequential event to the immutable journal', () => {
+    const outcome = applyLiveSessionEvent(base, {
+      actorId: 'aveline',
+      createdAt: '2026-04-30T10:01:00.000Z',
+      id: 'event-2',
+      payload: { text: 'Aveline avance.' },
+      sequence: 2,
+      type: 'player_action'
+    });
+
+    expect(outcome.kind).toBe('applied');
+
+    if (outcome.kind === 'applied') {
+      expect(outcome.state.events.map((event) => event.sequence)).toEqual([1, 2]);
+    }
+  });
+
+  it('ignores an already-known sequence (idempotent dedupe)', () => {
+    const outcome = applyLiveSessionEvent(base, {
+      actorId: 'gm',
+      createdAt: '2026-04-30T10:00:00.000Z',
+      id: 'event-1',
+      payload: { location: 'Porte nord' },
+      sequence: 1,
+      type: 'scene_opened'
+    });
+
+    expect(outcome.kind).toBe('duplicate');
+  });
+
+  it('signals a gap when an event skips ahead, so the caller resyncs', () => {
+    const outcome = applyLiveSessionEvent(base, {
+      actorId: 'gm',
+      createdAt: '2026-04-30T10:05:00.000Z',
+      id: 'event-5',
+      payload: {},
+      sequence: 5,
+      type: 'dice_roll'
+    });
+
+    expect(outcome.kind).toBe('gap');
+  });
+});

--- a/apps/game/src/features/session-manager/model.ts
+++ b/apps/game/src/features/session-manager/model.ts
@@ -236,10 +236,7 @@ export function applyLiveSessionEvent(
   state: SessionManagerState,
   event: SessionEvent
 ): LiveSessionEventOutcome {
-  const maxSequence = state.events.reduce(
-    (max, current) => Math.max(max, current.sequence),
-    0
-  );
+  const maxSequence = state.events.reduce((max, current) => Math.max(max, current.sequence), 0);
 
   if (event.sequence <= maxSequence) {
     return { kind: 'duplicate' };

--- a/apps/game/src/features/session-manager/model.ts
+++ b/apps/game/src/features/session-manager/model.ts
@@ -221,6 +221,37 @@ export function requestRollbackFromEvent(
   );
 }
 
+export type LiveSessionEventOutcome =
+  | { kind: 'applied'; state: SessionManagerState }
+  | { kind: 'duplicate' }
+  | { kind: 'gap' };
+
+/**
+ * Applies a single live (broadcast) event to the local session state.
+ * The immutable journal grows strictly by `sequence`: an already-known sequence
+ * is a no-op (idempotent dedupe) and a forward gap signals the caller to
+ * resynchronise from the authoritative GET /sessions/:slug.
+ */
+export function applyLiveSessionEvent(
+  state: SessionManagerState,
+  event: SessionEvent
+): LiveSessionEventOutcome {
+  const maxSequence = state.events.reduce(
+    (max, current) => Math.max(max, current.sequence),
+    0
+  );
+
+  if (event.sequence <= maxSequence) {
+    return { kind: 'duplicate' };
+  }
+
+  if (event.sequence === maxSequence + 1) {
+    return { kind: 'applied', state: { ...state, events: [...state.events, event] } };
+  }
+
+  return { kind: 'gap' };
+}
+
 function getActiveScene(state: SessionManagerState): SessionScene | undefined {
   return state.scenes.find((scene) => scene.status === 'active') ?? state.scenes[0];
 }

--- a/apps/game/src/features/session-manager/session-api.ts
+++ b/apps/game/src/features/session-manager/session-api.ts
@@ -87,7 +87,7 @@ export function toSessionManagerState(snapshot: PersistedSessionSnapshot): Sessi
   });
 }
 
-function toSessionEvent(event: SessionEvent | PersistedSessionEvent): SessionEvent {
+export function toSessionEvent(event: SessionEvent | PersistedSessionEvent): SessionEvent {
   if ('type' in event) {
     return event;
   }

--- a/apps/game/src/features/session-manager/useSessionLiveFeed.ts
+++ b/apps/game/src/features/session-manager/useSessionLiveFeed.ts
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { getClientWsBaseUrl } from '../../lib/api';
+
+import type { PersistedSessionEvent } from './session-api';
+
+export type SessionLiveStatus = 'connecting' | 'offline' | 'online';
+
+interface SessionLiveMessage {
+  count?: number;
+  event?: PersistedSessionEvent;
+  kind?: string;
+  slug?: string;
+}
+
+export interface SessionLiveHandlers {
+  onEvent?: (event: PersistedSessionEvent) => void;
+  onPresence?: (count: number) => void;
+}
+
+export interface SessionLiveFeed {
+  connections: number;
+  status: SessionLiveStatus;
+}
+
+const RECONNECT_DELAY_MS = 2000;
+
+/**
+ * Subscribes to the live session room (E-N) over a WebSocket and forwards
+ * committed journal events + presence to the caller. Connection failures are
+ * non-fatal: the surface keeps working over REST and the feed reconnects.
+ */
+export function useSessionLiveFeed(slug: string, handlers: SessionLiveHandlers): SessionLiveFeed {
+  const [status, setStatus] = useState<SessionLiveStatus>('connecting');
+  const [connections, setConnections] = useState(0);
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof WebSocket === 'undefined' || slug.length === 0) {
+      return undefined;
+    }
+
+    const url = `${getClientWsBaseUrl()}/sessions/${encodeURIComponent(slug)}/live`;
+    let socket: WebSocket | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let disposed = false;
+
+    function connect(): void {
+      setStatus('connecting');
+
+      try {
+        socket = new WebSocket(url);
+      } catch {
+        if (!disposed) {
+          reconnectTimer = setTimeout(connect, RECONNECT_DELAY_MS);
+        }
+
+        return;
+      }
+
+      socket.onopen = () => setStatus('online');
+
+      socket.onmessage = (raw: MessageEvent) => {
+        if (typeof raw.data !== 'string') {
+          return;
+        }
+
+        let message: SessionLiveMessage;
+
+        try {
+          message = JSON.parse(raw.data) as SessionLiveMessage;
+        } catch {
+          return;
+        }
+
+        if (message.kind === 'session.event' && message.event) {
+          handlersRef.current.onEvent?.(message.event);
+        } else if (message.kind === 'session.presence' && typeof message.count === 'number') {
+          setConnections(message.count);
+          handlersRef.current.onPresence?.(message.count);
+        }
+      };
+
+      socket.onerror = () => socket?.close();
+
+      socket.onclose = () => {
+        setStatus('offline');
+
+        if (!disposed) {
+          reconnectTimer = setTimeout(connect, RECONNECT_DELAY_MS);
+        }
+      };
+    }
+
+    connect();
+
+    return () => {
+      disposed = true;
+
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+      }
+
+      socket?.close();
+    };
+  }, [slug]);
+
+  return { connections, status };
+}

--- a/apps/game/src/lib/api.ts
+++ b/apps/game/src/lib/api.ts
@@ -25,6 +25,11 @@ export function getClientApiBaseUrl(): string {
   return process.env.NEXT_PUBLIC_API_BASE_URL ?? DEFAULT_API_BASE_URL;
 }
 
+/** Same origin as the REST API, but over the WebSocket scheme (ws/wss). */
+export function getClientWsBaseUrl(): string {
+  return getClientApiBaseUrl().replace(/^http/i, 'ws');
+}
+
 export async function getApiHealth(): Promise<ApiHealthStatus> {
   const baseUrl = getApiBaseUrl();
 


### PR DESCRIPTION
## Résumé

E-S **étape 1** — la **surface Session devient temps réel** (le côté client de « jeu en réseau »), conforme à l'ADR `docs/architecture/realtime-mvp.md`.

- **`useSessionLiveFeed`** : ouvre la WebSocket de la room (`/sessions/:slug/live`, livrée en E-N), expose `status` + `connections` (présence), reconnecte automatiquement.
- **`applyLiveSessionEvent`** (réducteur pur, testé) : applique un événement diffusé **par `sequence`** — append séquentiel, **dedup idempotent**, **détection de trou → resync** via `GET /sessions/:slug`.
- **`SessionManager`** : applique les événements **distants** au journal en direct + affiche présence/statut. Le **chemin REST reste la mise à jour autoritaire de l'acteur**, donc la surface fonctionne même si la WebSocket tombe (dégradation propre — l'e2e existant reste vert).

**Effet** : deux navigateurs sur `/session` voient en direct les actions/dés/décisions/rollbacks l'un de l'autre. Le serveur reste autoritaire ; le client n'applique que des événements déjà résolus.

> Première étape d'E-S. Suite : promouvoir le feed en `<SessionLiveProvider>` de layout de route-group + store partagé (Zustand), puis **dé-mock** des autres surfaces (personnage, bestiaire, grimoire…). Un e2e à deux clients validera la synchro bout-en-bout.

## Test plan

- [x] `pnpm --filter @knightandwizard/game typecheck` — vert
- [x] `pnpm --filter @knightandwizard/game lint` — vert
- [x] Tests unitaires `applyLiveSessionEvent` (append / dedup / trou) + session-manager — **13/13** verts
- [ ] CI Validate (build + tests + e2e session inchangé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
