### PR TITLE
feat(magic): energie des sorts R-8.10 (M2 etape 2)

### DIFF
--- a/packages/rules-core/src/magic.test.ts
+++ b/packages/rules-core/src/magic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveSpellCast } from './magic.js';
+import { gainEnergy, resolveSpellCast, restoreEnergyToFull, spendEnergy } from './magic.js';
 
 function scriptedRolls(values: number[]) {
   let index = 0;
@@ -54,5 +54,29 @@ describe('spell casting roll (R-8.5)', () => {
   it('rejects negative inputs', () => {
     expect(() => resolveSpellCast(-1, 0, 7)).toThrow();
     expect(() => resolveSpellCast(4, -2, 7)).toThrow();
+  });
+});
+
+describe('spell energy (R-8.10)', () => {
+  it('spends the spell energy cost from the current pool', () => {
+    expect(spendEnergy({ current: 60, max: 60 }, 10)).toEqual({ current: 50, max: 60 });
+  });
+
+  it('rejects casting without enough energy (no vitality inversion in MVP)', () => {
+    expect(() => spendEnergy({ current: 5, max: 60 }, 6)).toThrow();
+  });
+
+  it('rejects negative or non-integer costs', () => {
+    expect(() => spendEnergy({ current: 60, max: 60 }, -1)).toThrow();
+    expect(() => spendEnergy({ current: 60, max: 60 }, 1.5)).toThrow();
+  });
+
+  it('gains energy but never exceeds the maximum (R-8.10 plafond)', () => {
+    expect(gainEnergy({ current: 50, max: 60 }, 5)).toEqual({ current: 55, max: 60 });
+    expect(gainEnergy({ current: 58, max: 60 }, 10)).toEqual({ current: 60, max: 60 });
+  });
+
+  it('restores energy to full on a complete (8h) rest', () => {
+    expect(restoreEnergyToFull({ current: 12, max: 60 })).toEqual({ current: 60, max: 60 });
   });
 });

--- a/packages/rules-core/src/magic.ts
+++ b/packages/rules-core/src/magic.ts
@@ -1,3 +1,4 @@
+import type { CharacterResource } from './character.js';
 import { type DiceRollResult, type RollDiceOptions, rollDice } from './dice.js';
 
 /**
@@ -43,6 +44,42 @@ export function resolveSpellCast(
     netSuccesses: roll.successes,
     success: roll.successes > 0
   };
+}
+
+/**
+ * R-8.10 — Modèle d'énergie (MVP : coût + récupération + plafond).
+ *
+ * L'énergie est un pool `{ current, max }` (`CharacterResource`). `energyMax` provient de la
+ * création (magicien 60, non-magicien 0, R-8.10) ; il n'est donc PAS recalculé ici. La durée
+ * de repos (8 h, R-2.11) est gérée par l'action de repos (Fiche) : ce module ne fournit que les
+ * primitives numériques que la Fiche / le combat décrémentent automatiquement.
+ *
+ * Hors périmètre (V2) : inversion énergie↔vitalité (R-8.14) et dépassement du plafond
+ * ("Débordement d'énergie", R-8.14). En MVP, lancer sans énergie suffisante échoue.
+ */
+export function spendEnergy(energy: CharacterResource, cost: number): CharacterResource {
+  assertNonNegativeInteger('cost', cost);
+
+  if (cost > energy.current) {
+    throw new Error(`insufficient energy: ${cost} required, ${energy.current} available`);
+  }
+
+  return { current: energy.current - cost, max: energy.max };
+}
+
+/**
+ * R-8.10 — Regagne de l'énergie (potion, effet, récupération partielle), **plafonné** à `max`.
+ * Le dépassement du plafond ("Débordement d'énergie") est V2.
+ */
+export function gainEnergy(energy: CharacterResource, amount: number): CharacterResource {
+  assertNonNegativeInteger('amount', amount);
+
+  return { current: Math.min(energy.current + amount, energy.max), max: energy.max };
+}
+
+/** R-8.10 / R-2.11 — Un repos complet (8 h) restaure l'énergie à son maximum. */
+export function restoreEnergyToFull(energy: CharacterResource): CharacterResource {
+  return { current: energy.max, max: energy.max };
 }
 
 function assertNonNegativeInteger(name: string, value: number): void {


### PR DESCRIPTION
## Resume

M2 (Moteur de Magie D8, #164) — etape 2 : le **modele d'energie** R-8.10 (MVP : cout + recuperation + plafond).

Trois primitives pures sur le pool `{ current, max }` (`CharacterResource`) dans `packages/rules-core/src/magic.ts` :

- `spendEnergy(energy, cost)` — decremente le cout du sort ; **refuse** le lancement sans energie suffisante (en MVP, l'inversion energie<->vitalite R-8.14 n'existe pas)
- `gainEnergy(energy, amount)` — regagne de l'energie, **plafonne a `max`** (le depassement "Debordement d'energie" est V2)
- `restoreEnergyToFull(energy)` — repos complet (8h, R-2.11) = energie au max

## Choix / perimetre

- `energyMax` vient de la **creation** (magicien 60 / non-magicien 0, deja en config `magicianStartingEnergy`) ; il n'est **pas recalcule** ici.
- La **duree** de repos (8h) est geree par l'action de repos cote Fiche ; ce module ne fournit que les primitives numeriques (decrement automatique au cast, jamais manuel).
- **Hors scope (V2)** : inversion energie<->vitalite (R-8.14), depassement de plafond, recuperation partielle (non specifiee en canon — volontairement non modelisee, pas de regle inventee).
- Prepare le hook combat existant : `combat.ts` note deja "Spell energy loss (R-9.31) applies once energy is modeled" ; `spendEnergy` est la primitive que l'interruption (R-8.7, etape 3) reutilisera.

## Tests / gates

- `magic.test.ts` : +5 tests energie (spend ; refus si insuffisant ; rejet cout negatif/non-entier ; plafond R-8.10 ; repos complet) ; 9 tests magie au total
- Local : lint OK, format:check OK, typecheck 7/7, **259** tests unitaires verts, canonical:check current

Epic: #164
