### PR TITLE
test(e2e): prouver la synchro multijoueur temps reel + /session?slug= (E-S)

### DIFF
--- a/apps/game/src/app/session/page.tsx
+++ b/apps/game/src/app/session/page.tsx
@@ -3,8 +3,15 @@ import { getSessionManagerReadModel } from '@/features/session-manager/read-mode
 
 export const dynamic = 'force-dynamic';
 
-export default async function SessionPage() {
-  const readModel = await getSessionManagerReadModel();
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export default async function SessionPage({
+  searchParams
+}: Readonly<{ searchParams: Promise<Record<string, string | string[] | undefined>> }>) {
+  const params = await searchParams;
+  const rawSlug = params.slug;
+  const slug = typeof rawSlug === 'string' && SLUG_PATTERN.test(rawSlug) ? rawSlug : undefined;
+  const readModel = await getSessionManagerReadModel(slug);
 
   return <SessionManager initialState={readModel.initialState} />;
 }

--- a/tests/e2e/session-multiplayer.spec.ts
+++ b/tests/e2e/session-multiplayer.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * End-to-end proof of "jeu en reseau" (E-C journal -> E-N broadcast -> E-S feed).
+ *
+ * Two independent browser contexts join the same session room. An action committed
+ * by one player must appear on the other player's screen with no reload and no action
+ * on their side: the only path for that text to reach them is the live WebSocket feed.
+ */
+test('two networked players see each other journal actions live', async ({ browser }) => {
+  const slug = `e2e-net-${Date.now()}`;
+  const url = `/session?slug=${slug}`;
+
+  const hostContext = await browser.newContext();
+  const guestContext = await browser.newContext();
+
+  try {
+    // Host creates + loads the room first, so the guest joins an existing session.
+    const host = await hostContext.newPage();
+    await host.goto(url);
+    await expect(host.getByRole('button', { name: 'RP' })).toBeVisible();
+
+    // Guest joins; wait until its live feed is actually connected before acting,
+    // otherwise a broadcast could fire before the guest is subscribed.
+    const guest = await guestContext.newPage();
+    await guest.goto(url);
+    await expect(guest.getByTestId('session-live-status')).toContainText('En direct');
+
+    // Host plays a role-play beat. The guest did nothing: this can only arrive live.
+    await host.getByRole('button', { name: 'RP' }).click();
+    await expect(guest.getByText('Aveline precise son intention.')).toBeVisible();
+
+    // A server-resolved dice roll from the host also propagates live to the guest.
+    await host.getByRole('button', { name: 'D10' }).click();
+    await expect(guest.getByText(/Jet de d/).first()).toBeVisible();
+  } finally {
+    await hostContext.close();
+    await guestContext.close();
+  }
+});


### PR DESCRIPTION
## Résumé

**Preuve bout-en-bout du « jeu en réseau »** (E-S) + petite capacité multi-session.

- **e2e à deux clients** (`tests/e2e/session-multiplayer.spec.ts`) : deux contextes navigateur rejoignent la même room. Une action committée par un joueur (RP, puis dé) apparaît **en direct** chez l'autre via le fil WebSocket — **sans rechargement, sans action de son côté**. Le seul chemin pour ce texte est le broadcast. Valide la chaîne **E-C (journal) → E-N (broadcast) → E-S (feed)**.
- L'invité n'agit qu'**après** que son indicateur affiche « En direct » (feed connecté) → pas de course à la jonction.
- **`/session?slug=`** : la page charge/crée une session par slug (slug validé). Rend l'e2e **hermétique** (slug unique par run, ne pollue pas `brumeval`) et ouvre le **multi-session**.

> Note : l'hôte crée la room puis l'invité la rejoint (séquentiel) — le cas de création **concurrente** exacte d'une room neuve (409/contrainte unique) reste à durcir (`INSERT ... ON CONFLICT`) en suivi.

## Test plan

- [x] `pnpm format:check` — vert
- [x] `pnpm lint` — vert
- [x] `pnpm typecheck` — vert (7/7)
- [ ] CI `test:e2e` — exécute le nouveau test à deux clients (nécessite les serveurs + devlab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
