### PR TITLE
feat(combat): seuils de KO/mort par zone R-9.17

### DIFF
--- a/packages/rules-core/src/combat.test.ts
+++ b/packages/rules-core/src/combat.test.ts
@@ -667,3 +667,48 @@ describe('damage-target effects in combat (#137)', () => {
     expect(target?.vitality.current).toBe(5);
   });
 });
+
+describe('zone-based KO and death (R-9.17)', () => {
+  it('knocks out on a head hit over a quarter of max vitality', () => {
+    const state = addCombatant(createCombatState(1), combatant({ id: 'target' }));
+    const target = applyDamage(state, 'target', 3, undefined, { zone: { id: 'tete' } }).timeline[0];
+
+    expect(target.vitality.current).toBe(7);
+    expect(target.statuses).toContainEqual({ id: 'unconscious', appliedAtDT: 1 });
+    expect(target.statuses).not.toContainEqual({ id: 'dead', appliedAtDT: 1 });
+  });
+
+  it('kills on a head or throat hit over half the base vitality', () => {
+    const head = addCombatant(createCombatState(1), combatant({ id: 'a' }));
+    expect(
+      applyDamage(head, 'a', 6, undefined, { zone: { id: 'tete' } }).timeline[0].statuses
+    ).toContainEqual({ id: 'dead', appliedAtDT: 1 });
+
+    const throat = addCombatant(createCombatState(1), combatant({ id: 'b' }));
+    expect(
+      applyDamage(throat, 'b', 6, undefined, { zone: { id: 'gorge_nuque' } }).timeline[0].statuses
+    ).toContainEqual({ id: 'dead', appliedAtDT: 1 });
+  });
+
+  it('does not apply zone death to a non-lethal zone', () => {
+    const state = addCombatant(createCombatState(1), combatant({ id: 'target' }));
+    const target = applyDamage(state, 'target', 6, undefined, {
+      zone: { id: 'haut_jambe' }
+    }).timeline[0];
+
+    expect(target.statuses).not.toContainEqual({ id: 'dead', appliedAtDT: 1 });
+    expect(target.vitality.current).toBe(4);
+  });
+
+  it('skips zone death for until-death combatants', () => {
+    const state = addCombatant(
+      createCombatState(1),
+      combatant({ id: 'skeleton', ignoresVitalityMalus: true })
+    );
+    const target = applyDamage(state, 'skeleton', 6, undefined, {
+      zone: { id: 'tete' }
+    }).timeline[0];
+
+    expect(target.statuses).not.toContainEqual({ id: 'dead', appliedAtDT: 1 });
+  });
+});

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -111,6 +111,8 @@ export interface Combatant {
   nextActionAt: number;
   reflexes: number;
   vitality: CombatVitality;
+  /** R-9.17 — base (racial) max vitality for the lethal-zone death threshold; defaults to vitality.max. */
+  baseVitalityMax?: number;
   attributes: CombatAttributes;
   baseAttributes?: CombatAttributes;
   skills: CombatSkillSet;
@@ -284,11 +286,17 @@ export function resolveNextAction(
  *
  * Positive values are damage. Negative values are healing.
  */
+export interface ApplyDamageOptions {
+  /** R-9.17 — the zone struck, enabling head-knockout and lethal-zone thresholds. */
+  zone?: { id?: string };
+}
+
 export function applyDamage(
   state: CombatState,
   targetId: string,
   damage: number,
-  config: RulesConfig = DEFAULT_RULES_CONFIG
+  config: RulesConfig = DEFAULT_RULES_CONFIG,
+  options: ApplyDamageOptions = {}
 ): CombatState {
   const target = findCombatant(state, targetId);
   const previousVitality = target.vitality.current;
@@ -307,12 +315,25 @@ export function applyDamage(
     config
   );
 
-  const withDeath =
-    nextVitality === 0 ? withStatus(nextTarget, { id: 'dead' }, state.currentDT) : nextTarget;
+  // R-9.17 — zone thresholds use the blow's final damage in a single hit.
+  const blow = Math.max(0, damage);
+  const zoneId = options.zone?.id;
+  const survivesMalus = !target.ignoresVitalityMalus;
+  const zoneDeath =
+    survivesMalus &&
+    zoneId !== undefined &&
+    config.combat.lethalZoneIds.includes(zoneId) &&
+    blow > (target.baseVitalityMax ?? target.vitality.max) * config.combat.lethalZoneBaseRatio;
+  const headKnockout =
+    survivesMalus &&
+    zoneId !== undefined &&
+    config.combat.headZoneIds.includes(zoneId) &&
+    blow > target.vitality.max * config.combat.headUnconsciousMaxRatio;
+  const isDead = nextVitality === 0 || zoneDeath;
+  const withDeath = isDead ? withStatus(nextTarget, { id: 'dead' }, state.currentDT) : nextTarget;
+  const generalKnockout = finalDamage > previousVitality * config.combat.unconsciousDamageRatio;
   const withUnconscious =
-    finalDamage > previousVitality * config.combat.unconsciousDamageRatio &&
-    nextVitality > 0 &&
-    !target.ignoresVitalityMalus
+    !isDead && survivesMalus && (generalKnockout || headKnockout)
       ? withStatus(withDeath, { id: 'unconscious' }, state.currentDT)
       : withDeath;
 
@@ -491,7 +512,9 @@ function resolveAttack(
   };
 
   if (damageBreakdown !== undefined) {
-    return applyDamage(withAttackLog, action.targetId, damageBreakdown.finalDamage, config);
+    return applyDamage(withAttackLog, action.targetId, damageBreakdown.finalDamage, config, {
+      zone: action.damage?.zone
+    });
   }
 
   if (successes > 0 && action.damageOnHit !== undefined && action.damageOnHit > 0) {

--- a/packages/rules-core/src/rules-config.ts
+++ b/packages/rules-core/src/rules-config.ts
@@ -21,6 +21,14 @@ export interface CombatRulesConfig {
   encumbranceKgPerStep: number;
   /** R-1.38 — lower bound for the effective speed factor in DT (an action costs >= this). */
   minSpeedFactor: number;
+  /** R-9.17 — head hit knocks out when final damage > vitality.max * this. */
+  headUnconsciousMaxRatio: number;
+  /** R-9.17 — a lethal-zone hit kills when final damage > base vitality max * this. */
+  lethalZoneBaseRatio: number;
+  /** R-9.17 — zone ids that trigger the head knockout threshold. */
+  headZoneIds: string[];
+  /** R-9.17 — zone ids that trigger the one-shot lethal threshold (head, throat). */
+  lethalZoneIds: string[];
 }
 
 export interface CreationRulesConfig {
@@ -104,7 +112,11 @@ export const DEFAULT_RULES_CONFIG: RulesConfig = {
     vitalityMalusRatio: 0.5,
     encumbranceKgPerStrength: 5,
     encumbranceKgPerStep: 5,
-    minSpeedFactor: 1
+    minSpeedFactor: 1,
+    headUnconsciousMaxRatio: 0.25,
+    lethalZoneBaseRatio: 0.5,
+    headZoneIds: ['tete'],
+    lethalZoneIds: ['tete', 'gorge_nuque']
   },
   creation: {
     attributeMaxOffset: 1,


### PR DESCRIPTION
applyDamage applique les seuils localises R-9.17 : KO tete si degats du coup > 1/4 vitalite max ; mort tete/gorge si > 1/2 vitalite de base (baseVitalityMax optionnel, defaut = max). Coup unique ; ignore par Jusqua la mort. Seuils/zones configurables. resolveAttack transmet la zone. 4 tests. Avance M1 #132.