### PR TITLE
docs(combat): regles provisoires a valider (table touches + allonge) + loi voix

### DIFF
--- a/docs/canonical/canonical-matrix.yaml
+++ b/docs/canonical/canonical-matrix.yaml
@@ -267201,7 +267201,7 @@ units:
     sources:
       - path: "docs/plan/COMBAT-IMPLEMENTATION.md"
         ref: "docs/plan/COMBAT-IMPLEMENTATION.md"
-        sha256: "07b1aaaa1eb88597b0d8915a000248919ed4412da59f09d6c8aec83d173432d4"
+        sha256: "10fa251fd441ea9b86ea623fc57a1d97fe44b11d34f644732168f6d0a075fb08"
     business_rule:
       summary: "docs/plan/COMBAT-IMPLEMENTATION.md from docs/plan/COMBAT-IMPLEMENTATION.md."
       ambiguity_ref: null

--- a/docs/canonical/nomos/canonical-matrix.yaml
+++ b/docs/canonical/nomos/canonical-matrix.yaml
@@ -136163,7 +136163,7 @@ units:
     source_refs:
       - source_id: DOCS-PLAN-COMBAT-IMPLEMENTATION
         locator: docs/plan/COMBAT-IMPLEMENTATION.md
-        hash: sha256:07b1aaaa1eb88597b0d8915a000248919ed4412da59f09d6c8aec83d173432d4
+        hash: sha256:10fa251fd441ea9b86ea623fc57a1d97fe44b11d34f644732168f6d0a075fb08
     business_rule: docs/plan/COMBAT-IMPLEMENTATION.md from docs/plan/COMBAT-IMPLEMENTATION.md.
     status: partial
     gaps:

--- a/docs/canonical/nomos/source-manifest.yaml
+++ b/docs/canonical/nomos/source-manifest.yaml
@@ -20552,7 +20552,7 @@ sources:
     domain: project-governance
     priority: derived
     status: active
-    hash: 07b1aaaa1eb88597b0d8915a000248919ed4412da59f09d6c8aec83d173432d4
+    hash: 10fa251fd441ea9b86ea623fc57a1d97fe44b11d34f644732168f6d0a075fb08
     owner: decarvalhoe
     license: proprietary
     confidentiality: internal

--- a/docs/canonical/source-manifest.yaml
+++ b/docs/canonical/source-manifest.yaml
@@ -13135,7 +13135,7 @@ sources:
     notes: "Project documentation source."
   - id: "docs-plan-combat-implementation"
     path: "docs/plan/COMBAT-IMPLEMENTATION.md"
-    sha256: "07b1aaaa1eb88597b0d8915a000248919ed4412da59f09d6c8aec83d173432d4"
+    sha256: "10fa251fd441ea9b86ea623fc57a1d97fe44b11d34f644732168f6d0a075fb08"
     source_type: generated_doc
     priority: 40
     status: active

