### PR TITLE
feat(progression): convertQuestPoints (R-7.3)

### DIFF
--- a/packages/rules-core/src/progression.test.ts
+++ b/packages/rules-core/src/progression.test.ts
@@ -11,6 +11,7 @@ import {
   attributeImprovementCost,
   calculateLearningPlan,
   calculateSessionXPAward,
+  convertQuestPoints,
   energyImprovementCost,
   factorImprovementCost,
   finalizeDefinitiveDeath,
@@ -292,5 +293,27 @@ describe('XP cost bareme (R-7.5)', () => {
     expect(attributeImprovementCost(2, {}, custom)).toBe(14);
     expect(factorImprovementCost(8, 8, custom)).toBe(30);
     expect(vitalityImprovementCost(custom)).toBe(99);
+  });
+});
+
+describe('quest points conversion (R-7.3)', () => {
+  it('converts accumulated quest points into usable XP on quest completion', () => {
+    const character = gainXP(fighter(), 5, { questPoints: 3 });
+    const converted = convertQuestPoints(character);
+
+    expect(converted.progression).toEqual({
+      experiencePoints: 8,
+      experienceTotal: 8,
+      questPoints: 0
+    });
+    // immutable
+    expect(character.progression.questPoints).toBe(3);
+  });
+
+  it('is a no-op when there are no quest points', () => {
+    const character = gainXP(fighter(), 4);
+    const converted = convertQuestPoints(character);
+
+    expect(converted).toBe(character);
   });
 });

--- a/packages/rules-core/src/progression.ts
+++ b/packages/rules-core/src/progression.ts
@@ -393,3 +393,25 @@ export function vitalityImprovementCost(config: RulesConfig = DEFAULT_RULES_CONF
 export function energyImprovementCost(config: RulesConfig = DEFAULT_RULES_CONFIG): number {
   return config.progression.energyImprovementCost;
 }
+
+/**
+ * R-7.3 — Once a quest is completed (and the character survives), accumulated quest points
+ * become usable experience points. They were earned but deferred, so they now count toward the
+ * spendable pool and the lifetime total; the quest-point gauge is reset.
+ */
+export function convertQuestPoints<TCharacter extends Character>(
+  character: TCharacter
+): TCharacter {
+  const questPoints = character.progression.questPoints;
+
+  if (questPoints <= 0) {
+    return character;
+  }
+
+  return withProgression(character, {
+    ...character.progression,
+    experiencePoints: character.progression.experiencePoints + questPoints,
+    experienceTotal: character.progression.experienceTotal + questPoints,
+    questPoints: 0
+  });
+}


### PR DESCRIPTION
Conversion des points de quete en XP utilisables a la fin dune quete (R-7.3) : questPoints -> experiencePoints + experienceTotal, jauge remise a 0 (no-op si 0). 2 tests. Avance Epic M6 #167 (gain XP).