### PR TITLE
feat(effects+combat): consommer target=damage (#137)

### DIFF
--- a/packages/rules-core/src/combat.test.ts
+++ b/packages/rules-core/src/combat.test.ts
@@ -626,3 +626,44 @@ function factorEffect(op: 'add' | 'sub', value: number): EffectModel {
     fidelity: 'covered'
   });
 }
+
+describe('damage-target effects in combat (#137)', () => {
+  it('adds a damage-target effect bonus to the attack damage', () => {
+    const damageEffect = parseEffectModel({
+      source: { prose: 'Coup affute.', ref: 'fixture:dmg' },
+      spec: {
+        target: 'damage',
+        scope: 'C',
+        op: 'add',
+        value: 2,
+        activation: 'passive',
+        duration: 'permanent'
+      },
+      fidelity: 'covered'
+    });
+    const attacker = {
+      ...combatant({
+        id: 'attacker',
+        speedFactor: 5,
+        pendingAction: {
+          type: 'attack',
+          targetId: 'defender',
+          attack: { pool: 2, difficulty: 7 },
+          damage: {
+            attackerForce: 0,
+            weaponDamage: { components: [{ type: 'C', includesForce: false, flat: 3 }] }
+          }
+        }
+      }),
+      activeEffects: [damageEffect]
+    };
+    const defender = combatant({ id: 'defender', speedFactor: 8 });
+    const state = addCombatant(addCombatant(createCombatState(1), defender), attacker);
+
+    const result = resolveNextAction(state, { randomInteger: scriptedRolls([7, 8]) });
+    const target = result.timeline.find((entry) => entry.id === 'defender');
+
+    // flat 3 + damage-effect +2 (type C) = 5
+    expect(target?.vitality.current).toBe(5);
+  });
+});

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -3,13 +3,14 @@ import {
   type CombatDamageResult,
   type DamageDefenseInput,
   type DamageModifier,
+  type DamageType,
   type DamageZoneInput,
   type WeaponDamageSpec
 } from './combat-damage.js';
 import { type DiceRollResult, type RandomInteger, rollDice } from './dice.js';
 import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
 import { type EffectModel } from './effect-model.js';
-import { effectiveValue } from './effects.js';
+import { applyEffectiveModifiers, computeEffectiveModifiers, effectiveValue } from './effects.js';
 
 export const COMBAT_ROUND_LENGTH_DT = DEFAULT_RULES_CONFIG.combat.roundLengthDT;
 
@@ -462,6 +463,10 @@ function resolveAttack(
     action.damage !== undefined && successes > 0
       ? computeAttackDamage({
           ...action.damage,
+          damageModifiers: [
+            ...(action.damage.damageModifiers ?? []),
+            ...damageModifiersFromEffects(actor)
+          ],
           netToucheSuccesses: successes,
           randomInteger,
           config
@@ -556,6 +561,29 @@ function encumbrancePenalty(actor: Combatant, config: RulesConfig): number {
   const excess = Math.max(0, carried - capacity);
 
   return Math.ceil(excess / config.combat.encumbranceKgPerStep);
+}
+
+const DAMAGE_TYPES: DamageType[] = ['P', 'E', 'C', 'T'];
+
+/**
+ * #137 — Maps the actor's active EffectModel `damage`-target effects to per-type damage
+ * modifiers consumed by combat-damage. Scope = damage type (P/E/C/T) or global (all types).
+ * Only additive (add/sub) effects are mapped.
+ */
+function damageModifiersFromEffects(actor: Combatant): DamageModifier[] {
+  const effects = actor.activeEffects ?? [];
+
+  if (effects.length === 0) {
+    return [];
+  }
+
+  const modifiers = computeEffectiveModifiers(effects, {});
+
+  return DAMAGE_TYPES.flatMap((type) => {
+    const value = Math.round(applyEffectiveModifiers(0, 'damage', type, modifiers, {}));
+
+    return value === 0 ? [] : [{ type, value, source: 'effect' }];
+  });
 }
 
 function randomIntegerForResolution(options: CombatResolutionOptions): RandomInteger {

--- a/packages/rules-core/src/effects.test.ts
+++ b/packages/rules-core/src/effects.test.ts
@@ -179,3 +179,14 @@ function effect(
     fidelity: 'covered'
   });
 }
+
+describe('damage-target effects (#137)', () => {
+  it('computes per-type damage modifiers', () => {
+    const modifiers = computeEffectiveModifiers(
+      [effect({ target: 'damage', scope: 'C', op: 'add', value: 2 })],
+      {}
+    );
+
+    expect(modifiers.damage.C).toMatchObject({ target: 'damage', additive: 2 });
+  });
+});

--- a/packages/rules-core/src/effects.ts
+++ b/packages/rules-core/src/effects.ts
@@ -20,7 +20,7 @@ import {
 
 export const GLOBAL_EFFECT_SCOPE = '__global__';
 
-export type NumericEffectTarget = Exclude<EffectTarget, 'status' | 'damage'>;
+export type NumericEffectTarget = Exclude<EffectTarget, 'status'>;
 export type NumericEffectOperation = Extract<EffectOperation, 'add' | 'sub' | 'set' | 'multiply'>;
 
 const COMPUTED_NUMERIC_EFFECT_TARGETS = [
@@ -29,7 +29,8 @@ const COMPUTED_NUMERIC_EFFECT_TARGETS = [
   'difficulty',
   'pool',
   'energy',
-  'vitality'
+  'vitality',
+  'damage'
 ] as const satisfies readonly NumericEffectTarget[];
 
 export type EffectApplicationContext = EffectConditionContext &
@@ -80,6 +81,7 @@ export interface EffectiveModifiers {
   pool: Record<string, EffectModifierBucket>;
   energy: Record<string, EffectModifierBucket>;
   vitality: Record<string, EffectModifierBucket>;
+  damage: Record<string, EffectModifierBucket>;
   status: Record<string, EffectStatusBucket>;
 }
 
@@ -178,6 +180,7 @@ function createEmptyModifiers(): EffectiveModifiers {
     pool: {},
     energy: {},
     vitality: {},
+    damage: {},
     status: {}
   };
 }


### PR DESCRIPTION
effects.ts supporte la cible numerique damage ; combat.ts applique les effets target=damage de lattaquant aux degats (par type P/E/C/T ou global) dans resolveAttack. Les atouts/sorts modifiant les degats agissent enfin. 2 tests. Epic M3 #122. Closes #137.