### PR TITLE
feat(rules-core): E1a - EffectModel successes + durees narratives (R-8.20)

### DIFF
--- a/packages/rules-core/src/effect-model.test.ts
+++ b/packages/rules-core/src/effect-model.test.ts
@@ -329,6 +329,18 @@ describe('evaluateValue', () => {
   it('evaluates table lookups by whitelisted key variable', () => {
     expect(evaluateValue({ table: 'energy_by_level', key: 'level' }, context)).toBe(12);
   });
+
+  it('evaluates the successes variable (effet mis a l’echelle par reussite, R-8.x)', () => {
+    expect(evaluateValue('successes', { successes: 3 })).toBe(3);
+    expect(evaluateValue('successes * 2', { successes: 3 })).toBe(6);
+    expect(evaluateValue('level + successes', { level: 4, successes: 2 })).toBe(6);
+  });
+
+  it('throws when successes is required but absent from the context', () => {
+    expect(() => evaluateValue('successes', context)).toThrow(
+      /Missing effect value variable "successes"/
+    );
+  });
 });
 
 describe('matchesCondition', () => {
@@ -380,5 +392,53 @@ describe('matchesCondition', () => {
         context
       )
     ).toBe(false);
+  });
+});
+
+describe('EffectModel narrative duration (R-8.20, systeme de temps double)', () => {
+  const withDuration = (duration: unknown) => ({
+    source: { prose: 'Effet dont la duree narrative depend du niveau.', ref: 'lexique:0' },
+    spec: {
+      target: 'vitality',
+      op: 'add',
+      value: 1,
+      activation: 'active',
+      duration
+    },
+    fidelity: 'pending'
+  });
+
+  it('parses a numeric narrative duration', () => {
+    const model = parseEffectModel(withDuration({ amount: 30, unit: 'minute' }));
+    expect(model.spec.duration).toEqual({ amount: 30, unit: 'minute' });
+  });
+
+  it('parses a narrative duration whose amount is a value expression', () => {
+    const model = parseEffectModel(withDuration({ amount: 'level * 10', unit: 'hour' }));
+    expect(model.spec.duration).toEqual({ amount: 'level * 10', unit: 'hour' });
+  });
+
+  it('accepts each whitelisted narrative unit', () => {
+    for (const unit of ['minute', 'hour', 'day'] as const) {
+      expect(() => parseEffectModel(withDuration({ amount: 1, unit }))).not.toThrow();
+    }
+  });
+
+  it('rejects an unknown narrative unit', () => {
+    expect(() => parseEffectModel(withDuration({ amount: 1, unit: 'week' }))).toThrow(
+      /effect duration unit/
+    );
+  });
+
+  it('rejects a non-positive numeric amount', () => {
+    expect(() => parseEffectModel(withDuration({ amount: 0, unit: 'minute' }))).toThrow(
+      /Effect duration amount/
+    );
+  });
+
+  it('rejects an unknown key inside a narrative duration', () => {
+    expect(() => parseEffectModel(withDuration({ amount: 1, unit: 'day', locked: true }))).toThrow(
+      /effect duration/
+    );
   });
 });

--- a/packages/rules-core/src/effect-model.ts
+++ b/packages/rules-core/src/effect-model.ts
@@ -21,10 +21,19 @@ export const EFFECT_ACTIVATIONS = ['passive', 'active', 'triggered'] as const;
 
 export type EffectActivation = (typeof EFFECT_ACTIVATIONS)[number];
 
+export const NARRATIVE_DURATION_UNITS = ['minute', 'hour', 'day'] as const;
+
+export type NarrativeDurationUnit = (typeof NARRATIVE_DURATION_UNITS)[number];
+
+/**
+ * `{ dt }` = durée de combat (DT). `{ amount, unit }` = durée narrative (R-8.20, le système de temps
+ * double) — `amount` peut être une expression (ex. `'level * 10'` pour « 10 min/niveau »).
+ */
 export type EffectDuration =
   | 'permanent'
   | 'ephemeral'
   | { dt: number | string; locked?: boolean }
+  | { amount: number | string; unit: NarrativeDurationUnit }
   | 'until_dispel';
 
 export const EFFECT_FIDELITIES = ['covered', 'ambiguous', 'pending'] as const;
@@ -43,7 +52,8 @@ export const EFFECT_VALUE_VARIABLES = [
   'empathy',
   'aestheticism',
   'vitalityMax',
-  'energyMax'
+  'energyMax',
+  'successes'
 ] as const;
 
 export type EffectValueVariable = (typeof EFFECT_VALUE_VARIABLES)[number];
