### PR TITLE
feat(rules-core): E1b - resolveSpell applique l effet structure (par reussite)

### DIFF
--- a/packages/rules-core/src/combat.test.ts
+++ b/packages/rules-core/src/combat.test.ts
@@ -850,3 +850,166 @@ describe('spell casting in combat (R-8.5 / R-8.6 / R-8.7 / R-8.8)', () => {
     );
   });
 });
+
+describe('structured spell effects applied on resolution (E1b, R-8.5)', () => {
+  const spell = (overrides: Partial<SpellAction> = {}): SpellAction => ({
+    type: 'spell',
+    intelligence: 4,
+    spellPoints: 2,
+    difficulty: 7,
+    energyCost: 10,
+    castingTimeDT: 12,
+    ...overrides
+  });
+
+  const mage = () => ({
+    ...combatant({ id: 'mage', speedFactor: 7 }),
+    energy: { current: 60, max: 60 }
+  });
+
+  // Target parked far in the future so the mage's windup resolves first.
+  const target = (overrides: Partial<Combatant> = {}) =>
+    combatant({ id: 'orc', speedFactor: 6, nextActionAt: 999, ...overrides });
+
+  const damageEffect = parseEffectModel({
+    source: { prose: 'Inflige 2 points de degats de coupe par reussite.', ref: 'spells:exemple' },
+    spec: {
+      target: 'damage',
+      scope: 'C',
+      op: 'add',
+      value: 'successes * 2',
+      activation: 'active',
+      duration: 'ephemeral'
+    },
+    fidelity: 'covered',
+    ambiguity_ref: null
+  });
+
+  // Pool 6 (Int 4 + 2 points) vs difficulty 7: three dice >= 7 -> 3 net successes, no explosion/1s.
+  const threeSuccesses = () => scriptedRolls([7, 8, 9, 2, 3, 4]);
+
+  it('scales damage by net successes and carries the damage type for resistance (E1b)', () => {
+    const state = addCombatant(addCombatant(createCombatState(1), mage()), target());
+    const declared = declareSpellCast(
+      state,
+      'mage',
+      spell({ targetId: 'orc', effect: damageEffect })
+    );
+
+    const resolved = resolveNextAction(declared, { randomInteger: threeSuccesses() });
+
+    const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
+    expect(spellEvent?.successes).toBe(3);
+    expect(spellEvent?.spellEffect).toEqual({
+      target: 'damage',
+      op: 'add',
+      scope: 'C',
+      value: 6,
+      applied: true
+    });
+    // 10 vitality - (3 successes * 2) = 4
+    expect(resolved.timeline.find((e) => e.id === 'orc')?.vitality.current).toBe(4);
+  });
+
+  it('applies a heal using the structured formula, not a flat per-success heal (E1b)', () => {
+    // Apaisement-style: the prose formula governs the magnitude, not a naive +R.
+    const healEffect = parseEffectModel({
+      source: { prose: 'Restaure 1 point de vitalite par reussite.', ref: 'spells:soin' },
+      spec: {
+        target: 'vitality',
+        op: 'add',
+        value: 'successes',
+        activation: 'active',
+        duration: 'ephemeral'
+      },
+      fidelity: 'covered',
+      ambiguity_ref: null
+    });
+    const state = addCombatant(
+      addCombatant(createCombatState(1), mage()),
+      target({ id: 'ally', vitality: { current: 4, max: 10 } })
+    );
+    const declared = declareSpellCast(
+      state,
+      'mage',
+      spell({ targetId: 'ally', effect: healEffect })
+    );
+
+    const resolved = resolveNextAction(declared, { randomInteger: threeSuccesses() });
+
+    const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
+    expect(spellEvent?.spellEffect).toEqual({
+      target: 'vitality',
+      op: 'add',
+      value: 3,
+      applied: true
+    });
+    // 4 + 3 successes = 7 (heal is a negative vitality delta, capped at max)
+    expect(resolved.timeline.find((e) => e.id === 'ally')?.vitality.current).toBe(7);
+  });
+
+  it('does not apply the effect when the cast nets zero successes (R-8.5)', () => {
+    const state = addCombatant(addCombatant(createCombatState(1), mage()), target());
+    const declared = declareSpellCast(
+      state,
+      'mage',
+      spell({ targetId: 'orc', effect: damageEffect })
+    );
+
+    // No die >= 7 and no 1s: zero successes, no critical-failure D100.
+    const resolved = resolveNextAction(declared, {
+      randomInteger: scriptedRolls([2, 3, 4, 5, 6, 6])
+    });
+
+    const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
+    expect(spellEvent?.successes).toBe(0);
+    expect(spellEvent?.spellEffect).toBeUndefined();
+    expect(resolved.timeline.find((e) => e.id === 'orc')?.vitality.current).toBe(10);
+  });
+
+  it('reports a non-vitality effect without mutating the target (deferred to E3/E4)', () => {
+    const slowEffect = parseEffectModel({
+      source: { prose: 'Ralentit la cible (facteur de vitesse +2).', ref: 'spells:lenteur' },
+      spec: {
+        target: 'factor',
+        op: 'add',
+        value: 2,
+        activation: 'active',
+        duration: { dt: 20 }
+      },
+      fidelity: 'covered',
+      ambiguity_ref: null
+    });
+    const state = addCombatant(addCombatant(createCombatState(1), mage()), target());
+    const declared = declareSpellCast(
+      state,
+      'mage',
+      spell({ targetId: 'orc', effect: slowEffect })
+    );
+
+    const resolved = resolveNextAction(declared, { randomInteger: threeSuccesses() });
+
+    const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
+    expect(spellEvent?.spellEffect).toEqual({
+      target: 'factor',
+      op: 'add',
+      value: 2,
+      applied: false
+    });
+    // No damage_applied event and vitality intact: the modifier is left to its dedicated layer.
+    expect(resolved.log.some((e) => e.type === 'damage_applied')).toBe(false);
+    expect(resolved.timeline.find((e) => e.id === 'orc')?.vitality.current).toBe(10);
+  });
+
+  it('omits the effect outcome entirely when the spell carries no structured effect', () => {
+    const state = addCombatant(addCombatant(createCombatState(1), mage()), target());
+    const declared = declareSpellCast(state, 'mage', spell({ targetId: 'orc' }));
+
+    const resolved = resolveNextAction(declared, { randomInteger: threeSuccesses() });
+
+    const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
+    expect(spellEvent?.successes).toBe(3);
+    expect(spellEvent?.spellEffect).toBeUndefined();
+    expect(resolved.timeline.find((e) => e.id === 'orc')?.vitality.current).toBe(10);
+  });
+});

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -10,7 +10,13 @@ import {
 import { type DiceRollResult, type RandomInteger, rollDice } from './dice.js';
 import { resolveSpellCast, type SpellCastResult, spendEnergy } from './magic.js';
 import { DEFAULT_RULES_CONFIG, type RulesConfig } from './rules-config.js';
-import { type EffectModel } from './effect-model.js';
+import {
+  type EffectModel,
+  type EffectOperation,
+  type EffectTarget,
+  type EffectValueContext,
+  evaluateValue
+} from './effect-model.js';
 import { applyEffectiveModifiers, computeEffectiveModifiers, effectiveValue } from './effects.js';
 
 export const COMBAT_ROUND_LENGTH_DT = DEFAULT_RULES_CONFIG.combat.roundLengthDT;
@@ -96,8 +102,15 @@ export interface SpellAction {
   castingTimeDT?: number;
   /** R-8.8 — DT shaved off the windup by spending 2 energy/DT; the TI floors at the speed factor. */
   tiReductionDT?: number;
-  /** Optional target of the spell (effect application is resolved by a later layer). */
+  /** Optional target of the spell. */
   targetId?: string;
+  /**
+   * E1b — structured effect of the spell (provenance: catalog `spells.yaml`). When present and the
+   * cast nets ≥1 success, `resolveSpell` evaluates it with `successes` = net successes (R-8.5) and,
+   * for `damage`/`vitality` targets, applies it to `targetId`. The damage type is carried on the
+   * resolved outcome (`spellEffect.scope`) so the resistance layer (E4) can interpose.
+   */
+  effect?: EffectModel;
   /** Post-cast recovery in DT; defaults to the caster's effective speed factor. */
   costDT?: number;
 }
@@ -186,8 +199,25 @@ export interface CombatEvent {
   status?: CombatStatus;
   /** R-8.5 — spell casting roll result (on `spell_resolved`). */
   spellCast?: SpellCastResult;
+  /** E1b — resolved structured spell effect, scaled by net successes (on `spell_resolved`). */
+  spellEffect?: SpellEffectOutcome;
   /** R-8.10 — energy committed for a spell (on `spell_started`; lost if interrupted). */
   energySpent?: number;
+}
+
+/**
+ * E1b — a spell's structured effect after evaluation, scaled by the cast's net successes (R-8.5).
+ * `value` is the resolved numeric magnitude; `scope` carries the damage type (P/E/C/T) for a
+ * `damage` target so the resistance layer (E4) can interpose. `applied` is true when the outcome
+ * mutated the target's vitality during this resolution (damage / heal); other targets (factor,
+ * difficulty, status, energy…) are reported but not auto-applied here.
+ */
+export interface SpellEffectOutcome {
+  target: EffectTarget;
+  op: EffectOperation;
+  scope?: string;
+  value: number;
+  applied: boolean;
 }
 
 export interface CombatState {
@@ -303,7 +333,7 @@ export function resolveNextAction(
 
   if (action.type === 'spell' && isSpellCastReady(action)) {
     return rescheduleActor(
-      resolveSpell(activeState, actor, action, { costDT, nextActionAt }, options),
+      resolveSpell(activeState, actor, action, { costDT, nextActionAt }, options, config),
       actor.id,
       action,
       config
@@ -675,7 +705,8 @@ function resolveSpell(
   actor: Combatant,
   action: ResolvableSpellCast,
   timing: { costDT: number; nextActionAt: number },
-  options: CombatResolutionOptions
+  options: CombatResolutionOptions,
+  config: RulesConfig = DEFAULT_RULES_CONFIG
 ): CombatState {
   const randomInteger = randomIntegerForResolution(options);
   // R-8.7 — the mage kept concentrating through the hits taken during the windup: the cast
@@ -687,6 +718,14 @@ function resolveSpell(
     action.difficulty + concentrationPenalty,
     { randomInteger }
   );
+
+  // E1b — the spell takes effect only on a successful cast (≥1 net success, R-8.5). The structured
+  // effect is then evaluated with `successes` = net successes (per-réussite scaling, R-8.15).
+  const spellEffect =
+    action.effect !== undefined && spellCast.netSuccesses > 0
+      ? evaluateSpellEffect(action.effect, actor, action, spellCast.netSuccesses)
+      : undefined;
+
   const event: CombatEvent = {
     type: 'spell_resolved',
     atDT: state.currentDT,
@@ -696,13 +735,88 @@ function resolveSpell(
     costDT: timing.costDT,
     nextActionAt: timing.nextActionAt,
     successes: spellCast.netSuccesses,
-    spellCast
+    spellCast,
+    ...(spellEffect !== undefined ? { spellEffect } : {})
   };
 
-  return {
+  const loggedState: CombatState = {
     ...state,
     log: [...state.log, event]
   };
+
+  // Apply the vitality delta (positive = damage of type `scope`, negative = heal) to the target.
+  // The damage type is preserved on `spellEffect.scope`; resistance interposition is E4.
+  if (spellEffect?.applied === true && action.targetId !== undefined) {
+    const delta = spellVitalityDelta(spellEffect);
+    if (delta !== 0) {
+      return applyDamage(loggedState, action.targetId, delta, config);
+    }
+  }
+
+  return loggedState;
+}
+
+/**
+ * E1b — evaluates a spell's structured effect, scaling per net successes. `damage` and `vitality`
+ * targets resolve to a vitality delta applied to the target; other targets (factor, difficulty,
+ * status, energy…) are reported (`applied: false`) and left to their dedicated layers (E3/E4).
+ */
+function evaluateSpellEffect(
+  effect: EffectModel,
+  actor: Combatant,
+  action: ResolvableSpellCast,
+  netSuccesses: number
+): SpellEffectOutcome {
+  const spec = effect.spec;
+  const value = Math.round(
+    evaluateValue(spec.value, spellEffectContext(actor, action, netSuccesses))
+  );
+  const mutatesVitality =
+    spec.target === 'damage' ||
+    (spec.target === 'vitality' && (spec.op === 'add' || spec.op === 'sub'));
+
+  return {
+    target: spec.target,
+    op: spec.op,
+    ...(spec.scope !== undefined ? { scope: spec.scope } : {}),
+    value,
+    applied: mutatesVitality && action.targetId !== undefined
+  };
+}
+
+/**
+ * Builds the evaluation context from the caster. Combat only tracks the three physical attributes
+ * plus the spell pool's Intelligence (R-8.5); effects referencing unavailable variables (e.g.
+ * `level`) throw explicitly rather than guessing.
+ */
+function spellEffectContext(
+  actor: Combatant,
+  action: ResolvableSpellCast,
+  netSuccesses: number
+): EffectValueContext {
+  return {
+    successes: netSuccesses,
+    force: actor.attributes.strength,
+    dexterity: actor.attributes.dexterity,
+    stamina: actor.attributes.stamina,
+    intelligence: action.intelligence,
+    vitalityMax: actor.vitality.max,
+    ...(actor.energy !== undefined ? { energyMax: actor.energy.max } : {})
+  };
+}
+
+/**
+ * Signed vitality delta for `applyDamage` (positive = damage, negative = heal). `damage` and a
+ * `vitality` reduction (`sub`) deal damage; a `vitality` increase (`add`) heals.
+ */
+function spellVitalityDelta(outcome: SpellEffectOutcome): number {
+  if (outcome.target === 'damage') {
+    return outcome.value;
+  }
+  if (outcome.target === 'vitality') {
+    return outcome.op === 'add' ? -outcome.value : outcome.value;
+  }
+  return 0;
 }
 
 function rescheduleActor(


### PR DESCRIPTION
## Résumé

E1b — seconde brique du moteur d'effets de magie (vague E1, suite de #209). `resolveSpell`
**applique** désormais l'effet structuré d'un sort, mis à l'échelle par le nombre de réussites nettes.

- **`SpellAction.effect?: EffectModel`** — l'effet structuré (provenance : catalogue `spells.yaml`).
- **Application conditionnée à la réussite** : l'effet n'est évalué que si le cast nette **≥ 1
  réussite** (R-8.5), avec `successes` = réussites nettes dans le contexte d'évaluation (R-8.15).
- **`damage` / `vitality`** : applique le delta de vitalité à la cible (`applyDamage` ; positif =
  dégâts, négatif = soin).
  - **Le soin suit la FORMULE structurée** (ex. `successes`, `level`…), **jamais un `+R` naïf** —
    conformément à la remarque : les soins K&W sont rarement des soins basiques de combat.
  - **Le type de dégât** (`scope` = P/E/C/T) est porté sur l'issue résolue (`spellEffect.scope`)
    pour que la **couche de résistance (E4)** puisse s'interposer.
- **Cibles non-vitalité** (factor, difficulty, status, energy…) : **rapportées** (`applied: false`),
  laissées à leur couche dédiée (E3/E4) sans mutation prématurée.

## Fichiers

- `combat.ts` : `SpellAction.effect`, interface `SpellEffectOutcome`, `CombatEvent.spellEffect`,
  `resolveSpell` (eval + application + `config`), helpers `evaluateSpellEffect` /
  `spellEffectContext` / `spellVitalityDelta`.
- `combat.test.ts` : +5 tests.

## Portée

Pur rules-core (2 fichiers). Le champ `effect?` est **additif et optionnel** → typecheck repo-wide
vert (game/server/cms inchangés). Prépare **E2** (audit/structuration des 324 sorts en EffectModel)
et **E4** (résistance multi-couches qui consommera `spellEffect.scope`).

## Test plan

- [x] `vitest run packages/rules-core` — 231/231 (combat 46/46, dont 5 E1b)
- [x] `pnpm typecheck` (turbo) — 7/7 packages/apps
- [x] eslint + prettier sur les 2 fichiers
- [ ] CI : Validate + 3 gates canonical/NOMOS verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
