### PR TITLE
feat(magic): jet de sort R-8.5 (M2 etape 1)

### DIFF
--- a/packages/rules-core/src/index.ts
+++ b/packages/rules-core/src/index.ts
@@ -8,6 +8,7 @@ export * from './effect-renderer.js';
 export * from './effects.js';
 export * from './hit-table.js';
 export * from './inventory.js';
+export * from './magic.js';
 export * from './money.js';
 export * from './npc-control.js';
 export * from './predilection.js';

--- a/packages/rules-core/src/magic.test.ts
+++ b/packages/rules-core/src/magic.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveSpellCast } from './magic.js';
+
+function scriptedRolls(values: number[]) {
+  let index = 0;
+
+  return (sides: number): number => {
+    const value = values[index];
+    index += 1;
+
+    if (value === undefined) {
+      throw new Error(`No scripted roll left for D${sides}`);
+    }
+
+    return value;
+  };
+}
+
+describe('spell casting roll (R-8.5)', () => {
+  it('pools Intelligence + spell points (no skill) against the spell difficulty', () => {
+    // Int 4 + 2 points = pool 6 ; difficulty 7 ; three dice >= 7 succeed.
+    const result = resolveSpellCast(4, 2, 7, {
+      randomInteger: scriptedRolls([7, 8, 9, 2, 3, 4])
+    });
+
+    expect(result.pool).toBe(6);
+    expect(result.difficulty).toBe(7);
+    expect(result.netSuccesses).toBe(3);
+    expect(result.success).toBe(true);
+  });
+
+  it('fails the spell on zero successes', () => {
+    const result = resolveSpellCast(2, 0, 7, { randomInteger: scriptedRolls([2, 3]) });
+
+    expect(result.pool).toBe(2);
+    expect(result.success).toBe(false);
+    expect(result.netSuccesses).toBe(0);
+  });
+
+  it('supports high spell difficulties (> 9, R-1.20)', () => {
+    // Difficulty 10 (> 9) is passed straight through to the dice engine. Eight dice
+    // (Int 5 + 3 points), no initial 10 so the scripted pool is consumed exactly.
+    const result = resolveSpellCast(5, 3, 10, {
+      randomInteger: scriptedRolls([9, 9, 8, 7, 6, 5, 4, 3])
+    });
+
+    expect(result.pool).toBe(8);
+    expect(result.difficulty).toBe(10);
+    expect(result.netSuccesses).toBeGreaterThanOrEqual(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects negative inputs', () => {
+    expect(() => resolveSpellCast(-1, 0, 7)).toThrow();
+    expect(() => resolveSpellCast(4, -2, 7)).toThrow();
+  });
+});

--- a/packages/rules-core/src/magic.ts
+++ b/packages/rules-core/src/magic.ts
@@ -1,0 +1,52 @@
+import { type DiceRollResult, type RollDiceOptions, rollDice } from './dice.js';
+
+/**
+ * D8 — Magie (moteur). Étape 1 : le **jet de sort** (R-8.5).
+ *
+ * Le moteur de magie est piloté par `docs/plan/MAGIC-IMPLEMENTATION.md`. Cœur MVP : lancement
+ * (ici) + énergie (coût/récup) + TI/concentration/interruption — ces deux derniers viendront
+ * brancher l'énergie et le temps d'incantation dans le combat (réutilise R-9.4).
+ */
+export interface SpellCastResult {
+  /** Dice pool = Intelligence + points invested in the spell. */
+  pool: number;
+  difficulty: number;
+  roll: DiceRollResult;
+  /** Net successes on the casting roll. */
+  netSuccesses: number;
+  /** A spell takes effect on at least one success. */
+  success: boolean;
+}
+
+/**
+ * R-8.5 — Spell casting roll. Pool = **Intelligence + points dans le sort** (PAS de compétence ni
+ * de spécialisation). Difficulté = la difficulté convenue du sort (peut dépasser 9, R-1.20).
+ *
+ * Ne gère QUE le jet : le coût en énergie et le temps d'incantation (TI) sont des étapes suivantes.
+ */
+export function resolveSpellCast(
+  intelligence: number,
+  spellPoints: number,
+  difficulty: number,
+  options: RollDiceOptions = {}
+): SpellCastResult {
+  assertNonNegativeInteger('intelligence', intelligence);
+  assertNonNegativeInteger('spellPoints', spellPoints);
+
+  const pool = intelligence + spellPoints;
+  const roll = rollDice(pool, difficulty, options);
+
+  return {
+    pool,
+    difficulty,
+    roll,
+    netSuccesses: roll.successes,
+    success: roll.successes > 0
+  };
+}
+
+function assertNonNegativeInteger(name: string, value: number): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+}


### PR DESCRIPTION
## Resume

M2 (Moteur de Magie D8, #164) — etape 1 : le **jet de sort** R-8.5.

- `resolveSpellCast(intelligence, spellPoints, difficulty, options)` dans `packages/rules-core/src/magic.ts`
- Pool = **Intelligence + points investis dans le sort** (PAS de competence ni de specialisation, R-8.5)
- Difficulte = celle convenue du sort ; supporte les difficultes > 9 (R-1.20) en deleguant au moteur de des (`rollDice`)
- Resultat : `{ pool, difficulty, roll, netSuccesses, success }` — `success` des qu'il y a au moins 1 succes net
- Entrees negatives rejetees (garde-fou typed-tool : le LLM/UI ne calcule jamais)

## Portee

Cette etape ne gere QUE le jet. Les etapes suivantes de M2 (a venir) :

- energie : cout de lancement + recuperation
- temps d'incantation (TI) / concentration / interruption (reutilise R-9.4 cote combat)

## Tests / gates

- `packages/rules-core/src/magic.test.ts` : 4 tests (pool Int+points vs difficulte ; echec a 0 succes ; difficulte > 9 R-1.20 ; rejet entrees negatives)
- Local : lint OK, format:check OK, typecheck 7/7, 254 tests unitaires verts, canonical:check current

Epic: #164
