### PR TITLE
feat(combat): facteur de vitesse effectif — encombrement R-2.18 + effets FV R-1.38 (V2b)

### DIFF
--- a/docs/canonical/canonical-matrix.yaml
+++ b/docs/canonical/canonical-matrix.yaml
@@ -136138,23 +136138,23 @@ units:
       status: not_applicable
       evidence: "No Zod schema required."
     relational_db:
-      status: partial
-      evidence: "Canonical relational tables/import evidence pending."
+      status: not_applicable
+      evidence: "Speed-factor modifiers are derived at runtime from a combatant active effects; there is no dedicated relational projection of the modifier."
     vector_store:
       status: covered
       evidence: "Indexed from source manifest by knowledge indexer."
     rules_core:
-      status: partial
-      evidence: "Rules-core behavior evidence pending or must be linked."
+      status: covered
+      evidence: "packages/rules-core/src/combat.ts effectiveSpeedFactor feeds the loaded base speed factor through effects.ts computeEffectiveModifiers on the \"factor\" target, so magic (haste/slowness) and atouts modify the action delay; the result is rounded and floored at combat.minSpeedFactor. Files: packages/rules-core/src/combat.ts, packages/rules-core/src/effects.ts. Tests: packages/rules-core/src/combat.test.ts."
     api:
-      status: partial
-      evidence: "Downstream API evidence pending."
+      status: not_applicable
+      evidence: "No dedicated endpoint; effect-modified scheduling is computed by rules-core and surfaced through session/combat flows."
     ui:
       status: partial
       evidence: "UI exposure evidence pending."
     tests:
-      status: partial
-      evidence: "Automated coverage evidence pending."
+      status: covered
+      evidence: "packages/rules-core/src/combat.test.ts covers haste lowering and slowness raising the effective factor via factor-target effects, including the minimum floor."
   - unit_id: "R-1.39"
     unit_type: "rule"
     domain: "D1-resolution"
@@ -140890,23 +140890,23 @@ units:
       status: not_applicable
       evidence: "No Zod schema required."
     relational_db:
-      status: partial
-      evidence: "Canonical relational tables/import evidence pending."
+      status: not_applicable
+      evidence: "Encumbrance is a runtime scheduling computation; carried weight comes from character/equipment projections, there is no dedicated relational table for the speed-factor penalty."
     vector_store:
       status: covered
       evidence: "Indexed from source manifest by knowledge indexer."
     rules_core:
-      status: partial
-      evidence: "Rules-core behavior evidence pending or must be linked."
+      status: covered
+      evidence: "packages/rules-core/src/combat.ts encumbrancePenalty adds +1 DT per full combat.encumbranceKgPerStep kg carried above strength * combat.encumbranceKgPerStrength, using the current Force (so weakening shrinks capacity); effectiveSpeedFactor applies it to scheduling and initial timeline placement. Files: packages/rules-core/src/combat.ts, packages/rules-core/src/rules-config.ts. Tests: packages/rules-core/src/combat.test.ts."
     api:
-      status: partial
-      evidence: "Downstream API evidence pending."
+      status: not_applicable
+      evidence: "No dedicated endpoint; combat scheduling is computed by rules-core and surfaced through session/combat flows."
     ui:
       status: partial
       evidence: "UI exposure evidence pending."
     tests:
-      status: partial
-      evidence: "Automated coverage evidence pending."
+      status: covered
+      evidence: "packages/rules-core/src/combat.test.ts covers the +1-per-5kg-over-Force*5 penalty, the exact-threshold boundary, and Force loss shrinking capacity."
   - unit_id: "R-2.19"
     unit_type: "rule"
     domain: "D2-attributs"
@@ -267201,7 +267201,7 @@ units:
     sources:
       - path: "docs/plan/COMBAT-IMPLEMENTATION.md"
         ref: "docs/plan/COMBAT-IMPLEMENTATION.md"
-        sha256: "383fa562c8d9a2198836081c0f8054d33e1e5d6b68e52c25b594e905bb67d011"
+        sha256: "44189d3739a8bc526fa9f282cc1b8e36d448fccba9ccb9997fd4f3009180e693"
     business_rule:
       summary: "docs/plan/COMBAT-IMPLEMENTATION.md from docs/plan/COMBAT-IMPLEMENTATION.md."
       ambiguity_ref: null

