### PR TITLE
docs(combat): sync registre - sorts en combat (R-9.31) livres via M2

### DIFF
--- a/docs/canonical/canonical-matrix.yaml
+++ b/docs/canonical/canonical-matrix.yaml
@@ -267201,7 +267201,7 @@ units:
     sources:
       - path: "docs/plan/COMBAT-IMPLEMENTATION.md"
         ref: "docs/plan/COMBAT-IMPLEMENTATION.md"
-        sha256: "44189d3739a8bc526fa9f282cc1b8e36d448fccba9ccb9997fd4f3009180e693"
+        sha256: "1355f0efab3d97859fd0c9f14b2f921fcfc0dcf424596eecc3d75043c51e8da7"
     business_rule:
       summary: "docs/plan/COMBAT-IMPLEMENTATION.md from docs/plan/COMBAT-IMPLEMENTATION.md."
       ambiguity_ref: null

--- a/docs/canonical/nomos/canonical-matrix.yaml
+++ b/docs/canonical/nomos/canonical-matrix.yaml
@@ -136155,7 +136155,7 @@ units:
     source_refs:
       - source_id: DOCS-PLAN-COMBAT-IMPLEMENTATION
         locator: docs/plan/COMBAT-IMPLEMENTATION.md
-        hash: sha256:44189d3739a8bc526fa9f282cc1b8e36d448fccba9ccb9997fd4f3009180e693
+        hash: sha256:1355f0efab3d97859fd0c9f14b2f921fcfc0dcf424596eecc3d75043c51e8da7
     business_rule: docs/plan/COMBAT-IMPLEMENTATION.md from docs/plan/COMBAT-IMPLEMENTATION.md.
     status: partial
     gaps:

--- a/docs/canonical/nomos/source-manifest.yaml
+++ b/docs/canonical/nomos/source-manifest.yaml
@@ -20552,7 +20552,7 @@ sources:
     domain: project-governance
     priority: derived
     status: active
-    hash: 44189d3739a8bc526fa9f282cc1b8e36d448fccba9ccb9997fd4f3009180e693
+    hash: 1355f0efab3d97859fd0c9f14b2f921fcfc0dcf424596eecc3d75043c51e8da7
     owner: decarvalhoe
     license: proprietary
     confidentiality: internal

--- a/docs/canonical/source-manifest.yaml
+++ b/docs/canonical/source-manifest.yaml
@@ -13135,7 +13135,7 @@ sources:
     notes: "Project documentation source."
   - id: "docs-plan-combat-implementation"
     path: "docs/plan/COMBAT-IMPLEMENTATION.md"
-    sha256: "44189d3739a8bc526fa9f282cc1b8e36d448fccba9ccb9997fd4f3009180e693"
+    sha256: "1355f0efab3d97859fd0c9f14b2f921fcfc0dcf424596eecc3d75043c51e8da7"
     source_type: generated_doc
     priority: 40
     status: active

--- a/docs/plan/COMBAT-IMPLEMENTATION.md
+++ b/docs/plan/COMBAT-IMPLEMENTATION.md
@@ -33,8 +33,9 @@
 - [ ] **Allonge** (#3) — champ catalogue + modificateur d'engagement.
 - [ ] **Statuts R-9.27 de base** — catalogue (modificateurs/durée/immunités/interactions).
 
-**V2** : lutte/étreinte (R-9.41), monture (R-9.43), multi-cibles (R-9.36), sorts-en-combat (R-9.31),
+**V2** : lutte/étreinte (R-9.41), monture (R-9.43), multi-cibles (R-9.36),
 surprise (R-9.39), désengagement (R-9.38), tactiques de groupe (R-9.40), encodage des 88 atouts.
+_(Les sorts-en-combat (R-9.31) sont passés en MVP et livrés via M2 — voir `MAGIC-IMPLEMENTATION.md`.)_
 
 ## Registre exhaustif (toutes les règles de combat)
 
@@ -49,9 +50,9 @@ surprise (R-9.39), désengagement (R-9.38), tactiques de groupe (R-9.40), encoda
 | R-2.13                        | FV depuis la race                                   | MVP       | ✅     | attribut acteur                                                                                                         |
 | R-2.18                        | Encombrement → +1 FV / 5 kg                         | MVP       | ✅     | `combat.ts` `effectiveSpeedFactor`/`encumbrancePenalty` (+1 DT par 5 kg > Force×5, Force courante) ; `rules-config.ts`  |
 | R-1.38                        | Sources de modif du FV (magie/atouts)               | MVP       | ✅     | `combat.ts` `effectiveSpeedFactor` appelle `effects.ts` cible `factor` (hâte/lenteur/atouts), plancher `minSpeedFactor` |
-| R-9.4                         | Interruptions (DT perdus, 3 cas)                    | **MVP**   | 🟡     | `interruptCombatant` (restart/release, DT perdus) ; perte d'énergie de sort différée (pas de modèle d'énergie)          |
+| R-9.4                         | Interruptions (DT perdus, 3 cas)                    | **MVP**   | ✅     | `interruptCombatant` (restart/release, DT perdus) ; énergie de sort perdue (engagée au cast, `declareSpellCast`)        |
 | R-9.18-bis                    | Dégâts repoussent l'action (+1 DT/pt)               | MVP       | ✅     | `combat.ts` `applyDamage` (+finalDamage)                                                                                |
