### PR TITLE
feat(combat): lancement de sort dans la timeline (M2 etape 3a)

### DIFF
--- a/packages/rules-core/src/combat.test.ts
+++ b/packages/rules-core/src/combat.test.ts
@@ -5,13 +5,15 @@ import {
   applyDamage,
   applyStatus,
   createCombatState,
+  declareSpellCast,
   effectiveSpeedFactor,
   getCyclicDT,
   interruptCombatant,
   resolveNextAction,
   resolveStaminaDamage,
   type AttackAction,
-  type Combatant
+  type Combatant,
+  type SpellAction
 } from './combat.js';
 import { parseEffectModel, type EffectModel } from './effect-model.js';
 
@@ -710,5 +712,93 @@ describe('zone-based KO and death (R-9.17)', () => {
     }).timeline[0];
 
     expect(target.statuses).not.toContainEqual({ id: 'dead', appliedAtDT: 1 });
+  });
+});
+
+describe('spell casting in combat (R-8.5 / R-8.6 / R-8.7)', () => {
+  const spell = (overrides: Partial<SpellAction> = {}): SpellAction => ({
+    type: 'spell',
+    intelligence: 4,
+    spellPoints: 2,
+    difficulty: 7,
+    energyCost: 10,
+    castingTimeDT: 12,
+    ...overrides
+  });
+
+  const mageWithEnergy = (current = 60) => ({
+    ...combatant({ id: 'mage', speedFactor: 7 }),
+    energy: { current, max: 60 }
+  });
+
+  it('commits the energy cost and schedules the casting-time windup (R-8.6 / R-8.10)', () => {
+    const state = addCombatant(createCombatState(1), mageWithEnergy());
+
+    const declared = declareSpellCast(state, 'mage', spell());
+    const caster = declared.timeline.find((entry) => entry.id === 'mage');
+
+    expect(caster?.energy).toEqual({ current: 50, max: 60 });
+    expect(caster?.nextActionAt).toBe(13); // currentDT 1 + TI 12
+    expect(caster?.pendingAction).toMatchObject({ type: 'spell', energyCost: 10 });
+    expect(declared.log.at(-1)).toMatchObject({
+      type: 'spell_started',
+      actorId: 'mage',
+      costDT: 12,
+      nextActionAt: 13,
+      energySpent: 10
+    });
+  });
+
+  it('resolves the casting roll when the caster reaches the front (R-8.5)', () => {
+    const declared = declareSpellCast(
+      addCombatant(createCombatState(1), mageWithEnergy()),
+      'mage',
+      spell()
+    );
+
+    // Pool 6 (Int 4 + 2 points) vs difficulty 7: three dice >= 7 succeed.
+    const resolved = resolveNextAction(declared, {
+      randomInteger: scriptedRolls([7, 8, 9, 2, 3, 4])
+    });
+    const event = resolved.log.at(-1);
+
+    expect(event).toMatchObject({
+      type: 'spell_resolved',
+      actorId: 'mage',
+      atDT: 13,
+      successes: 3
+    });
+    expect(event?.spellCast?.success).toBe(true);
+  });
+
+  it('loses the committed energy when the incantation is interrupted (R-8.7)', () => {
+    const state = addCombatant(
+      addCombatant(createCombatState(1), mageWithEnergy()),
+      combatant({ id: 'rogue', speedFactor: 5 })
+    );
+    const declared = declareSpellCast(state, 'mage', spell());
+
+    const interrupted = interruptCombatant(declared, 'mage', 'release');
+    const caster = interrupted.timeline.find((entry) => entry.id === 'mage');
+
+    expect(caster?.energy).toEqual({ current: 50, max: 60 }); // committed energy is NOT refunded
+    expect(caster?.pendingAction).toBeUndefined();
+    expect(interrupted.log.at(-1)).toMatchObject({
+      type: 'action_interrupted',
+      actorId: 'mage',
+      actionType: 'spell'
+    });
+  });
+
+  it('rejects a cast the caster cannot pay for', () => {
+    const state = addCombatant(createCombatState(1), mageWithEnergy(5));
+
+    expect(() => declareSpellCast(state, 'mage', spell())).toThrow();
+  });
+
+  it('rejects casting for a combatant without an energy pool', () => {
+    const state = addCombatant(createCombatState(1), combatant({ id: 'fighter', speedFactor: 7 }));
+
+    expect(() => declareSpellCast(state, 'fighter', spell())).toThrow('no energy pool');
   });
 });

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -8,6 +8,7 @@ import {
   type WeaponDamageSpec
 } from './combat-damage.js';
 import { type DiceRollResult, type RandomInteger, rollDice } from './dice.js';