--- a/docs/plan/COMBAT-IMPLEMENTATION.md
+++ b/docs/plan/COMBAT-IMPLEMENTATION.md
@@ -140,3 +140,54 @@ surprise (R-9.39), désengagement (R-9.38), tactiques de groupe (R-9.40), encoda
 
 - `docs/canonical/mecaniques-transversales.md` déclare la chaîne dégâts/défense « ABSENT » → **faux**
   désormais (`combat-damage.ts` l'implémente). Resynchroniser.
+
+## Loi UX transverse — « sortie explicite + voix »
+
+> **Toute mécanique qui produit un résultat émet (1) une sortie explicite typée ET (2) une ligne
+> de voix in-world.** À appliquer **systématiquement** : jet de dé, zone touchée, critique/D100,
+> chaque étape d'atténuation, application de statut, etc. La donnée sert le moteur ; la voix sert
+> l'immersion. (Directive propriétaire — saisir toutes les opportunités de ce type.)
+
+## Règles provisoires 🟡 (validées propriétaire, à formaliser en canon)
+
+> Statut **🟡 à valider** : actées pour l'implémentation, mais **non figées en 🟢**. À formaliser en
+> unités canoniques **R-9.45 (allonge)** et **R-9.46 (table des touches provisoire)** dans
+> `docs/rules/09-combat.md` (avec `ambiguity_ref`), et — pour la table — à **remplacer/confirmer par
+> le scan du rulebook papier** (OCR). Tracées ici pour ne pas les perdre.
+
+### R-9.46 (provisoire) — Table des Touches reconstruite 🟡
+
+Reconstruction depuis R-9.15 (effets de zone) + les 15 zones de `protections.yaml`, règle R-9.21/R-1.35
+« plus le D100 est haut, plus la zone est vitale ». **Sortie explicite** `{zone, damage_multiplier, allows_endurance}` **+ voix** par entrée. Tri par létalité : `×2 non endurable` (gorge) > `endurance interdite` (parties) > `×2 endurable` (tête).
+
+| D100  | Zone                 | ×mult | Endurance | Voix                                                       |
+| ----- | -------------------- | ----- | --------- | ---------------------------------------------------------- |
+| 01–04 | pied                 | 1     | oui       | « Au pied. Humiliant, rarement décisif. »                  |
+| 05–11 | bas_jambe            | 1     | oui       | « Au tibia — il dansera moins. »                           |
+| 12–14 | genou                | 1     | oui       | « Au genou. Ça lâche. »                                    |
+| 15–24 | haut_jambe           | 1     | oui       | « À la cuisse ; s'il s'en tire, il boitera. »              |
+| 25–29 | main                 | 1     | oui       | « À la main. Tenir son arme devient une opinion. »         |
+| 30–36 | avant_bras           | 1     | oui       | « À l'avant-bras. La parade s'en souviendra. »             |
+| 37–39 | coude                | 1     | oui       | « Au coude. Articulation contrariée. »                     |
+| 40–47 | haut_bras            | 1     | oui       | « Au bras. Le geste perd de son ampleur. »                 |
+| 48–51 | epaule               | 1     | oui       | « À l'épaule. Lever le bras devient négociable. »          |
+| 52–63 | ventre_bas_dos       | 1     | oui       | « En plein ventre. Le genre de coup dont on se souvient. » |
+| 64–75 | thorax_dos           | 1     | oui       | « En pleine poitrine. »                                    |
+| 76–82 | haut_thorax_haut_dos | 1     | oui       | « Haut du buste, près de ce qui compte. »                  |
+| 83–88 | tete                 | 2     | oui       | « En plein crâne. »                                        |
+| 89–92 | parties_genitales    | 1     | **non**   | « …là. Pas un mot de plus. »                               |
+| 93–00 | gorge_nuque          | 2     | **non**   | « À la gorge. Le sang n'attend pas. »                      |
+
+> `yeux` (×2, endurance interdite) = sous-zone de **précision** (action précise R-1.12), hors tirage
+> aléatoire. Voix : « Dans l'œil. Il ne verra pas venir le suivant. »
+
+### R-9.45 (provisoire) — Allonge de mêlée 🟡
+
+Nouveau champ `reach` (allonge) dans `armes.yaml` : **0** corps-à-corps serré (dague, couteau, poing) ·
+**1** standard (épée, hache, masse) · **2** longue (lance, hallebarde, pique). Défaut = 1.
+
+**Règle** : attaquer un adversaire à allonge **supérieure** ajoute **+1 difficulté par cran d'écart**
+sur **l'action offensive choisie par l'assaillant** (l'action _est_ l'attaque décidée — **pas
+d'action perdue, pas de double peine**). L'arme la plus longue frappe à distance de mêlée sans malus.
+**Sortie explicite** : `reach_gap` + le delta de difficulté ; **voix** : « Trop court — il faut entrer
+dans la garde. »


### PR DESCRIPTION
Annexe au registre combat : Table des Touches reconstruite (ordre de letalite corrige : gorge x2 non-endurable au sommet, tete sous parties/gorge) avec sortie explicite + voix par zone ; regle allonge (reach 0/1/2, +1 diff/cran, pas de double peine) ; loi UX transverse sortie-explicite + voix. Statut a valider (a formaliser en R-9.45/R-9.46). canonical:write + nomos:export resync.