### PR TITLE
feat(combat): interruptions R-9.4 + types reload/aim R-9.3 (V2a)

### DIFF
--- a/apps/game/src/features/combat-tracker/CombatTracker.tsx
+++ b/apps/game/src/features/combat-tracker/CombatTracker.tsx
@@ -7,9 +7,11 @@ import {
   Hourglass,
   Minus,
   Plus,
+  RotateCcw,
   Shield,
   Sparkles,
   Swords,
+  Target,
   Trash2,
   UserPlus
 } from 'lucide-react';
@@ -56,7 +58,9 @@ const actionIcons: Record<CombatActionType, typeof Swords> = {
   defense: Shield,
   move: Footprints,
   spell: Sparkles,
-  wait: Hourglass
+  wait: Hourglass,
+  reload: RotateCcw,
+  aim: Target
 };
 
 const actionLabels: Record<CombatActionType, string> = {
@@ -64,7 +68,9 @@ const actionLabels: Record<CombatActionType, string> = {
   defense: 'Défense',
   move: 'Mouvement',
   spell: 'Sort',
-  wait: 'Attente'
+  wait: 'Attente',
+  reload: 'Recharge',
+  aim: 'Visée'
 };
 
 interface CombatTrackerProps {

--- a/apps/game/src/features/combat-tracker/model.ts
+++ b/apps/game/src/features/combat-tracker/model.ts
@@ -72,7 +72,9 @@ const actionLabels: Record<CombatActionType, string> = {
   defense: 'défense',
   move: 'déplacement',
   spell: 'sort',
-  wait: 'attente'
+  wait: 'attente',
+  reload: 'recharge',
+  aim: 'visée'
 };
 
 const statusLabels: Record<string, string> = {

--- a/docs/canonical/canonical-matrix.yaml
+++ b/docs/canonical/canonical-matrix.yaml
@@ -267201,7 +267201,7 @@ units:
     sources:
       - path: "docs/plan/COMBAT-IMPLEMENTATION.md"
         ref: "docs/plan/COMBAT-IMPLEMENTATION.md"
-        sha256: "10fa251fd441ea9b86ea623fc57a1d97fe44b11d34f644732168f6d0a075fb08"
+        sha256: "383fa562c8d9a2198836081c0f8054d33e1e5d6b68e52c25b594e905bb67d011"
     business_rule:
       summary: "docs/plan/COMBAT-IMPLEMENTATION.md from docs/plan/COMBAT-IMPLEMENTATION.md."
       ambiguity_ref: null

--- a/docs/canonical/nomos/canonical-matrix.yaml
+++ b/docs/canonical/nomos/canonical-matrix.yaml
@@ -136163,7 +136163,7 @@ units:
     source_refs:
       - source_id: DOCS-PLAN-COMBAT-IMPLEMENTATION
         locator: docs/plan/COMBAT-IMPLEMENTATION.md
-        hash: sha256:10fa251fd441ea9b86ea623fc57a1d97fe44b11d34f644732168f6d0a075fb08
+        hash: sha256:383fa562c8d9a2198836081c0f8054d33e1e5d6b68e52c25b594e905bb67d011
     business_rule: docs/plan/COMBAT-IMPLEMENTATION.md from docs/plan/COMBAT-IMPLEMENTATION.md.
     status: partial
     gaps:

--- a/docs/canonical/nomos/source-manifest.yaml
+++ b/docs/canonical/nomos/source-manifest.yaml
@@ -20552,7 +20552,7 @@ sources:
     domain: project-governance
     priority: derived
     status: active
-    hash: 10fa251fd441ea9b86ea623fc57a1d97fe44b11d34f644732168f6d0a075fb08
+    hash: 383fa562c8d9a2198836081c0f8054d33e1e5d6b68e52c25b594e905bb67d011
     owner: decarvalhoe
     license: proprietary
     confidentiality: internal

--- a/docs/canonical/source-manifest.yaml
+++ b/docs/canonical/source-manifest.yaml
@@ -13135,7 +13135,7 @@ sources:
     notes: "Project documentation source."
   - id: "docs-plan-combat-implementation"
     path: "docs/plan/COMBAT-IMPLEMENTATION.md"
-    sha256: "10fa251fd441ea9b86ea623fc57a1d97fe44b11d34f644732168f6d0a075fb08"
+    sha256: "383fa562c8d9a2198836081c0f8054d33e1e5d6b68e52c25b594e905bb67d011"
     source_type: generated_doc
     priority: 40
     status: active

--- a/docs/plan/COMBAT-IMPLEMENTATION.md
+++ b/docs/plan/COMBAT-IMPLEMENTATION.md
@@ -40,20 +40,20 @@ surprise (R-9.39), désengagement (R-9.38), tactiques de groupe (R-9.40), encoda
 
 ### Timing / initiative
 
-| Règle                         | Objet                                               | Périmètre | Statut | Emplacement / écart                                      |
-| ----------------------------- | --------------------------------------------------- | --------- | ------ | -------------------------------------------------------- |
-| R-9.1                         | DT = 0,2 s, cycle 1→50                              | MVP       | ✅     | `combat.ts` `getCyclicDT`, `roundForDT`                  |
-| R-9.2                         | FV = délai d'action (déclare→FV→résout)             | MVP       | ✅     | `combat.ts` `actionCostDT`, `nextActionAt`               |
-| R-9.22                        | Timeline dynamique (pas d'initiative fixe)          | MVP       | ✅     | `combat.ts` `sortTimeline`                               |
-| R-9.23                        | Tie-break DT (simultané/Réflexes/conservée/arbitre) | MVP       | 🟡     | Réflexes+id ok ; préemption action conservée ❌          |
-| R-2.13                        | FV depuis la race                                   | MVP       | ✅     | attribut acteur                                          |
-| R-2.18                        | Encombrement → +1 FV / 5 kg                         | MVP       | ❌     | non recomposé au scheduling (moteur consomme un FV fixe) |
-| R-1.38                        | Sources de modif du FV (magie/atouts)               | MVP       | ❌     | `effects.ts` `factor` non appelé par `combat.ts`         |
-| R-9.4                         | Interruptions (DT perdus, 3 cas)                    | **MVP**   | ❌     | aucune op d'interruption                                 |
-| R-9.18-bis                    | Dégâts repoussent l'action (+1 DT/pt)               | MVP       | ✅     | `combat.ts` `applyDamage` (+finalDamage)                 |
-| R-1.24                        | Action conservée : +1 diff / pt subi                | V2        | ❌     | pas d'état temporel `damageDuringAction`                 |
-| R-9.3                         | Recharge = viser/recharger/tirer (3 actions)        | **MVP**   | ❌     | `AttackAction` mono-résolution                           |
-| atout `frappe-affaiblissante` | +FV sur cible blessée (50 DT/niv)                   | V2        | ❌     | catalogue seulement                                      |
+| Règle                         | Objet                                               | Périmètre | Statut | Emplacement / écart                                                                                            |
+| ----------------------------- | --------------------------------------------------- | --------- | ------ | -------------------------------------------------------------------------------------------------------------- |
+| R-9.1                         | DT = 0,2 s, cycle 1→50                              | MVP       | ✅     | `combat.ts` `getCyclicDT`, `roundForDT`                                                                        |
+| R-9.2                         | FV = délai d'action (déclare→FV→résout)             | MVP       | ✅     | `combat.ts` `actionCostDT`, `nextActionAt`                                                                     |
+| R-9.22                        | Timeline dynamique (pas d'initiative fixe)          | MVP       | ✅     | `combat.ts` `sortTimeline`                                                                                     |
+| R-9.23                        | Tie-break DT (simultané/Réflexes/conservée/arbitre) | MVP       | 🟡     | Réflexes+id ok ; préemption action conservée ❌                                                                |
+| R-2.13                        | FV depuis la race                                   | MVP       | ✅     | attribut acteur                                                                                                |
+| R-2.18                        | Encombrement → +1 FV / 5 kg                         | MVP       | ❌     | non recomposé au scheduling (moteur consomme un FV fixe)                                                       |
+| R-1.38                        | Sources de modif du FV (magie/atouts)               | MVP       | ❌     | `effects.ts` `factor` non appelé par `combat.ts`                                                               |
+| R-9.4                         | Interruptions (DT perdus, 3 cas)                    | **MVP**   | 🟡     | `interruptCombatant` (restart/release, DT perdus) ; perte d'énergie de sort différée (pas de modèle d'énergie) |
+| R-9.18-bis                    | Dégâts repoussent l'action (+1 DT/pt)               | MVP       | ✅     | `combat.ts` `applyDamage` (+finalDamage)                                                                       |
+| R-1.24                        | Action conservée : +1 diff / pt subi                | V2        | ❌     | pas d'état temporel `damageDuringAction`                                                                       |
+| R-9.3                         | Recharge = viser/recharger/tirer (3 actions)        | **MVP**   | 🟡     | types d'action `reload`/`aim` (coût FV) ; séquence imposée + stock munitions à venir                           |
+| atout `frappe-affaiblissante` | +FV sur cible blessée (50 DT/niv)                   | V2        | ❌     | catalogue seulement                                                                                            |
 
 ### Résolution touche / dégâts / atténuation
 

--- a/packages/rules-core/src/combat.test.ts
+++ b/packages/rules-core/src/combat.test.ts
@@ -6,6 +6,7 @@ import {
   applyStatus,
   createCombatState,
   getCyclicDT,
+  interruptCombatant,
   resolveNextAction,
   resolveStaminaDamage,
   type AttackAction
@@ -483,3 +484,48 @@ function scriptedRolls(values: number[]) {
     return value;
   };
 }
+
+describe('combat interruptions (R-9.4)', () => {
+  it('releases an interrupted actor at the current DT and loses the elapsed DT', () => {
+    const base = addCombatant(
+      createCombatState(1),
+      combatant({ id: 'archer', speedFactor: 7, reflexes: 3 })
+    );
+    const inProgress = {
+      ...base,
+      currentDT: 4,
+      timeline: base.timeline.map((entry) =>
+        entry.id === 'archer' ? { ...entry, pendingAction: { type: 'aim' as const } } : entry
+      )
+    };
+
+    const result = interruptCombatant(inProgress, 'archer', 'release');
+    const archer = result.timeline.find((entry) => entry.id === 'archer');
+
+    expect(archer?.nextActionAt).toBe(4);
+    expect(archer?.pendingAction).toBeUndefined();
+    const event = result.log.at(-1);
+    expect(event?.type).toBe('action_interrupted');
+    expect(event?.costDT).toBe(3);
+  });
+
+  it('restarts the same action paying the full speed factor again', () => {
+    const base = addCombatant(
+      createCombatState(1),
+      combatant({ id: 'archer', speedFactor: 7, reflexes: 3 })
+    );
+    const inProgress = {
+      ...base,
+      currentDT: 4,
+      timeline: base.timeline.map((entry) =>
+        entry.id === 'archer' ? { ...entry, pendingAction: { type: 'aim' as const } } : entry
+      )
+    };
+
+    const result = interruptCombatant(inProgress, 'archer', 'restart');
+    const archer = result.timeline.find((entry) => entry.id === 'archer');
+
+    expect(archer?.nextActionAt).toBe(11);
+    expect(archer?.pendingAction).toEqual({ type: 'aim' });
+  });
+});

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -12,7 +12,7 @@ import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
 export const COMBAT_ROUND_LENGTH_DT = DEFAULT_RULES_CONFIG.combat.roundLengthDT;
 
 export type TimelineDirection = '+' | '-' | '';
-export type CombatActionType = 'attack' | 'defense' | 'spell' | 'move' | 'wait';
+export type CombatActionType = 'attack' | 'defense' | 'spell' | 'move' | 'wait' | 'reload' | 'aim';
 export type CombatStatusId = 'bleeding' | 'stunned' | 'unconscious' | 'dead' | string;
 
 export interface CombatAttributes {
@@ -79,7 +79,25 @@ export interface WaitAction {
   costDT?: number;
 }
 
-export type CombatAction = AttackAction | DefenseAction | SpellAction | MoveAction | WaitAction;
+/** R-9.3 — Ballistic preparation steps; each takes the actor's speed factor in DT. */
+export interface ReloadAction {
+  type: 'reload';
+  costDT?: number;
+}
+
+export interface AimAction {
+  type: 'aim';
+  costDT?: number;
+}
+
+export type CombatAction =
+  | AttackAction
+  | DefenseAction
+  | SpellAction
+  | MoveAction
+  | WaitAction
+  | ReloadAction
+  | AimAction;
 
 export type CombatDamageBreakdown = CombatDamageResult;
 
@@ -101,6 +119,7 @@ export interface Combatant {
 export interface CombatEvent {
   type:
     | 'action_resolved'
+    | 'action_interrupted'
     | 'attack_resolved'
     | 'damage_applied'
     | 'status_applied'
@@ -329,6 +348,51 @@ export function applyStatus(
       ]
     },
     nextTarget
+  );
+}
+
+export type InterruptOutcome = 'restart' | 'release';
+
+/**
+ * R-9.4 — Interrupts a combatant's in-progress action. The DT already invested
+ * since declaration are LOST (no partial benefit). With `release` the actor is
+ * freed at the current DT; with `restart` it re-attempts the same action and pays
+ * its full speed-factor cost again from now. Spell energy loss (R-9.31) applies
+ * once energy is modeled.
+ */
+export function interruptCombatant(
+  state: CombatState,
+  combatantId: string,
+  outcome: InterruptOutcome = 'release'
+): CombatState {
+  const target = findCombatant(state, combatantId);
+  const interruptedAction = target.pendingAction;
+  const cost = interruptedAction ? actionCostDT(target, interruptedAction) : 0;
+  const remaining = Math.max(0, target.nextActionAt - state.currentDT);
+  const lostDT = Math.max(0, cost - remaining);
+  const restart = outcome === 'restart' && interruptedAction !== undefined;
+  const next: Combatant = {
+    ...target,
+    nextActionAt: restart ? state.currentDT + cost : state.currentDT,
+    pendingAction: restart ? interruptedAction : undefined
+  };
+
+  return replaceCombatant(
+    {
+      ...state,
+      log: [
+        ...state.log,
+        {
+          type: 'action_interrupted',
+          atDT: state.currentDT,
+          actorId: combatantId,
+          actionType: interruptedAction?.type,
+          costDT: lostDT,
+          nextActionAt: next.nextActionAt
+        }
+      ]
+    },
+    next
   );
 }
 


### PR DESCRIPTION
V2a timing : interruptCombatant (R-9.4, restart/release, DT ecoules perdus) + types daction reload/aim (R-9.3, cout FV). 22 tests rules-core verts (dont 2 nouveaux). Registre maj R-9.3/R-9.4 -> 🟡. canonical:write + nomos:export resync.