+import { resolveSpellCast, type SpellCastResult, spendEnergy } from './magic.js';
 import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
 import { type EffectModel } from './effect-model.js';
 import { applyEffectiveModifiers, computeEffectiveModifiers, effectiveValue } from './effects.js';
@@ -67,8 +68,35 @@ export interface DefenseAction {
   costDT?: number;
 }
 
+/**
+ * A spell action in the combat timeline. The casting fields are OPTIONAL so the same `'spell'`
+ * action type can also stand for a scheduled incantation placeholder (only a `costDT`), as the
+ * combat tracker UI uses it. A *resolvable cast* additionally carries the R-8.5 roll inputs
+ * (`intelligence` + `spellPoints` vs `difficulty`); `resolveNextAction` only rolls a cast when
+ * those are present, otherwise the action resolves as a generic timed action.
+ *
+ * The canonical entry point is `declareSpellCast`: it spends `energyCost` immediately (R-8.10) and
+ * schedules the caster `castingTimeDT` DT ahead (R-8.6 windup), so an interruption during that
+ * window loses the energy with no refund (R-8.7). `costDT` is the post-cast recovery (defaults to
+ * the effective speed factor).
+ */
 export interface SpellAction {
   type: 'spell';
+  /** Optional catalog id of the spell being cast (provenance / logging). */
+  spellId?: string;
+  /** R-8.5 — caster Intelligence (the cast pool is Intelligence + spellPoints). */
+  intelligence?: number;
+  /** R-8.5 — points invested in the spell (no skill, no specialisation). */
+  spellPoints?: number;
+  /** R-8.5 — agreed spell difficulty (may exceed 9, R-1.20). */
+  difficulty?: number;
+  /** R-8.10 — energy spent to cast, committed at declaration (lost if interrupted). */
+  energyCost?: number;
+  /** R-8.6 — incantation time in DT (the interruptible windup before the spell launches). */
+  castingTimeDT?: number;
+  /** Optional target of the spell (effect application is resolved by a later layer). */
+  targetId?: string;
+  /** Post-cast recovery in DT; defaults to the caster's effective speed factor. */
   costDT?: number;
 }
 