--- a/docs/canonical/nomos/canonical-matrix.yaml
+++ b/docs/canonical/nomos/canonical-matrix.yaml
@@ -72527,11 +72527,7 @@ units:
       docs/rules/01-resolution.md.
     status: partial
     gaps:
-      - 'relational_db: Canonical relational tables/import evidence pending.'
-      - 'rules_core: Rules-core behavior evidence pending or must be linked.'
-      - 'api: Downstream API evidence pending.'
       - 'ui: UI exposure evidence pending.'
-      - 'tests: Automated coverage evidence pending.'
     vector_refs:
       - collection: knowledge_chunks
   - unit_id: R-1-39
@@ -75104,11 +75100,7 @@ units:
       docs/rules/02-attributs.md.
     status: partial
     gaps:
-      - 'relational_db: Canonical relational tables/import evidence pending.'
-      - 'rules_core: Rules-core behavior evidence pending or must be linked.'
-      - 'api: Downstream API evidence pending.'
       - 'ui: UI exposure evidence pending.'
-      - 'tests: Automated coverage evidence pending.'
     vector_refs:
       - collection: knowledge_chunks
   - unit_id: R-2-19
@@ -136163,7 +136155,7 @@ units:
     source_refs:
       - source_id: DOCS-PLAN-COMBAT-IMPLEMENTATION
         locator: docs/plan/COMBAT-IMPLEMENTATION.md
-        hash: sha256:383fa562c8d9a2198836081c0f8054d33e1e5d6b68e52c25b594e905bb67d011
+        hash: sha256:44189d3739a8bc526fa9f282cc1b8e36d448fccba9ccb9997fd4f3009180e693
     business_rule: docs/plan/COMBAT-IMPLEMENTATION.md from docs/plan/COMBAT-IMPLEMENTATION.md.
     status: partial
     gaps:

--- a/docs/canonical/nomos/source-manifest.yaml
+++ b/docs/canonical/nomos/source-manifest.yaml
@@ -20552,7 +20552,7 @@ sources:
     domain: project-governance
     priority: derived
     status: active
-    hash: 383fa562c8d9a2198836081c0f8054d33e1e5d6b68e52c25b594e905bb67d011
+    hash: 44189d3739a8bc526fa9f282cc1b8e36d448fccba9ccb9997fd4f3009180e693
     owner: decarvalhoe
     license: proprietary
     confidentiality: internal

--- a/docs/canonical/rule-evidence.yaml
+++ b/docs/canonical/rule-evidence.yaml
@@ -141,3 +141,43 @@ R-3.5:
       - 'apps/server/src/routes/catalogs.test.ts:25'
       - 'apps/game/src/features/character-creation/model.test.ts:20'
       - 'apps/game/src/features/character-creation/model.test.ts:120'
+
+R-1.38:
+  ambiguity_ref: null
+  rules_core:
+    status: covered
+    evidence: 'packages/rules-core/src/combat.ts effectiveSpeedFactor feeds the loaded base speed factor through effects.ts computeEffectiveModifiers on the "factor" target, so magic (haste/slowness) and atouts modify the action delay; the result is rounded and floored at combat.minSpeedFactor.'
+    files:
+      - 'packages/rules-core/src/combat.ts'
+      - 'packages/rules-core/src/effects.ts'
+    tests:
+      - 'packages/rules-core/src/combat.test.ts'
+  relational_db:
+    status: not_applicable
+    evidence: 'Speed-factor modifiers are derived at runtime from a combatant active effects; there is no dedicated relational projection of the modifier.'
+  api:
+    status: not_applicable
+    evidence: 'No dedicated endpoint; effect-modified scheduling is computed by rules-core and surfaced through session/combat flows.'
+  tests:
+    status: covered
+    evidence: 'packages/rules-core/src/combat.test.ts covers haste lowering and slowness raising the effective factor via factor-target effects, including the minimum floor.'
+
+R-2.18:
+  ambiguity_ref: null
+  rules_core:
+    status: covered
+    evidence: 'packages/rules-core/src/combat.ts encumbrancePenalty adds +1 DT per full combat.encumbranceKgPerStep kg carried above strength * combat.encumbranceKgPerStrength, using the current Force (so weakening shrinks capacity); effectiveSpeedFactor applies it to scheduling and initial timeline placement.'
+    files:
+      - 'packages/rules-core/src/combat.ts'
+      - 'packages/rules-core/src/rules-config.ts'
+    tests:
+      - 'packages/rules-core/src/combat.test.ts'
+  relational_db:
+    status: not_applicable
+    evidence: 'Encumbrance is a runtime scheduling computation; carried weight comes from character/equipment projections, there is no dedicated relational table for the speed-factor penalty.'
+  api:
+    status: not_applicable
+    evidence: 'No dedicated endpoint; combat scheduling is computed by rules-core and surfaced through session/combat flows.'
+  tests:
+    status: covered
+    evidence: 'packages/rules-core/src/combat.test.ts covers the +1-per-5kg-over-Force*5 penalty, the exact-threshold boundary, and Force loss shrinking capacity.'

