### PR TITLE
feat(money): systeme monetaire R-10.18 (M4 etape 4)

### DIFF
--- a/packages/rules-core/src/index.ts
+++ b/packages/rules-core/src/index.ts
@@ -8,6 +8,7 @@ export * from './effect-renderer.js';
 export * from './effects.js';
 export * from './hit-table.js';
 export * from './inventory.js';
+export * from './money.js';
 export * from './npc-control.js';
 export * from './predilection.js';
 export * from './progression.js';

--- a/packages/rules-core/src/money.test.ts
+++ b/packages/rules-core/src/money.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { breakdownToCopper, copperToBreakdown, spendCopper } from './money.js';
+
+describe('money — R-10.18 (factor 10, internal copper)', () => {
+  it('converts a Po/Pa/Pb/Pc breakdown to copper', () => {
+    expect(breakdownToCopper({ po: 1, pa: 2, pb: 3, pc: 4 })).toBe(1234);
+    expect(breakdownToCopper({ po: 0, pa: 0, pb: 0, pc: 0 })).toBe(0);
+  });
+
+  it('converts copper back to the canonical breakdown', () => {
+    expect(copperToBreakdown(1234)).toEqual({ po: 1, pa: 2, pb: 3, pc: 4 });
+    expect(copperToBreakdown(0)).toEqual({ po: 0, pa: 0, pb: 0, pc: 0 });
+    expect(copperToBreakdown(7)).toEqual({ po: 0, pa: 0, pb: 0, pc: 7 });
+  });
+
+  it('round-trips breakdown <-> copper', () => {
+    const breakdown = { po: 3, pa: 0, pb: 9, pc: 5 };
+    expect(copperToBreakdown(breakdownToCopper(breakdown))).toEqual(breakdown);
+  });
+
+  it('spends copper and rejects insufficient funds', () => {
+    expect(spendCopper(1234, 234)).toBe(1000);
+    expect(() => spendCopper(100, 101)).toThrow();
+  });
+
+  it('rejects non-integer or negative amounts', () => {
+    expect(() => copperToBreakdown(-1)).toThrow();
+    expect(() => breakdownToCopper({ po: 1.5, pa: 0, pb: 0, pc: 0 })).toThrow();
+  });
+});

--- a/packages/rules-core/src/money.ts
+++ b/packages/rules-core/src/money.ts
@@ -1,0 +1,60 @@
+/**
+ * R-10.18 — Système monétaire minimaliste : 4 unités (Po, Pa, Pb, Pc) en facteur 10.
+ *
+ * La **source de vérité interne** est un entier de **Pc** (pièces de cuivre) ; la répartition
+ * Po/Pa/Pb/Pc n'est qu'une conversion d'affichage.
+ *   1 Po = 1000 Pc · 1 Pa = 100 Pc · 1 Pb = 10 Pc · 1 Pc = 1 Pc.
+ */
+export interface MoneyBreakdown {
+  po: number;
+  pa: number;
+  pb: number;
+  pc: number;
+}
+
+const COPPER_PER_PO = 1000;
+const COPPER_PER_PA = 100;
+const COPPER_PER_PB = 10;
+
+/** Valeur totale en Pc (cuivre) d'une répartition Po/Pa/Pb/Pc. */
+export function breakdownToCopper(money: MoneyBreakdown): number {
+  assertNonNegativeInteger('po', money.po);
+  assertNonNegativeInteger('pa', money.pa);
+  assertNonNegativeInteger('pb', money.pb);
+  assertNonNegativeInteger('pc', money.pc);
+
+  return money.po * COPPER_PER_PO + money.pa * COPPER_PER_PA + money.pb * COPPER_PER_PB + money.pc;
+}
+
+/** Convertit un montant interne en Pc vers la répartition canonique Po/Pa/Pb/Pc (affichage). */
+export function copperToBreakdown(copper: number): MoneyBreakdown {
+  assertNonNegativeInteger('copper', copper);
+
+  let rest = copper;
+  const po = Math.floor(rest / COPPER_PER_PO);
+  rest %= COPPER_PER_PO;
+  const pa = Math.floor(rest / COPPER_PER_PA);
+  rest %= COPPER_PER_PA;
+  const pb = Math.floor(rest / COPPER_PER_PB);
+  rest %= COPPER_PER_PB;
+
+  return { po, pa, pb, pc: rest };
+}
+
+/** Dépense un coût (en Pc) sur un solde (en Pc) ; lève une erreur si fonds insuffisants. */
+export function spendCopper(balance: number, cost: number): number {
+  assertNonNegativeInteger('balance', balance);
+  assertNonNegativeInteger('cost', cost);
+
+  if (cost > balance) {
+    throw new Error(`insufficient funds: ${cost} required, ${balance} available`);
+  }
+
+  return balance - cost;
+}
+
+function assertNonNegativeInteger(name: string, value: number): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+}


### PR DESCRIPTION
money.ts : Po/Pa/Pb/Pc facteur 10, source de verite interne en Pc (cuivre) ; breakdownToCopper/copperToBreakdown + spendCopper. 5 tests. Termine le coeur rules-core de M4 #165 (modele + encombrement + loadout + conso + monnaie). Reste M4 cote app : peuplement des snapshots depuis le catalogue + UI inventaire (Fiche).