@@ -113,6 +141,8 @@ export interface Combatant {
   vitality: CombatVitality;
   /** R-9.17 — base (racial) max vitality for the lethal-zone death threshold; defaults to vitality.max. */
   baseVitalityMax?: number;
+  /** R-8.10 — spell energy pool ({ current, max }); required to declare a spell cast. */
+  energy?: CombatVitality;
   attributes: CombatAttributes;
   baseAttributes?: CombatAttributes;
   skills: CombatSkillSet;
@@ -130,6 +160,8 @@ export interface CombatEvent {
     | 'action_resolved'
     | 'action_interrupted'
     | 'attack_resolved'
+    | 'spell_started'
+    | 'spell_resolved'
     | 'damage_applied'
     | 'status_applied'
     | 'stamina_roll_resolved';
@@ -148,6 +180,10 @@ export interface CombatEvent {
   defenseRoll?: DiceRollResult;
   staminaRoll?: DiceRollResult;
   status?: CombatStatus;
+  /** R-8.5 — spell casting roll result (on `spell_resolved`). */
+  spellCast?: SpellCastResult;
+  /** R-8.10 — energy committed for a spell (on `spell_started`; lost if interrupted). */
+  energySpent?: number;
 }
 
 export interface CombatState {
@@ -255,6 +291,15 @@ export function resolveNextAction(
   if (action.type === 'attack') {
     return rescheduleActor(
       resolveAttack(activeState, actor, action, { costDT, nextActionAt }, options, config),
+      actor.id,
+      action,
+      config
+    );
+  }
+
+  if (action.type === 'spell' && isSpellCastReady(action)) {
+    return rescheduleActor(
+      resolveSpell(activeState, actor, action, { costDT, nextActionAt }, options),
       actor.id,
       action,
       config
@@ -387,8 +432,8 @@ export type InterruptOutcome = 'restart' | 'release';
  * R-9.4 — Interrupts a combatant's in-progress action. The DT already invested
  * since declaration are LOST (no partial benefit). With `release` the actor is
  * freed at the current DT; with `restart` it re-attempts the same action and pays
- * its full speed-factor cost again from now. Spell energy loss (R-9.31) applies
- * once energy is modeled.
+ * its full speed-factor cost again from now. A spell's energy is committed at
+ * `declareSpellCast`, so interrupting an in-progress cast loses it with no refund (R-8.7 / R-9.31).
  */
 export function interruptCombatant(
   state: CombatState,
@@ -420,6 +465,70 @@ export function interruptCombatant(
           actionType: interruptedAction?.type,
           costDT: lostDT,
           nextActionAt: next.nextActionAt
+        }
+      ]
+    },
+    next
+  );
+}
+
+/**
+ * R-8.5 / R-8.6 / R-8.7 — Commits a combatant to casting a spell from the current DT.
+ *
+ * The energy cost is spent immediately (R-8.10) and the caster is scheduled to resolve the cast
+ * `castingTimeDT` DT later (R-8.6): that window is the interruptible incantation. Because the
+ * energy is already committed, an `interruptCombatant` during the window loses it with no refund
+ * (R-8.7). Call this on the caster's turn, then advance the timeline with `resolveNextAction`,
+ * which resolves the casting roll when the caster reaches the front again.
+ */
+export function declareSpellCast(
+  state: CombatState,
+  casterId: string,
+  action: SpellAction
+): CombatState {
+  const caster = findCombatant(state, casterId);
+
+  if (caster.energy === undefined) {
+    throw new Error(`combatant ${casterId} has no energy pool and cannot cast spells`);
+  }
+
+  if (!isSpellCastReady(action)) {
+    throw new Error('declareSpellCast requires intelligence, spellPoints and difficulty (R-8.5)');
+  }
+
+  if (action.castingTimeDT === undefined) {
+    throw new Error('declareSpellCast requires castingTimeDT (R-8.6)');
+  }
+
+  if (action.energyCost === undefined) {
+    throw new Error('declareSpellCast requires energyCost (R-8.10)');
+  }
+
+  assertPositiveInteger('castingTimeDT', action.castingTimeDT);
+
+  const energy = spendEnergy(caster.energy, action.energyCost);
+  const nextActionAt = state.currentDT + action.castingTimeDT;
+  const next: Combatant = {
+    ...caster,
+    energy,
+    nextActionAt,
+    pendingAction: action
+  };
+
+  return replaceCombatant(
+    {
+      ...state,
+      log: [
+        ...state.log,
+        {
+          type: 'spell_started',
+          atDT: state.currentDT,
+          actorId: casterId,
+          ...(action.targetId !== undefined ? { targetId: action.targetId } : {}),
+          actionType: 'spell',
+          costDT: action.castingTimeDT,
+          nextActionAt,
+          energySpent: action.energyCost
         }
       ]
     },
@@ -522,6 +631,50 @@ function resolveAttack(
   }
 
   return withAttackLog;
+}
+
+/** A spell action that carries the R-8.5 roll inputs and can therefore be resolved as a cast. */
+type ResolvableSpellCast = SpellAction & {
+  intelligence: number;
+  spellPoints: number;
+  difficulty: number;
+};
+
+function isSpellCastReady(action: SpellAction): action is ResolvableSpellCast {
+  return (
+    action.intelligence !== undefined &&
+    action.spellPoints !== undefined &&
+    action.difficulty !== undefined
+  );
+}
+
+function resolveSpell(
+  state: CombatState,
+  actor: Combatant,
+  action: ResolvableSpellCast,
+  timing: { costDT: number; nextActionAt: number },
+  options: CombatResolutionOptions
+): CombatState {
+  const randomInteger = randomIntegerForResolution(options);
+  const spellCast = resolveSpellCast(action.intelligence, action.spellPoints, action.difficulty, {
+    randomInteger
+  });
+  const event: CombatEvent = {
+    type: 'spell_resolved',
+    atDT: state.currentDT,
+    actorId: actor.id,
+    ...(action.targetId !== undefined ? { targetId: action.targetId } : {}),
+    actionType: 'spell',
+    costDT: timing.costDT,
+    nextActionAt: timing.nextActionAt,
+    successes: spellCast.netSuccesses,
+    spellCast
+  };
+
+  return {
+    ...state,
+    log: [...state.log, event]
+  };
 }
 
 function rescheduleActor(


### PR DESCRIPTION
## Resume

M2 (Moteur de Magie D8, #164) — etape 3a : le **lancement de sort dans la timeline de combat** (mode live), branchant le jet R-8.5 et l'energie R-8.10 sur le moteur de combat.

- **`declareSpellCast(state, casterId, action)`** : engage le magicien depuis le DT courant — energie depensee immediatement (R-8.10), resolution planifiee `castingTimeDT` DT plus tard (R-8.6, le windup d'incantation). Emet `spell_started`.
- **Fenetre interruptible (R-8.7)** : l'energie etant deja engagee, `interruptCombatant` pendant l'incantation la perd sans remboursement (R-8.7 / R-9.31 — le hook attendait justement la modelisation de l'energie).
- **`resolveNextAction`** : quand le lanceur revient en tete, resout le jet via `resolveSpellCast` et emet `spell_resolved` (succes nets). Un sort **sans** parametres de jet reste une action minutee generique (placeholder du combat-tracker).
- Ajoute `Combatant.energy`, les evenements `spell_started` / `spell_resolved`, et des champs de cast **optionnels** sur `SpellAction` (meme patron que `AttackAction.damage`).

## Choix

- `SpellAction` porte `intelligence` : le combattant de combat n'a pas d'Intelligence dans `CombatAttributes`, donc le pool R-8.5 (Intelligence + spellPoints) vient de l'action, fournie par l'appelant.
- Champs de cast optionnels → le combat-tracker (apps/game) qui planifie un `{ type:'spell', costDT }` continue de typer et de se resoudre comme avant (aucune regression UI).

## Hors-perimetre (etapes suivantes de M2)

- Reduction de TI (R-8.8 : 2 energie/DT, plancher = FV).
- Malus de concentration (R-8.7 action conservee : +1 difficulte / point de degat subi pendant le TI).
- Application de l'**effet** du sort (degats/statut/buff) — releve du moteur d'effets + data sorts.

## Tests / gates

- `combat.test.ts` : +5 tests (engagement energie + windup ; resolution du jet en tete ; perte d'energie sur interruption ; refus si energie insuffisante ; refus sans pool d'energie) ; 38 tests combat.
- Local : lint OK, format:check OK, typecheck 7/7 (game inclus), **264** tests unitaires, canonical:check current.

Epic: #164