@@ -252,6 +262,21 @@ function validateEffectValue(value: unknown): asserts value is EffectValue {
 
 function validateEffectDuration(duration: unknown): asserts duration is EffectDuration {
   if (duration === 'permanent' || duration === 'ephemeral' || duration === 'until_dispel') {
+    return;
+  }
+
+  if (isRecord(duration) && ('amount' in duration || 'unit' in duration)) {
+    assertKnownKeys(duration, ['amount', 'unit'], 'effect duration');
+
+    if (typeof duration.amount === 'number') {
+      assertPositiveInteger(duration.amount, 'Effect duration amount');
+    } else if (typeof duration.amount === 'string') {
+      parseValueExpression(duration.amount);
+    } else {
+      throw new Error('Effect duration amount must be a positive integer or value expression');
+    }
+
+    assertEnum(duration.unit, NARRATIVE_DURATION_UNITS, 'effect duration unit');
     return;
   }
 

--- a/packages/rules-core/src/effect-renderer.ts
+++ b/packages/rules-core/src/effect-renderer.ts
@@ -33,7 +33,8 @@ const VALUE_LABELS: Record<EffectValueVariable, string> = {
   empathy: 'Empathie',
   aestheticism: 'Esthétique',
   vitalityMax: 'vitalité maximale',
-  energyMax: 'énergie maximale'
+  energyMax: 'énergie maximale',
+  successes: 'réussite'
 };
 
 const SCOPE_LABELS: Record<string, string> = {

--- a/packages/rules-core/src/effects.ts
+++ b/packages/rules-core/src/effects.ts
@@ -210,6 +210,13 @@ function isDurationActive(duration: EffectDuration, ctx: EffectApplicationContex
     return ctx.includeEphemeral !== false;
   }
 
+  // Durée narrative (R-8.20, minutes/heures/jours) : hors de l'horloge DT du combat. Un tel effet
+  // reste actif pendant le combat ; son expiration relève du runtime double-horloge (E3), pas de
+  // l'agrégation de modificateurs ici.
+  if ('amount' in duration) {
+    return true;
+  }
+
   const dt = typeof duration.dt === 'number' ? duration.dt : evaluateValue(duration.dt, ctx);
 
   return ctx.elapsedDT === undefined || ctx.elapsedDT < dt;

--- a/packages/rules-core/src/status-effects.ts
+++ b/packages/rules-core/src/status-effects.ts
@@ -143,6 +143,12 @@ export function isStatusActive(
     return true;
   }
 
+  // Durée narrative (R-8.20) : hors de l'horloge DT du combat ; l'effet reste actif au regard de
+  // l'elapsedDT (son expiration relève du runtime double-horloge, E3).
+  if ('amount' in duration) {
+    return true;
+  }
+
   if (elapsedDT === undefined) {
     return true;
   }
@@ -247,7 +253,7 @@ function statusIdFor(activeStatus: ActiveStatusEntry): string {
 }
 
 function isLockedDuration(duration: EffectDuration | undefined): boolean {
-  return typeof duration === 'object' && duration.locked === true;
+  return typeof duration === 'object' && 'locked' in duration && duration.locked === true;
 }
 
 function isActivationSource(source: string): source is ActivationSource {


### PR DESCRIPTION
## Résumé

E1a — première brique du moteur d'effets de magie (vague E1). Étend `EffectModel`
(rules-core) avec deux primitives canoniques requises par la structuration des 324 sorts :

- **`successes`** : nouvelle variable de mise à l'échelle d'un effet **par réussite** (le pattern
  K&W `/R`). Ajoutée à `EFFECT_VALUE_VARIABLES`, évaluée depuis le contexte comme toute autre
  variable (ex. `'successes * 2'`, `'level + successes'`).
- **Durée narrative `{ amount, unit: minute|hour|day }`** : le second cadran du **système de temps
  double R-8.20**, distinct de la durée de combat `{ dt }`. `amount` accepte une expression
  (ex. `'level * 10'` pour « 10 min/niveau »).

Les consommateurs existants sont alignés sans changement de comportement combat : une durée
narrative est **hors horloge DT** (reste active pendant le combat ; son expiration relève du
runtime double-horloge **E3**, pas de l'agrégation de modificateurs).

## Fichiers

- `effect-model.ts` : `NARRATIVE_DURATION_UNITS`, variante `EffectDuration` narrative, `successes`,
  branche de validation de durée narrative.
- `effect-renderer.ts` : libellé FR `successes → « réussite »`.
- `effects.ts` / `status-effects.ts` : `isDurationActive`, `isStatusActive`, `isLockedDuration`
  narrowent correctement la nouvelle variante.
- `effect-model.test.ts` : +8 tests.

## Portée

Pur rules-core (5 fichiers TS) — aucune source/catalogue/doc canonique touchée, donc artefacts
canonical/NOMOS inchangés. Prépare **E1b** (resolveSpell applique l'effet structuré mis à l'échelle
par réussite, avec type de dégât pour les résistances).

## Test plan

- [x] `vitest run packages/rules-core` — 226/226 (dont effect-model 27/27)
- [x] `tsc -b` rules-core (typecheck)
- [x] eslint + prettier sur les 5 fichiers
- [ ] CI : Validate + 3 gates canonical/NOMOS verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