-| R-1.24                        | Action conservée : +1 diff / pt subi                | V2        | ❌     | pas d'état temporel `damageDuringAction`                                                                                |
+| R-1.24                        | Action conservée : +1 diff / pt subi                | V2        | 🟡     | implémenté pour la concentration de sort (`spellConcentrationDamage`, R-8.7) ; préemption générale ❌                   |
 | R-9.3                         | Recharge = viser/recharger/tirer (3 actions)        | **MVP**   | 🟡     | types d'action `reload`/`aim` (coût FV) ; séquence imposée + stock munitions à venir                                    |
 | atout `frappe-affaiblissante` | +FV sur cible blessée (50 DT/niv)                   | V2        | ❌     | catalogue seulement                                                                                                     |
 
@@ -89,7 +90,7 @@ surprise (R-9.39), désengagement (R-9.38), tactiques de groupe (R-9.40), encoda
 | ---------------------------------- | --------------------------- | -------------- | ------ | ------------------------------------------------------------------------------ |
 | EffectModel                        | cadre source/spec/render    | —              | ✅     | `effect-model.ts`, `effects.ts`, renderer                                      |
 | 88 specs atouts classe/orientation | modificateurs d'action      | V2             | ❌     | cadre prêt, **specs non encodées**                                             |
-| `target:'damage'`                  | bonus dégâts d'atout/sort   | MVP            | ❌     | enum présent, **non consommé** par le moteur (#137)                            |
+| `target:'damage'`                  | bonus dégâts d'atout/sort   | MVP            | ✅     | `combat.ts` `damageModifiersFromEffects` consomme `target:'damage'` (#137)     |
 | `requires_mj_validation`           | garde/juste-cause/méfait…   | MVP            | 🟡     | flag présent ; flux d'arbitrage ❌                                             |
 | prédilection (slots)               | arme/instrument/monture/…   | —              | ✅     | `predilection.ts`                                                              |
 | R-9.27                             | catalogue d'états tactiques | **MVP** (base) | 🟡     | 4 statuts nus ; `fou_furieux` ✅ ; **modificateurs/immunités/interactions ❌** |
@@ -116,7 +117,7 @@ surprise (R-9.39), désengagement (R-9.38), tactiques de groupe (R-9.40), encoda
 | R-9.41          | Lutte / étreinte (mains nues)                                                                                                | V2        | ❌                        |
 | R-9.43          | Combat monté                                                                                                                 | V2        | ❌                        |
 | R-9.44          | Coup de grâce / reddition / otage                                                                                            | V2        | ❌                        |
-| R-9.31          | Sorts en combat (incantation, interruption)                                                                                  | V2        | ❌                        |
+| R-9.31          | Sorts en combat (incantation, interruption)                                                                                  | MVP (M2)  | 🟡 (`declareSpellCast`)   |
 | R-9.29          | Transformation de race                                                                                                       | V2        | ❌                        |
 | R-9.28          | Apparition de PNJ / vagues / invocations                                                                                     | V2        | ❌                        |
 | R-9.32          | Déplacement / terrain / charge                                                                                               | V2        | ❌                        |


### PR DESCRIPTION
## Resume

Aligne le registre vivant **COMBAT-IMPLEMENTATION.md** sur le code apres l'integration magie (M2) :

- **R-9.31 (sorts en combat)** : V2 / ❌ -> **MVP / 🟡** (`declareSpellCast` + `resolveNextAction`, events `spell_started` / `spell_resolved`) ; retire de la liste V2.
- **R-9.4 (interruptions)** : 🟡 -> **✅** — l'energie de sort est perdue a l'interruption (engagee au cast).
- **R-1.24 (action conservee, +1 diff / pt subi)** : ❌ -> **🟡** — implementee pour la concentration de sort (`spellConcentrationDamage`, R-8.7) ; la preemption generale reste a faire.
- **`target:'damage'` (#137)** : ❌ -> **✅** — consomme par `damageModifiersFromEffects`.

Artefacts canoniques + NOMOS regeneres (`canonical:write` + `nomos:export`). Documentation vivante : aucun code modifie.

Epic: #164
