### PR TITLE
feat(inventory): pont loadout -> combat (M4 etape 2)

### DIFF
--- a/packages/rules-core/src/inventory.test.ts
+++ b/packages/rules-core/src/inventory.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
-import { type InventoryItem, carriedWeightKg, setItemState, wornItems } from './inventory.js';
+import {
+  type InventoryItem,
+  carriedWeightKg,
+  equippedWeaponDamage,
+  loadoutProtections,
+  setItemState,
+  wornItems
+} from './inventory.js';
 
 function items(): InventoryItem[] {
   return [
@@ -47,5 +54,54 @@ describe('inventory — worn loadout & state changes', () => {
 
     expect(after.find((item) => item.id === 'armor')?.state).toBe('carried');
     expect(before.find((item) => item.id === 'armor')?.state).toBe('worn');
+  });
+});
+
+describe('inventory — loadout to combat bridge (M4)', () => {
+  function combatItems(): InventoryItem[] {
+    return [
+      {
+        id: 'sword',
+        typeId: 'epee',
+        weightKg: 1.5,
+        state: 'worn',
+        weaponDamage: { components: [{ type: 'C', includesForce: true, flat: 3 }] }
+      },
+      {
+        id: 'hauberk',
+        typeId: 'cuir-cloute-haubergeon',
+        weightKg: 8,
+        state: 'worn',
+        protection: { layer: 'cuir', zones: ['thorax_dos', 'ventre_bas_dos'], values: { C: 2 } }
+      },
+      {
+        id: 'spare-helm',
+        typeId: 'casque',
+        weightKg: 2,
+        state: 'carried',
+        protection: { layer: 'acier', zones: ['tete'], values: { C: 3 } }
+      }
+    ];
+  }
+
+  it('exposes the worn weapon damage spec', () => {
+    expect(equippedWeaponDamage(combatItems())).toEqual({
+      components: [{ type: 'C', includesForce: true, flat: 3 }]
+    });
+  });
+
+  it('returns undefined when no weapon is worn', () => {
+    expect(equippedWeaponDamage([])).toBeUndefined();
+  });
+
+  it('collects protection layers from worn armor only (not carried/stored)', () => {
+    const protections = loadoutProtections(combatItems());
+
+    expect(protections).toHaveLength(1);
+    expect(protections[0]).toMatchObject({
+      id: 'hauberk',
+      layer: 'cuir',
+      zones: ['thorax_dos', 'ventre_bas_dos']
+    });
   });
 });

--- a/packages/rules-core/src/inventory.ts
+++ b/packages/rules-core/src/inventory.ts
@@ -9,6 +9,12 @@
  * The carried weight feeds the encumbrance speed penalty (R-2.18, already in combat.ts via V2b).
  * Containers / extradimensional storage are out of scope for now.
  */
+import {
+  type DamageProtectionLayerInput,
+  type DamageProtectionValues,
+  type WeaponDamageSpec
+} from './combat-damage.js';
+
 export type ItemState = 'worn' | 'carried' | 'stored';
 
 export interface InventoryItem {
@@ -24,6 +30,10 @@ export interface InventoryItem {
   state: ItemState;
   /** Stack quantity (consumables, ammo, coins); defaults to 1. */
   quantity?: number;
+  /** R-10.19 — frozen combat snapshot for a worn weapon (drives attack damage). */
+  weaponDamage?: WeaponDamageSpec;
+  /** R-10.19 — frozen combat snapshot for a worn armor piece (protection by zone). */
+  protection?: { layer: string; zones: string[]; values: DamageProtectionValues };
 }
 
 const ON_PERSON_STATES: readonly ItemState[] = ['worn', 'carried'];
@@ -72,4 +82,29 @@ function assertPositiveInteger(name: string, value: number): void {
   if (!Number.isInteger(value) || value < 1) {
     throw new Error(`${name} must be a positive integer`);
   }
+}
+
+/**
+ * The active worn weapon's damage spec — the first worn item carrying a `weaponDamage` snapshot.
+ * (Dual-wielding / two-weapon rules R-9.42 are out of scope here.)
+ */
+export function equippedWeaponDamage(
+  items: readonly InventoryItem[]
+): WeaponDamageSpec | undefined {
+  return wornItems(items).find((item) => item.weaponDamage !== undefined)?.weaponDamage;
+}
+
+/**
+ * Protection layers contributed by all WORN armor — feeds `combat-damage` `defense.protections`
+ * (mitigation by zone, R-9.14). Carried/stored armor does not protect.
+ */
+export function loadoutProtections(items: readonly InventoryItem[]): DamageProtectionLayerInput[] {
+  return wornItems(items)
+    .filter((item) => item.protection !== undefined)
+    .map((item) => ({
+      id: item.id,
+      layer: item.protection!.layer,
+      zones: item.protection!.zones,
+      values: item.protection!.values
+    }));
 }


### PR DESCRIPTION
InventoryItem porte un snapshot combat fige (R-10.19) : weaponDamage + protection par zone. equippedWeaponDamage() / loadoutProtections() derivent les entrees combat-damage depuis les objets PORTES (R-9.14). rules-core pur. 3 tests. Avance Epic M4 #165 (etape 2/4).