--- a/docs/canonical/source-manifest.yaml
+++ b/docs/canonical/source-manifest.yaml
@@ -13135,7 +13135,7 @@ sources:
     notes: "Project documentation source."
   - id: "docs-plan-combat-implementation"
     path: "docs/plan/COMBAT-IMPLEMENTATION.md"
-    sha256: "383fa562c8d9a2198836081c0f8054d33e1e5d6b68e52c25b594e905bb67d011"
+    sha256: "44189d3739a8bc526fa9f282cc1b8e36d448fccba9ccb9997fd4f3009180e693"
     source_type: generated_doc
     priority: 40
     status: active

--- a/docs/plan/COMBAT-IMPLEMENTATION.md
+++ b/docs/plan/COMBAT-IMPLEMENTATION.md
@@ -40,20 +40,20 @@ surprise (R-9.39), désengagement (R-9.38), tactiques de groupe (R-9.40), encoda
 
 ### Timing / initiative
 
-| Règle                         | Objet                                               | Périmètre | Statut | Emplacement / écart                                                                                            |
-| ----------------------------- | --------------------------------------------------- | --------- | ------ | -------------------------------------------------------------------------------------------------------------- |
-| R-9.1                         | DT = 0,2 s, cycle 1→50                              | MVP       | ✅     | `combat.ts` `getCyclicDT`, `roundForDT`                                                                        |
-| R-9.2                         | FV = délai d'action (déclare→FV→résout)             | MVP       | ✅     | `combat.ts` `actionCostDT`, `nextActionAt`                                                                     |
-| R-9.22                        | Timeline dynamique (pas d'initiative fixe)          | MVP       | ✅     | `combat.ts` `sortTimeline`                                                                                     |
-| R-9.23                        | Tie-break DT (simultané/Réflexes/conservée/arbitre) | MVP       | 🟡     | Réflexes+id ok ; préemption action conservée ❌                                                                |
-| R-2.13                        | FV depuis la race                                   | MVP       | ✅     | attribut acteur                                                                                                |
-| R-2.18                        | Encombrement → +1 FV / 5 kg                         | MVP       | ❌     | non recomposé au scheduling (moteur consomme un FV fixe)                                                       |
-| R-1.38                        | Sources de modif du FV (magie/atouts)               | MVP       | ❌     | `effects.ts` `factor` non appelé par `combat.ts`                                                               |
-| R-9.4                         | Interruptions (DT perdus, 3 cas)                    | **MVP**   | 🟡     | `interruptCombatant` (restart/release, DT perdus) ; perte d'énergie de sort différée (pas de modèle d'énergie) |
-| R-9.18-bis                    | Dégâts repoussent l'action (+1 DT/pt)               | MVP       | ✅     | `combat.ts` `applyDamage` (+finalDamage)                                                                       |
-| R-1.24                        | Action conservée : +1 diff / pt subi                | V2        | ❌     | pas d'état temporel `damageDuringAction`                                                                       |
-| R-9.3                         | Recharge = viser/recharger/tirer (3 actions)        | **MVP**   | 🟡     | types d'action `reload`/`aim` (coût FV) ; séquence imposée + stock munitions à venir                           |
-| atout `frappe-affaiblissante` | +FV sur cible blessée (50 DT/niv)                   | V2        | ❌     | catalogue seulement                                                                                            |
+| Règle                         | Objet                                               | Périmètre | Statut | Emplacement / écart                                                                                                     |
+| ----------------------------- | --------------------------------------------------- | --------- | ------ | ----------------------------------------------------------------------------------------------------------------------- |
+| R-9.1                         | DT = 0,2 s, cycle 1→50                              | MVP       | ✅     | `combat.ts` `getCyclicDT`, `roundForDT`                                                                                 |
+| R-9.2                         | FV = délai d'action (déclare→FV→résout)             | MVP       | ✅     | `combat.ts` `actionCostDT`, `nextActionAt`                                                                              |
+| R-9.22                        | Timeline dynamique (pas d'initiative fixe)          | MVP       | ✅     | `combat.ts` `sortTimeline`                                                                                              |
+| R-9.23                        | Tie-break DT (simultané/Réflexes/conservée/arbitre) | MVP       | 🟡     | Réflexes+id ok ; préemption action conservée ❌                                                                         |
+| R-2.13                        | FV depuis la race                                   | MVP       | ✅     | attribut acteur                                                                                                         |
+| R-2.18                        | Encombrement → +1 FV / 5 kg                         | MVP       | ✅     | `combat.ts` `effectiveSpeedFactor`/`encumbrancePenalty` (+1 DT par 5 kg > Force×5, Force courante) ; `rules-config.ts`  |
+| R-1.38                        | Sources de modif du FV (magie/atouts)               | MVP       | ✅     | `combat.ts` `effectiveSpeedFactor` appelle `effects.ts` cible `factor` (hâte/lenteur/atouts), plancher `minSpeedFactor` |
+| R-9.4                         | Interruptions (DT perdus, 3 cas)                    | **MVP**   | 🟡     | `interruptCombatant` (restart/release, DT perdus) ; perte d'énergie de sort différée (pas de modèle d'énergie)          |
+| R-9.18-bis                    | Dégâts repoussent l'action (+1 DT/pt)               | MVP       | ✅     | `combat.ts` `applyDamage` (+finalDamage)                                                                                |
+| R-1.24                        | Action conservée : +1 diff / pt subi                | V2        | ❌     | pas d'état temporel `damageDuringAction`                                                                                |
+| R-9.3                         | Recharge = viser/recharger/tirer (3 actions)        | **MVP**   | 🟡     | types d'action `reload`/`aim` (coût FV) ; séquence imposée + stock munitions à venir                                    |
+| atout `frappe-affaiblissante` | +FV sur cible blessée (50 DT/niv)                   | V2        | ❌     | catalogue seulement                                                                                                     |
 
 ### Résolution touche / dégâts / atténuation
 

