### PR TITLE
feat(progression): bareme XP complet R-7.5 (M6)

### DIFF
--- a/packages/rules-core/src/progression.test.ts
+++ b/packages/rules-core/src/progression.test.ts
@@ -8,13 +8,18 @@ import {
 } from './character.js';
 import {
   ProgressionError,
+  attributeImprovementCost,
   calculateLearningPlan,
   calculateSessionXPAward,
+  energyImprovementCost,
+  factorImprovementCost,
   finalizeDefinitiveDeath,
   gainXP,
   learnSkill,
-  learnSpell
+  learnSpell,
+  vitalityImprovementCost
 } from './progression.js';
+import { DEFAULT_RULES_CONFIG } from './rules-config.js';
 
 describe('session XP awards', () => {
   it('calculates the official 1-8 session XP scale plus separate quest point', () => {
@@ -241,3 +246,51 @@ function validAttributes() {
     aestheticism: 1
   };
 }
+
+describe('XP cost bareme (R-7.5)', () => {
+  it('costs an attribute under the racial limit at NA x 5', () => {
+    expect(attributeImprovementCost(1)).toBe(5);
+    expect(attributeImprovementCost(5)).toBe(25);
+  });
+
+  it('costs an attribute above the racial limit at NA x 20, reduced by atouts', () => {
+    expect(attributeImprovementCost(3, { aboveLimit: true })).toBe(60);
+    expect(attributeImprovementCost(3, { aboveLimit: true, limitModifier: 'anti_limits' })).toBe(
+      30
+    );
+    expect(attributeImprovementCost(3, { aboveLimit: true, limitModifier: 'self_transcend' })).toBe(
+      45
+    );
+  });
+
+  it('costs a factor improvement at (NB - NA + 1) x 25', () => {
+    expect(factorImprovementCost(8, 8)).toBe(25);
+    expect(factorImprovementCost(8, 7)).toBe(50);
+    expect(factorImprovementCost(8, 1)).toBe(200);
+  });
+
+  it('rejects a factor current value above its base', () => {
+    expect(() => factorImprovementCost(8, 9)).toThrow(ProgressionError);
+  });
+
+  it('costs max vitality at 10 flat and max energy at 3 flat', () => {
+    expect(vitalityImprovementCost()).toBe(10);
+    expect(energyImprovementCost()).toBe(3);
+  });
+
+  it('is data-driven by the rules config', () => {
+    const custom = {
+      ...DEFAULT_RULES_CONFIG,
+      progression: {
+        ...DEFAULT_RULES_CONFIG.progression,
+        attributeImprovementBaseCost: 7,
+        factorImprovementBaseCost: 30,
+        vitalityImprovementCost: 99
+      }
+    };
+
+    expect(attributeImprovementCost(2, {}, custom)).toBe(14);
+    expect(factorImprovementCost(8, 8, custom)).toBe(30);
+    expect(vitalityImprovementCost(custom)).toBe(99);
+  });
+});

--- a/packages/rules-core/src/progression.ts
+++ b/packages/rules-core/src/progression.ts
@@ -329,3 +329,67 @@ function copySkill(skill: CharacterSkill): CharacterSkill {
 function copySpell(spell: CharacterSpell): CharacterSpell {
   return { ...spell };
 }
+
+export type AttributeLimitModifier = 'none' | 'anti_limits' | 'self_transcend';
+
+export interface AttributeImprovementOptions {
+  /** True when raising the attribute above its racial limit (R-7.5). */
+  aboveLimit?: boolean;
+  /** Atout that reduces the above-limit cost. */
+  limitModifier?: AttributeLimitModifier;
+}
+
+/**
+ * R-7.5 — XP cost to raise an attribute by +1. `currentValue` is NA (the value
+ * before the increment). Under the racial limit: NA x base. Above the limit:
+ * NA x the (optionally atout-reduced) above-limit multiplier.
+ */
+export function attributeImprovementCost(
+  currentValue: number,
+  options: AttributeImprovementOptions = {},
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): number {
+  assertNonNegativeInteger('currentValue', currentValue);
+
+  if (options.aboveLimit !== true) {
+    return currentValue * config.progression.attributeImprovementBaseCost;
+  }
+
+  switch (options.limitModifier ?? 'none') {
+    case 'anti_limits':
+      return currentValue * config.progression.attributeAboveLimitAntiLimitsCost;
+    case 'self_transcend':
+      return currentValue * config.progression.attributeAboveLimitSelfTranscendCost;
+    default:
+      return currentValue * config.progression.attributeAboveLimitCost;
+  }
+}
+
+/**
+ * R-7.5 — XP cost to improve a factor (speed/will) by -1 (factors improve downward
+ * from their racial base). NB = `baseValue`, NA = `currentValue`; cost = (NB - NA + 1) x base.
+ */
+export function factorImprovementCost(
+  baseValue: number,
+  currentValue: number,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): number {
+  assertPositiveInteger('baseValue', baseValue);
+  assertPositiveInteger('currentValue', currentValue);
+
+  if (currentValue > baseValue) {
+    throw new ProgressionError('factor current value cannot exceed its base value');
+  }
+
+  return (baseValue - currentValue + 1) * config.progression.factorImprovementBaseCost;
+}
+
+/** R-7.5 — flat XP cost to raise max vitality by +1. */
+export function vitalityImprovementCost(config: RulesConfig = DEFAULT_RULES_CONFIG): number {
+  return config.progression.vitalityImprovementCost;
+}
+
+/** R-7.5 — flat XP cost to raise max energy by +1. */
+export function energyImprovementCost(config: RulesConfig = DEFAULT_RULES_CONFIG): number {
+  return config.progression.energyImprovementCost;
+}

--- a/packages/rules-core/src/rules-config.ts
+++ b/packages/rules-core/src/rules-config.ts
@@ -47,6 +47,20 @@ export interface ProgressionRulesConfig {
   skillImprovementBaseCost: number;
   /** XP cost to raise a spell: 0 pts -> base, otherwise currentPoints * base. */
   spellImprovementBaseCost: number;
+  /** R-7.5 — XP per +1 on an attribute under its racial limit (NA * this). */
+  attributeImprovementBaseCost: number;
+  /** R-7.5 — XP per +1 on an attribute above its racial limit (NA * this). */
+  attributeAboveLimitCost: number;
+  /** R-7.5 — above-limit attribute cost with Anti-limites physiques / Force de geant (NA * this). */
+  attributeAboveLimitAntiLimitsCost: number;
+  /** R-7.5 — above-limit attribute cost with Depassement de soi (NA * this). */
+  attributeAboveLimitSelfTranscendCost: number;
+  /** R-7.5 — XP per -1 on a factor (speed/will): (NB - NA + 1) * this. */
+  factorImprovementBaseCost: number;
+  /** R-7.5 — flat XP per +1 on max vitality. */
+  vitalityImprovementCost: number;
+  /** R-7.5 — flat XP per +1 on max energy. */
+  energyImprovementCost: number;
   /** Base learning days per XP cost point. */
   learningDaysPerXP: number;
   /** Multiplier applied to learning time when self-taught (no mentor). */
@@ -105,6 +119,13 @@ export const DEFAULT_RULES_CONFIG: RulesConfig = {
   progression: {
     skillImprovementBaseCost: 3,
     spellImprovementBaseCost: 10,
+    attributeImprovementBaseCost: 5,
+    attributeAboveLimitCost: 20,
+    attributeAboveLimitAntiLimitsCost: 10,
+    attributeAboveLimitSelfTranscendCost: 15,
+    factorImprovementBaseCost: 25,
+    vitalityImprovementCost: 10,
+    energyImprovementCost: 3,
     learningDaysPerXP: 3,
     selfTaughtMultiplier: 2,
     learningFloors: {


### PR DESCRIPTION
Complete le moteur de cout XP : attribut (NA x5 / x20 au-dela), facteurs ((NB-NA+1) x25), vitalite (+10), energie (+3). Constantes dans rules-config (regles vivantes), 6 tests. Ferme une partie de Epic M6 #167 (bareme ; le gain XP horloge/award/points de quete reste a faire).