### PR TITLE
feat(inventory): modele dinventaire + carriedWeightKg (M4 etape 1)

### DIFF
--- a/packages/rules-core/src/index.ts
+++ b/packages/rules-core/src/index.ts
@@ -7,6 +7,7 @@ export * from './effect-model.js';
 export * from './effect-renderer.js';
 export * from './effects.js';
 export * from './hit-table.js';
+export * from './inventory.js';
 export * from './npc-control.js';
 export * from './predilection.js';
 export * from './progression.js';

--- a/packages/rules-core/src/inventory.test.ts
+++ b/packages/rules-core/src/inventory.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { type InventoryItem, carriedWeightKg, setItemState, wornItems } from './inventory.js';
+
+function items(): InventoryItem[] {
+  return [
+    { id: 'armor', typeId: 'cuir-cloute-haubergeon', weightKg: 8, state: 'worn' },
+    { id: 'sword', typeId: 'epee', weightKg: 1.5, state: 'worn' },
+    { id: 'rations', typeId: 'rations', weightKg: 0.5, state: 'carried', quantity: 4 },
+    { id: 'tent', typeId: 'tente', weightKg: 6, state: 'stored' }
+  ];
+}
+
+describe('inventory — carried weight (R-10.10)', () => {
+  it('sums worn + carried weight, excluding stored, applying quantity', () => {
+    // 8 (worn) + 1.5 (worn) + 0.5*4 (carried) = 11.5 ; tent (stored) excluded
+    expect(carriedWeightKg(items())).toBe(11.5);
+  });
+
+  it('excludes an item once it is stored off-person', () => {
+    const stowed = setItemState(items(), 'armor', 'stored');
+    expect(carriedWeightKg(stowed)).toBe(3.5);
+  });
+
+  it('returns 0 for an empty inventory', () => {
+    expect(carriedWeightKg([])).toBe(0);
+  });
+
+  it('rejects a negative weight or non-positive quantity', () => {
+    expect(() =>
+      carriedWeightKg([{ id: 'x', typeId: 't', weightKg: -1, state: 'worn' }])
+    ).toThrow();
+    expect(() =>
+      carriedWeightKg([{ id: 'x', typeId: 't', weightKg: 1, state: 'worn', quantity: 0 }])
+    ).toThrow();
+  });
+});
+
+describe('inventory — worn loadout & state changes', () => {
+  it('lists only worn items as the active loadout', () => {
+    expect(wornItems(items()).map((item) => item.id)).toEqual(['armor', 'sword']);
+  });
+
+  it('changes an item state immutably (dressed for the moment)', () => {
+    const before = items();
+    const after = setItemState(before, 'armor', 'carried');
+
+    expect(after.find((item) => item.id === 'armor')?.state).toBe('carried');
+    expect(before.find((item) => item.id === 'armor')?.state).toBe('worn');
+  });
+});

--- a/packages/rules-core/src/inventory.ts
+++ b/packages/rules-core/src/inventory.ts
@@ -1,0 +1,75 @@
+/**
+ * R-10 / R-10.10 — Inventory model (MVP "arcade" mode : flat list + cumulative weight, no containers).
+ *
+ * Three states model the "habillé de ville" play loop (cf. docs/plan/SURFACES.md, Fiche) :
+ * - `worn`    : equipped/active right now (armor by zone, weapon in hand, clothes) — feeds combat AND weight ;
+ * - `carried` : on the person but not equipped — counts toward weight ;
+ * - `stored`  : off-person (chest, vault elsewhere) — does NOT count toward encumbrance.
+ *
+ * The carried weight feeds the encumbrance speed penalty (R-2.18, already in combat.ts via V2b).
+ * Containers / extradimensional storage are out of scope for now.
+ */
+export type ItemState = 'worn' | 'carried' | 'stored';
+
+export interface InventoryItem {
+  /** Unique instance id. */
+  id: string;
+  /** Catalog item-type id (frozen reference — R-10.19 versioning). */
+  typeId: string;
+  /** Display name (snapshot from the catalog). */
+  name?: string;
+  /** Weight in kg of a single unit (fractional allowed). */
+  weightKg: number;
+  /** porté (worn) / transporté (carried) / rangé hors-personne (stored). */
+  state: ItemState;
+  /** Stack quantity (consumables, ammo, coins); defaults to 1. */
+  quantity?: number;
+}
+
+const ON_PERSON_STATES: readonly ItemState[] = ['worn', 'carried'];
+
+/**
+ * R-10.10 — Total carried weight (kg) of everything on the person (worn + carried),
+ * excluding items stored off-person. Convertible into `Combatant.carriedWeightKg`.
+ */
+export function carriedWeightKg(items: readonly InventoryItem[]): number {
+  return items
+    .filter((item) => ON_PERSON_STATES.includes(item.state))
+    .reduce((sum, item) => {
+      const quantity = item.quantity ?? 1;
+
+      assertNonNegativeNumber('weightKg', item.weightKg);
+      assertPositiveInteger('quantity', quantity);
+
+      return sum + item.weightKg * quantity;
+    }, 0);
+}
+
+/** Items currently worn/equipped — the loadout that feeds combat (protections by zone, weapon specs). */
+export function wornItems(items: readonly InventoryItem[]): InventoryItem[] {
+  return items.filter((item) => item.state === 'worn');
+}
+
+/**
+ * Immutably change an item's state — the core "dressed for the moment" gesture
+ * (worn ↔ carried ↔ stored).
+ */
+export function setItemState(
+  items: readonly InventoryItem[],
+  itemId: string,
+  state: ItemState
+): InventoryItem[] {
+  return items.map((item) => (item.id === itemId ? { ...item, state } : item));
+}
+
+function assertNonNegativeNumber(name: string, value: number): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative number`);
+  }
+}
+
+function assertPositiveInteger(name: string, value: number): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+}


### PR DESCRIPTION
inventory.ts (rules-core, arcade) : InventoryItem 3 etats worn/carried/stored ; carriedWeightKg() (poids sur soi, hors stored) ferme la boucle equipement->encombrement->FV (R-10.10/R-2.18) ; wornItems() (loadout combat) ; setItemState() immutable. 6 tests. Avance Epic M4 #165 (etape 1/4 ; suite : pont loadout->combat, decompte conso, monnaie).