### PR TITLE
feat(inventory): decompte des consommables (M4 etape 3)

### DIFF
--- a/packages/rules-core/src/inventory.test.ts
+++ b/packages/rules-core/src/inventory.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   type InventoryItem,
   carriedWeightKg,
+  consumeItem,
   equippedWeaponDamage,
   loadoutProtections,
   setItemState,
@@ -103,5 +104,36 @@ describe('inventory — loadout to combat bridge (M4)', () => {
       layer: 'cuir',
       zones: ['thorax_dos', 'ventre_bas_dos']
     });
+  });
+});
+
+describe('inventory — consumables (M4)', () => {
+  function pouch(): InventoryItem[] {
+    return [
+      { id: 'arrows', typeId: 'fleche', weightKg: 0.05, state: 'carried', quantity: 20 },
+      { id: 'potion', typeId: 'soin-mineur', weightKg: 0.2, state: 'carried' }
+    ];
+  }
+
+  it('decrements a stack on use', () => {
+    const after = consumeItem(pouch(), 'arrows', 3);
+    expect(after.find((item) => item.id === 'arrows')?.quantity).toBe(17);
+  });
+
+  it('removes the item when the stack reaches 0', () => {
+    expect(consumeItem(pouch(), 'arrows', 20).some((item) => item.id === 'arrows')).toBe(false);
+    // implicit quantity 1
+    expect(consumeItem(pouch(), 'potion').some((item) => item.id === 'potion')).toBe(false);
+  });
+
+  it('rejects consuming more than available or an unknown item', () => {
+    expect(() => consumeItem(pouch(), 'arrows', 21)).toThrow();
+    expect(() => consumeItem(pouch(), 'ghost')).toThrow();
+  });
+
+  it('does not mutate the original inventory', () => {
+    const before = pouch();
+    consumeItem(before, 'arrows', 5);
+    expect(before.find((item) => item.id === 'arrows')?.quantity).toBe(20);
   });
 });

--- a/packages/rules-core/src/inventory.ts
+++ b/packages/rules-core/src/inventory.ts
@@ -108,3 +108,36 @@ export function loadoutProtections(items: readonly InventoryItem[]): DamageProte
       values: item.protection!.values
     }));
 }
+
+/**
+ * Consommables (potion bue, munition tiree, charge depensee) — consume `amount` units of an item.
+ * Decrements the stack; removes the item when it reaches 0. Throws if the item is missing or the
+ * stack is insufficient. Quantity is never edited by hand (R-9.25 / loi UX : decompte a l'usage).
+ */
+export function consumeItem(
+  items: readonly InventoryItem[],
+  itemId: string,
+  amount = 1
+): InventoryItem[] {
+  assertPositiveInteger('amount', amount);
+
+  const item = items.find((candidate) => candidate.id === itemId);
+
+  if (item === undefined) {
+    throw new Error(`unknown inventory item: ${itemId}`);
+  }
+
+  const quantity = item.quantity ?? 1;
+
+  if (amount > quantity) {
+    throw new Error(`cannot consume ${amount} of ${itemId}: only ${quantity} available`);
+  }
+
+  const remaining = quantity - amount;
+
+  return remaining === 0
+    ? items.filter((candidate) => candidate.id !== itemId)
+    : items.map((candidate) =>
+        candidate.id === itemId ? { ...candidate, quantity: remaining } : candidate
+      );
+}


### PR DESCRIPTION
consumeItem(items, id, amount) : decremente le stock a lusage (potion/munition/charge), retire a 0, rejette stock insuffisant/inconnu. Immutable. 4 tests. Avance Epic M4 #165 (etape 3/4).