### PR TITLE
feat(combat): reduction TI R-8.8 + concentration R-8.7 (M2 etape 3b)

### DIFF
--- a/packages/rules-core/src/combat.test.ts
+++ b/packages/rules-core/src/combat.test.ts
@@ -715,7 +715,7 @@ describe('zone-based KO and death (R-9.17)', () => {
   });
 });
 
-describe('spell casting in combat (R-8.5 / R-8.6 / R-8.7)', () => {
+describe('spell casting in combat (R-8.5 / R-8.6 / R-8.7 / R-8.8)', () => {
   const spell = (overrides: Partial<SpellAction> = {}): SpellAction => ({
     type: 'spell',
     intelligence: 4,
@@ -800,5 +800,53 @@ describe('spell casting in combat (R-8.5 / R-8.6 / R-8.7)', () => {
     const state = addCombatant(createCombatState(1), combatant({ id: 'fighter', speedFactor: 7 }));
 
     expect(() => declareSpellCast(state, 'fighter', spell())).toThrow('no energy pool');
+  });
+
+  it('reduces the windup by spending 2 energy per DT, flooring at the speed factor (R-8.8)', () => {
+    const state = addCombatant(createCombatState(1), mageWithEnergy());
+
+    const declared = declareSpellCast(state, 'mage', spell({ tiReductionDT: 5 }));
+    const caster = declared.timeline.find((entry) => entry.id === 'mage');
+
+    // FV 7, TI 12 -> reduced to 7 (the floor): 5 DT removed at +2 energy/DT.
+    expect(caster?.nextActionAt).toBe(8); // currentDT 1 + effective TI 7
+    expect(caster?.energy).toEqual({ current: 40, max: 60 }); // 60 - (10 + 2 * 5)
+    expect(declared.log.at(-1)).toMatchObject({
+      type: 'spell_started',
+      costDT: 7,
+      energySpent: 20
+    });
+  });
+
+  it('never reduces below the speed factor and only charges DT actually removed (R-8.8)', () => {
+    const state = addCombatant(createCombatState(1), mageWithEnergy());
+
+    const declared = declareSpellCast(state, 'mage', spell({ tiReductionDT: 10 }));
+    const caster = declared.timeline.find((entry) => entry.id === 'mage');
+
+    expect(caster?.nextActionAt).toBe(8); // floored at FV 7, not 12 - 10
+    expect(caster?.energy).toEqual({ current: 40, max: 60 }); // charged for the 5 DT removed, not 10
+  });
+
+  it('raises the cast difficulty by damage taken during the incantation (R-8.7)', () => {
+    const declared = declareSpellCast(
+      addCombatant(createCombatState(1), mageWithEnergy()),
+      'mage',
+      spell()
+    );
+    const hit = applyDamage(declared, 'mage', 2); // 2 damage suffered mid-incantation
+    const casting = hit.timeline.find((entry) => entry.id === 'mage');
+    expect(casting?.spellConcentrationDamage).toBe(2);
+
+    // difficulty 7 + 2 damage = 9; three dice >= 9 succeed.
+    const resolved = resolveNextAction(hit, { randomInteger: scriptedRolls([9, 9, 9, 2, 2, 2]) });
+    const event = resolved.log.at(-1);
+
+    expect(event?.spellCast?.difficulty).toBe(9);
+    expect(event).toMatchObject({ type: 'spell_resolved', successes: 3 });
+    // the accumulator is cleared once the cast resolves.
+    expect(resolved.timeline.find((entry) => entry.id === 'mage')?.spellConcentrationDamage).toBe(
+      undefined
+    );
   });
 });

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -94,6 +94,8 @@ export interface SpellAction {
   energyCost?: number;
   /** R-8.6 — incantation time in DT (the interruptible windup before the spell launches). */
   castingTimeDT?: number;
+  /** R-8.8 — DT shaved off the windup by spending 2 energy/DT; the TI floors at the speed factor. */
+  tiReductionDT?: number;
   /** Optional target of the spell (effect application is resolved by a later layer). */
   targetId?: string;
   /** Post-cast recovery in DT; defaults to the caster's effective speed factor. */
@@ -143,6 +145,8 @@ export interface Combatant {
   baseVitalityMax?: number;
   /** R-8.10 — spell energy pool ({ current, max }); required to declare a spell cast. */
   energy?: CombatVitality;
+  /** R-8.7 — damage suffered during the current incantation; raises the cast difficulty (+1/pt). */
+  spellConcentrationDamage?: number;
   attributes: CombatAttributes;
   baseAttributes?: CombatAttributes;
   skills: CombatSkillSet;
@@ -355,7 +359,11 @@ export function applyDamage(
         ...target.vitality,
         current: nextVitality
       },
-      nextActionAt: finalDamage > 0 ? target.nextActionAt + finalDamage : target.nextActionAt
+      nextActionAt: finalDamage > 0 ? target.nextActionAt + finalDamage : target.nextActionAt,
+      // R-8.7 — damage suffered mid-incantation accumulates and raises the eventual cast difficulty.
+      ...(target.pendingAction?.type === 'spell' && finalDamage > 0
+        ? { spellConcentrationDamage: (target.spellConcentrationDamage ?? 0) + finalDamage }
+        : {})
     },
     config
   );
@@ -450,7 +458,8 @@ export function interruptCombatant(
   const next: Combatant = {
     ...target,
     nextActionAt: restart ? state.currentDT + cost : state.currentDT,
-    pendingAction: restart ? interruptedAction : undefined
+    pendingAction: restart ? interruptedAction : undefined,
+    spellConcentrationDamage: undefined
   };
 
   return replaceCombatant(
@@ -484,7 +493,8 @@ export function interruptCombatant(
 export function declareSpellCast(
   state: CombatState,
   casterId: string,
-  action: SpellAction
+  action: SpellAction,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
 ): CombatState {
   const caster = findCombatant(state, casterId);
 
@@ -506,8 +516,20 @@ export function declareSpellCast(
 
   assertPositiveInteger('castingTimeDT', action.castingTimeDT);
 
-  const energy = spendEnergy(caster.energy, action.energyCost);
-  const nextActionAt = state.currentDT + action.castingTimeDT;
+  const reductionRequest = action.tiReductionDT ?? 0;
+  if (!Number.isInteger(reductionRequest) || reductionRequest < 0) {
+    throw new Error('tiReductionDT must be a non-negative integer');
+  }
+
+  // R-8.8 — spending 2 energy/DT shortens the windup, but never below the speed factor (web
+  // canonical floor) and never inflating an already-faster-than-FV spell.
+  const floor = Math.min(effectiveSpeedFactor(caster, config), action.castingTimeDT);
+  const effectiveTI = Math.max(floor, action.castingTimeDT - reductionRequest);
+  const actualReduction = action.castingTimeDT - effectiveTI;
+  const totalEnergyCost = action.energyCost + 2 * actualReduction;
+
+  const energy = spendEnergy(caster.energy, totalEnergyCost);
+  const nextActionAt = state.currentDT + effectiveTI;
   const next: Combatant = {
     ...caster,
     energy,
@@ -526,9 +548,9 @@ export function declareSpellCast(
           actorId: casterId,
           ...(action.targetId !== undefined ? { targetId: action.targetId } : {}),
           actionType: 'spell',
-          costDT: action.castingTimeDT,
+          costDT: effectiveTI,
           nextActionAt,
-          energySpent: action.energyCost
+          energySpent: totalEnergyCost
         }
       ]
     },
@@ -656,9 +678,15 @@ function resolveSpell(
   options: CombatResolutionOptions
 ): CombatState {
   const randomInteger = randomIntegerForResolution(options);
-  const spellCast = resolveSpellCast(action.intelligence, action.spellPoints, action.difficulty, {
-    randomInteger
-  });
+  // R-8.7 — the mage kept concentrating through the hits taken during the windup: the cast
+  // difficulty rises by +1 per damage point suffered during the incantation.
+  const concentrationPenalty = actor.spellConcentrationDamage ?? 0;
+  const spellCast = resolveSpellCast(
+    action.intelligence,
+    action.spellPoints,
+    action.difficulty + concentrationPenalty,
+    { randomInteger }
+  );
   const event: CombatEvent = {
     type: 'spell_resolved',
     atDT: state.currentDT,
@@ -689,7 +717,8 @@ function rescheduleActor(
   return replaceCombatant(state, {
     ...actor,
     nextActionAt: state.currentDT + delay,
-    pendingAction: undefined
+    pendingAction: undefined,
+    spellConcentrationDamage: undefined
   });
 }
 


### PR DESCRIPTION
## Resume

M2 (Moteur de Magie D8, #164) — etape 3b : finalise le **windup d'incantation** en combat avec la reduction de TI (R-8.8) et la concentration (R-8.7).

- **Reduction de TI (R-8.8)** : `declareSpellCast` accepte `tiReductionDT`. Chaque DT retire coute **2 energie** ; le TI plancher au **facteur de vitesse** (regle web canonique) et ne gonfle jamais un sort deja plus rapide que le FV. Seuls les DT *reellement* retires sont factures (sur-reduction plafonnee).
- **Concentration / action conservee (R-8.7)** : les degats subis **pendant** l'incantation s'accumulent (`Combatant.spellConcentrationDamage`, alimente par `applyDamage`) et augmentent la **difficulte** du jet de **+1 par point** a la resolution. Le compteur est remis a zero a la fin du sort comme a l'interruption.

## Choix

- `effectiveSpeedFactor` sert de plancher (coherent avec la timeline : encombrement R-2.18 + effets R-1.38 inclus).
- L'accumulation se declenche tant que `pendingAction.type === 'spell'` (la fenetre du windup) ; un placeholder UI sans jet n'en subit aucun effet visible.

## Hors-perimetre (etapes suivantes)

- Application de l'**effet** du sort (degats/statut/buff), resistance R-8.15, durees R-8.20 — MVP-resolution.

## Tests / gates

- `combat.test.ts` : +3 tests (reduction au plancher FV + cout 2/DT ; sur-reduction plafonnee ; malus +1/degat + reset) ; 41 tests combat.
- Local : lint OK, format:check OK, typecheck 7/7, **267** tests unitaires, canonical:check current.

Avec 3a, cela complete le coeur combat-integre de M2 : lancement (R-8.5) + energie (R-8.10) + TI/windup (R-8.6) + reduction (R-8.8) + interruption + concentration (R-8.7).

Epic: #164