--- a/packages/rules-core/src/combat.test.ts
+++ b/packages/rules-core/src/combat.test.ts
@@ -5,12 +5,15 @@ import {
   applyDamage,
   applyStatus,
   createCombatState,
+  effectiveSpeedFactor,
   getCyclicDT,
   interruptCombatant,
   resolveNextAction,
   resolveStaminaDamage,
-  type AttackAction
+  type AttackAction,
+  type Combatant
 } from './combat.js';
+import { parseEffectModel, type EffectModel } from './effect-model.js';
 
 describe('combat DT timeline', () => {
   it('wraps the legacy 1-50 DT counter', () => {
@@ -529,3 +532,97 @@ describe('combat interruptions (R-9.4)', () => {
     expect(archer?.pendingAction).toEqual({ type: 'aim' });
   });
 });
+
+describe('effective speed factor (R-2.18 encumbrance / R-1.38 effects)', () => {
+  it('adds no penalty at or below the carrying capacity (Force x 5 kg)', () => {
+    expect(effectiveSpeedFactor(loaded({ speedFactor: 5, strength: 3, carriedWeightKg: 15 }))).toBe(
+      5
+    );
+  });
+
+  it('adds +1 speed factor per full 5 kg above the capacity', () => {
+    // Force 3 -> capacity 15 kg.
+    expect(
+      effectiveSpeedFactor(loaded({ speedFactor: 5, strength: 3, carriedWeightKg: 15.1 }))
+    ).toBe(6);
+    expect(effectiveSpeedFactor(loaded({ speedFactor: 5, strength: 3, carriedWeightKg: 20 }))).toBe(
+      6
+    );
+    expect(
+      effectiveSpeedFactor(loaded({ speedFactor: 5, strength: 3, carriedWeightKg: 20.1 }))
+    ).toBe(7);
+  });
+
+  it('shrinks carrying capacity when Force drops (R-2.18 edge case)', () => {
+    expect(effectiveSpeedFactor(loaded({ speedFactor: 5, strength: 5, carriedWeightKg: 22 }))).toBe(
+      5
+    );
+    expect(effectiveSpeedFactor(loaded({ speedFactor: 5, strength: 3, carriedWeightKg: 22 }))).toBe(
+      7
+    );
+  });
+
+  it('lets haste lower and slowness raise the effective factor (R-1.38)', () => {
+    expect(
+      effectiveSpeedFactor(loaded({ speedFactor: 7, activeEffects: [factorEffect('sub', 2)] }))
+    ).toBe(5);
+    expect(
+      effectiveSpeedFactor(loaded({ speedFactor: 5, activeEffects: [factorEffect('add', 3)] }))
+    ).toBe(8);
+  });
+
+  it('combines encumbrance with effects and floors at the minimum speed factor', () => {
+    expect(
+      effectiveSpeedFactor(
+        loaded({
+          speedFactor: 5,
+          strength: 3,
+          carriedWeightKg: 20.1,
+          activeEffects: [factorEffect('sub', 1)]
+        })
+      )
+    ).toBe(6);
+    expect(
+      effectiveSpeedFactor(loaded({ speedFactor: 5, activeEffects: [factorEffect('sub', 100)] }))
+    ).toBe(1);
+  });
+
+  it('schedules the first action by the effective (encumbered) speed factor', () => {
+    const state = addCombatant(
+      createCombatState(1),
+      loaded({ id: 'porter', speedFactor: 5, strength: 3, carriedWeightKg: 20.1 })
+    );
+
+    expect(state.timeline[0].nextActionAt).toBe(8);
+  });
+});
+
+function loaded(props: {
+  id?: string;
+  speedFactor?: number;
+  strength?: number;
+  carriedWeightKg?: number;
+  activeEffects?: EffectModel[];
+}): Combatant {
+  return {
+    id: props.id ?? 'loaded',
+    name: 'Loaded',
+    speedFactor: props.speedFactor ?? 5,
+    nextActionAt: 0,
+    reflexes: 3,
+    vitality: { current: 10, max: 10 },
+    attributes: { strength: props.strength ?? 5, dexterity: 5, stamina: 5 },
+    skills: {},
+    statuses: [],
+    ...(props.carriedWeightKg === undefined ? {} : { carriedWeightKg: props.carriedWeightKg }),
+    ...(props.activeEffects === undefined ? {} : { activeEffects: props.activeEffects })
+  };
+}
+
+function factorEffect(op: 'add' | 'sub', value: number): EffectModel {
+  return parseEffectModel({
+    source: { prose: 'Fixture speed-factor effect.', ref: 'fixture:factor' },
+    spec: { target: 'factor', op, value, activation: 'passive', duration: 'permanent' },
+    fidelity: 'covered'
+  });
+}

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -8,6 +8,8 @@ import {
 } from './combat-damage.js';
 import { type DiceRollResult, type RandomInteger, rollDice } from './dice.js';
 import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
+import { type EffectModel } from './effect-model.js';
+import { effectiveValue } from './effects.js';
 
 export const COMBAT_ROUND_LENGTH_DT = DEFAULT_RULES_CONFIG.combat.roundLengthDT;
 
@@ -114,6 +116,10 @@ export interface Combatant {
   statuses: CombatStatus[];
   ignoresVitalityMalus?: boolean;
   pendingAction?: CombatAction;
+  /** R-2.18 — total carried equipment weight in kg; drives the encumbrance speed penalty. */
+  carriedWeightKg?: number;
+  /** R-1.38 — active effects that may modify the speed factor (haste, slowness, atouts). */
+  activeEffects?: EffectModel[];
 }
 
 export interface CombatEvent {
@@ -207,7 +213,7 @@ export function addCombatant(
       nextActionAt:
         combatant.nextActionAt > 0
           ? combatant.nextActionAt
-          : state.currentDT + combatant.speedFactor
+          : state.currentDT + effectiveSpeedFactor(combatant, config)
     },
     config
   );
@@ -233,7 +239,7 @@ export function resolveNextAction(
   const timeline = sortTimeline(state.timeline);
   const actor = timeline[0];
   const action = actor.pendingAction ?? { type: 'wait' };
-  const costDT = actionCostDT(actor, action);
+  const costDT = actionCostDT(actor, action, config);
   const currentDT = actor.nextActionAt;
   const nextActionAt = currentDT + costDT;
   const activeState: CombatState = {
@@ -247,7 +253,8 @@ export function resolveNextAction(
     return rescheduleActor(
       resolveAttack(activeState, actor, action, { costDT, nextActionAt }, options, config),
       actor.id,
-      action
+      action,
+      config
     );
   }
 
@@ -266,7 +273,8 @@ export function resolveNextAction(
       log: [...activeState.log, event]
     },
     actor.id,
-    action
+    action,
+    config
   );
 }
 
@@ -363,11 +371,12 @@ export type InterruptOutcome = 'restart' | 'release';
 export function interruptCombatant(
   state: CombatState,
   combatantId: string,
-  outcome: InterruptOutcome = 'release'
+  outcome: InterruptOutcome = 'release',
+  config: RulesConfig = DEFAULT_RULES_CONFIG
 ): CombatState {
   const target = findCombatant(state, combatantId);
   const interruptedAction = target.pendingAction;
-  const cost = interruptedAction ? actionCostDT(target, interruptedAction) : 0;
+  const cost = interruptedAction ? actionCostDT(target, interruptedAction, config) : 0;
   const remaining = Math.max(0, target.nextActionAt - state.currentDT);
   const lostDT = Math.max(0, cost - remaining);
   const restart = outcome === 'restart' && interruptedAction !== undefined;
@@ -487,9 +496,14 @@ function resolveAttack(
   return withAttackLog;
 }
 
-function rescheduleActor(state: CombatState, actorId: string, action: CombatAction): CombatState {
+function rescheduleActor(
+  state: CombatState,
+  actorId: string,
+  action: CombatAction,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): CombatState {
   const actor = findCombatant(state, actorId);
-  const delay = actionCostDT(actor, action);
+  const delay = actionCostDT(actor, action, config);
 
   return replaceCombatant(state, {
     ...actor,
@@ -498,8 +512,50 @@ function rescheduleActor(state: CombatState, actorId: string, action: CombatActi
   });
 }
 
-function actionCostDT(actor: Combatant, action: CombatAction): number {
-  return action.costDT ?? actor.speedFactor;
+function actionCostDT(
+  actor: Combatant,
+  action: CombatAction,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): number {
+  return action.costDT ?? effectiveSpeedFactor(actor, config);
+}
+
+/**
+ * R-2.18 / R-1.38 — Effective speed factor used to schedule a combatant's actions.
+ *
+ * Starts from the base (racial) speed factor, adds the encumbrance penalty (R-2.18:
+ * +1 DT per full `encumbranceKgPerStep` kg carried above `strength *
+ * encumbranceKgPerStrength`, using the CURRENT Force so weakening shrinks capacity),
+ * then applies magic/atout effects targeting `factor` (R-1.38: haste lowers, slowness
+ * raises). The result is rounded and floored at `minSpeedFactor`.
+ */
+export function effectiveSpeedFactor(
+  actor: Combatant,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): number {
+  const loadedBase = actor.speedFactor + encumbrancePenalty(actor, config);
+  const effects = actor.activeEffects ?? [];
+
+  if (effects.length === 0) {
+    return Math.max(config.combat.minSpeedFactor, loadedBase);
+  }
+
+  const modified = effectiveValue(loadedBase, 'factor', undefined, effects, {});
+
+  return Math.max(config.combat.minSpeedFactor, Math.round(modified));
+}
+
+function encumbrancePenalty(actor: Combatant, config: RulesConfig): number {
+  const carried = actor.carriedWeightKg;
+
+  if (carried === undefined || carried <= 0) {
+    return 0;
+  }
+
+  const capacity = actor.attributes.strength * config.combat.encumbranceKgPerStrength;
+  const excess = Math.max(0, carried - capacity);
+
+  return Math.ceil(excess / config.combat.encumbranceKgPerStep);
 }
 
 function randomIntegerForResolution(options: CombatResolutionOptions): RandomInteger {

--- a/packages/rules-core/src/rules-config.ts
+++ b/packages/rules-core/src/rules-config.ts
@@ -15,6 +15,12 @@ export interface CombatRulesConfig {
   unconsciousDamageRatio: number;
   /** Vitality malus = round(vitality.max * this ratio) - vitality.current (clamped >= 0). */
   vitalityMalusRatio: number;
+  /** R-2.18 — carrying capacity without speed penalty = strength * this (kg). */
+  encumbranceKgPerStrength: number;
+  /** R-2.18 — each full step of this many kg above capacity adds +1 to the speed factor. */
+  encumbranceKgPerStep: number;
+  /** R-1.38 — lower bound for the effective speed factor in DT (an action costs >= this). */
+  minSpeedFactor: number;
 }
 
 export interface CreationRulesConfig {
@@ -81,7 +87,10 @@ export const DEFAULT_RULES_CONFIG: RulesConfig = {
     roundLengthDT: 50,
     staminaRollDifficulty: 7,
     unconsciousDamageRatio: 0.5,
-    vitalityMalusRatio: 0.5
+    vitalityMalusRatio: 0.5,
+    encumbranceKgPerStrength: 5,
+    encumbranceKgPerStep: 5,
+    minSpeedFactor: 1
   },
   creation: {
     attributeMaxOffset: 1,


### PR DESCRIPTION
## Contexte

Chantier Combat, vague « Moteur — timing ». V2a (interruptions R-9.4, recharge R-9.3) était déjà livré ; cette PR ferme **V2b : facteur de vitesse effectif**. Voir `docs/plan/RESUME-COMBAT.md` et le registre `docs/plan/COMBAT-IMPLEMENTATION.md`.

## Changements

- **R-2.18 encombrement** : `+1` DT par tranche de 5 kg portée au-dessus de `Force × 5`, calculé sur la **Force courante** (l'affaiblissement réduit la capacité de portage — cas limite canonique explicite).
- **R-1.38 effets magie/atouts** : le FV de base *chargé* traverse `effects.ts` (cible `factor`, hâte abaisse / lenteur relève), arrondi puis plancher à `minSpeedFactor`.
- `Combatant` gagne deux champs **optionnels rétro-compatibles** : `carriedWeightKg`, `activeEffects`.
- `effectiveSpeedFactor` exporté, branché dans `actionCostDT` **et** le placement initial de la timeline (`addCombatant`).
- Constantes externalisées dans `rules-config.ts` (règles vivantes) : `encumbranceKgPerStrength`, `encumbranceKgPerStep`, `minSpeedFactor`.
- `rule-evidence.yaml` R-2.18 / R-1.38 passent `covered` (rules_core + tests) ; registre mis à jour ; artefacts canonical + NOMOS régénérés.

## Tests / gates (verts en local)

- `pnpm typecheck` complet : 7/7 (y compris `apps/game`, `apps/server`).
- 6 nouveaux tests combat (encombrement, seuil exact, perte de Force, hâte/lenteur, plancher, scheduling) — suite unitaire 211/211.
- `pnpm lint`, `pnpm format:check`, `pnpm canonical:check`, `pnpm canonical:check:strict` : verts.

## Note de design

Décision tranchée par le canon (R-2.18, cas limite) : la capacité de portage suit la **Force courante**, donc l'affaiblissement peut déclencher un encombrement soudain. Documenté dans le code et dans `rule-evidence.yaml`.
