### PR TITLE
feat(rules-core): E4a - moteur de resistance magique + elementaire (R-8.15)

### DIFF
--- a/packages/rules-core/src/index.ts
+++ b/packages/rules-core/src/index.ts
@@ -13,6 +13,7 @@ export * from './money.js';
 export * from './npc-control.js';
 export * from './predilection.js';
 export * from './progression.js';
+export * from './resistance.js';
 export * from './rules-config.js';
 export * from './session.js';
 export * from './status-effects.js';

--- a/packages/rules-core/src/resistance.test.ts
+++ b/packages/rules-core/src/resistance.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveSpellResistance, rollResistance } from './resistance.js';
+
+/** Deterministic D100 source (consumes scripted values in order). */
+function scripted(values: number[]): (sides: number) => number {
+  let i = 0;
+  return (sides: number): number => {
+    const v = values[i];
+    i += 1;
+    if (v === undefined) throw new Error(`No scripted roll left for D${sides}`);
+    return v;
+  };
+}
+
+describe('rollResistance (R-1.32 — D100 ≤ %)', () => {
+  it('resists when the D100 is at or below the threshold', () => {
+    const r = rollResistance('magic', 40, 10, { randomInteger: scripted([40]) });
+    expect(r).toEqual({ layer: 'magic', percent: 40, roll: 40, resisted: true });
+  });
+
+  it('does not resist when the D100 exceeds the threshold', () => {
+    const r = rollResistance('elemental', 40, 10, { randomInteger: scripted([41]) });
+    expect(r).toEqual({ layer: 'elemental', percent: 40, roll: 41, resisted: false });
+  });
+
+  it('does not roll when the percent is zero', () => {
+    const r = rollResistance('magic', 0, 10, {
+      randomInteger: scripted([]) // throws if a roll is attempted
+    });
+    expect(r).toEqual({ layer: 'magic', percent: 0, resisted: false });
+  });
+
+  it('does not roll when the amount is zero', () => {
+    const r = rollResistance('elemental', 50, 0, { randomInteger: scripted([]) });
+    expect(r).toEqual({ layer: 'elemental', percent: 50, resisted: false });
+  });
+
+  it('rejects an out-of-range percent', () => {
+    expect(() => rollResistance('magic', 120, 10)).toThrow(/between 0 and 100/);
+  });
+
+  it('rejects a negative amount', () => {
+    expect(() => rollResistance('magic', 50, -1)).toThrow(/non-negative/);
+  });
+});
+
+describe('resolveSpellResistance — magie directe (R-8.15)', () => {
+  it('blocks an offensive direct spell when the magic resistance succeeds (bouclier)', () => {
+    const result = resolveSpellResistance(
+      { directMagic: true, beneficial: false, amount: 12 },
+      { magicPercent: 50 },
+      { randomInteger: scripted([30]) }
+    );
+    expect(result.amount).toBe(0);
+    expect(result.fullyResisted).toBe(true);
+    expect(result.burden).toBe(false);
+    expect(result.layers).toEqual([{ layer: 'magic', percent: 50, roll: 30, resisted: true }]);
+  });
+
+  it('blocks a BENEFICIAL direct spell as a burden (un soin résisté est perdu)', () => {
+    const result = resolveSpellResistance(
+      { directMagic: true, beneficial: true, amount: 8 },
+      { magicPercent: 50 },
+      { randomInteger: scripted([10]) }
+    );
+    expect(result.amount).toBe(0);
+    expect(result.fullyResisted).toBe(true);
+    expect(result.burden).toBe(true); // R-8.15 — la résistance magique est un fardeau ici
+  });
+
+  it('lets the direct spell through when the magic resistance fails', () => {
+    const result = resolveSpellResistance(
+      { directMagic: true, beneficial: false, amount: 12 },
+      { magicPercent: 50 },
+      { randomInteger: scripted([77]) }
+    );
+    expect(result.amount).toBe(12);
+    expect(result.fullyResisted).toBe(false);
+    expect(result.burden).toBe(false);
+  });
+
+  it('ignores elemental resistance for a direct spell (only the magic layer applies)', () => {
+    const result = resolveSpellResistance(
+      { directMagic: true, beneficial: false, element: 'feu', amount: 12 },
+      { magicPercent: 0, elementalPercent: { feu: 90 } },
+      { randomInteger: scripted([]) } // no roll: magicPercent 0 ⇒ no magic roll, elemental skipped
+    );
+    expect(result.amount).toBe(12);
+    expect(result.layers).toEqual([{ layer: 'magic', percent: 0, resisted: false }]);
+  });
+});
+
+describe('resolveSpellResistance — magie indirecte élémentaire', () => {
+  it('blocks an elemental spell when the matching elemental resistance succeeds', () => {
+    const result = resolveSpellResistance(
+      { directMagic: false, beneficial: false, element: 'feu', amount: 20 },
+      { elementalPercent: { feu: 36 } },
+      { randomInteger: scripted([20]) }
+    );
+    expect(result.amount).toBe(0);
+    expect(result.fullyResisted).toBe(true);
+    expect(result.layers).toEqual([{ layer: 'elemental', percent: 36, roll: 20, resisted: true }]);
+  });
+
+  it('routes by element: no resistance to the spell element ⇒ full damage', () => {
+    const result = resolveSpellResistance(
+      { directMagic: false, beneficial: false, element: 'foudre', amount: 20 },
+      { elementalPercent: { feu: 90 } }, // resistant to fire, not lightning
+      { randomInteger: scripted([1]) } // would resist if fire were checked
+    );
+    expect(result.amount).toBe(20);
+    expect(result.layers).toEqual([{ layer: 'elemental', percent: 0, resisted: false }]);
+  });
+
+  it('applies no layer for a non-direct spell without an element', () => {
+    const result = resolveSpellResistance(
+      { directMagic: false, beneficial: false, amount: 5 },
+      { magicPercent: 90, elementalPercent: { feu: 90 } },
+      { randomInteger: scripted([]) }
+    );
+    expect(result.amount).toBe(5);
+    expect(result.layers).toEqual([]);
+    expect(result.fullyResisted).toBe(false);
+  });
+});

--- a/packages/rules-core/src/resistance.ts
+++ b/packages/rules-core/src/resistance.ts
@@ -1,0 +1,154 @@
+/**
+ * E4 — Moteur de résistance multi-couches **magique + élémentaire** (R-1.32 / R-1.33 / R-8.15).
+ *
+ * Couche complémentaire au pipeline de dégâts physiques (`combat-damage.ts`, qui couvre déjà
+ * bouclier → résistance P/E/C/T → armure → endurance). Ce module ajoute les couches que la magie
+ * réclame et que le combat physique n'a pas :
+ *
+ *  - **Résistance magique (R-8.15)** : ne s'applique qu'à la **magie directe** (`direct_magic`), c.-à-d.
+ *    un sort qui agit directement sur la cible vivante (contrôle, transformation, illusion, **soin**,
+ *    bénédiction). C'est un **bouclier** contre les sorts directs offensifs, MAIS un **fardeau** sur
+ *    les sorts directs bénéfiques (un soin peut être « résisté » donc bloqué).
+ *  - **Résistance élémentaire** : pour la magie **indirecte** qui projette un élément (feu, foudre,
+ *    eau, froid…). Routée par nom d'élément ; distincte des types physiques P/E/C/T.
+ *
+ * Routage (R-1.33) : un sort **direct** transite par la résistance magique ; un sort **indirect**
+ * (élémentaire) par la résistance élémentaire (+ armure/endurance, gérées par `combat-damage`). Pas
+ * de résistance générique : chaque agression passe par la (les) couche(s) pertinente(s).
+ *
+ * Toute résistance utilise la mécanique **D100 ≤ %** (R-1.32), tout-ou-rien (comme le bouclier
+ * passif R-1.34) : un jet réussi annule entièrement l'effet de la couche.
+ */
+import { type RandomInteger } from './dice.js';
+
+/** Quelle couche a (ou non) résisté. */
+export type ResistanceLayer = 'magic' | 'elemental';
+
+export interface ResistanceRoll {
+  /** Couche évaluée. */
+  layer: ResistanceLayer;
+  /** Seuil de résistance en % (0..100). */
+  percent: number;
+  /** Le D100 jeté (absent si aucun jet n'était nécessaire : % nul ou montant nul). */
+  roll?: number;
+  /** Vrai si `roll <= percent` : la couche a résisté (effet annulé). */
+  resisted: boolean;
+}
+
+/**
+ * Vecteur d'agression d'un effet de sort sur une cible. `directMagic` et `element` décrivent
+ * comment l'effet atteint la cible ; `beneficial` distingue un soin/buff (pour le fardeau R-8.15).
+ */
+export interface SpellAggression {
+  /** R-8.15 : la magie agit-elle DIRECTEMENT sur la cible vivante ? (contrôle, soin, transformation) */
+  directMagic: boolean;
+  /** Soin / buff : si résisté par la magie, c'est un **fardeau** (l'effet bénéfique est bloqué). */
+  beneficial: boolean;
+  /** Élément projeté pour un sort indirect (feu, foudre, eau, froid…). */
+  element?: string;
+  /** Magnitude entrante (dégâts si offensif, soin si bénéfique). Entier ≥ 0. */
+  amount: number;
+}
+
+/** Profil de résistance de la cible (sommes par type, cf. R-3.5 `character_resistances`). */
+export interface TargetResistanceProfile {
+  /** % de résistance à la magie directe (R-8.15). */
+  magicPercent?: number;
+  /** % de résistance par élément (clé = nom d'élément). */
+  elementalPercent?: Record<string, number>;
+}
+
+export interface SpellResistanceResult {
+  /** Magnitude après résistance (0 si une couche a résisté ; sinon l'entrée inchangée). */
+  amount: number;
+  /** Couche(s) effectivement évaluée(s), avec leur jet. */
+  layers: ResistanceRoll[];
+  /** Vrai si une couche a annulé l'effet. */
+  fullyResisted: boolean;
+  /** Vrai si un sort direct **bénéfique** a été bloqué par la résistance magique (fardeau R-8.15). */
+  burden: boolean;
+}
+
+export interface ResistanceOptions {
+  randomInteger?: RandomInteger;
+}
+
+function assertPercent(label: string, value: number): void {
+  if (!Number.isInteger(value) || value < 0 || value > 100) {
+    throw new Error(`${label} must be an integer between 0 and 100`);
+  }
+}
+
+function assertNonNegativeInteger(label: string, value: number): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer`);
+  }
+}
+
+function defaultRandomInteger(sides: number): number {
+  return Math.floor(Math.random() * sides) + 1;
+}
+
+function rollD100(randomInteger: RandomInteger): number {
+  const value = randomInteger(100);
+  if (!Number.isInteger(value) || value < 1 || value > 100) {
+    throw new Error('randomInteger(100) must return an integer between 1 and 100');
+  }
+  return value;
+}
+
+/**
+ * R-1.32 — primitive de résistance : `D100 ≤ percent` ⇒ résisté (tout-ou-rien). Ne jette pas si
+ * `percent` est nul ou `amount` nul (rien à résister). `percent` est borné [0, 100].
+ */
+export function rollResistance(
+  layer: ResistanceLayer,
+  percent: number,
+  amount: number,
+  options: ResistanceOptions = {}
+): ResistanceRoll {
+  assertPercent(`${layer} resistance percent`, percent);
+  assertNonNegativeInteger(`${layer} resistance amount`, amount);
+  const randomInteger = options.randomInteger ?? defaultRandomInteger;
+  const shouldRoll = amount > 0 && percent > 0;
+  const roll = shouldRoll ? rollD100(randomInteger) : undefined;
+  const resisted = roll !== undefined && roll <= percent;
+  return { layer, percent, ...(roll !== undefined ? { roll } : {}), resisted };
+}
+
+/**
+ * Applique les couches de résistance **magie/élémentaire** à un effet de sort, routées par le
+ * vecteur d'agression (R-1.33) :
+ *  - sort **direct** → résistance magique (R-8.15), bouclier offensif ET fardeau bénéfique ;
+ *  - sort **indirect** avec élément → résistance élémentaire de cet élément.
+ *
+ * (L'armure P/E/C/T et l'endurance restent gérées par `combat-damage.ts` pour les dégâts physiques.)
+ */
+export function resolveSpellResistance(
+  aggression: SpellAggression,
+  profile: TargetResistanceProfile,
+  options: ResistanceOptions = {}
+): SpellResistanceResult {
+  assertNonNegativeInteger('aggression.amount', aggression.amount);
+  const layers: ResistanceRoll[] = [];
+  let amount = aggression.amount;
+  let burden = false;
+
+  if (aggression.directMagic) {
+    // R-8.15 — magie directe : la résistance magique s'applique (et SEULEMENT elle).
+    const roll = rollResistance('magic', profile.magicPercent ?? 0, amount, options);
+    layers.push(roll);
+    if (roll.resisted) {
+      amount = 0;
+      burden = aggression.beneficial; // un soin/buff bloqué = fardeau
+    }
+  } else if (aggression.element !== undefined) {
+    // Sort indirect élémentaire : résistance de l'élément concerné.
+    const percent = profile.elementalPercent?.[aggression.element] ?? 0;
+    const roll = rollResistance('elemental', percent, amount, options);
+    layers.push(roll);
+    if (roll.resisted) amount = 0;
+  }
+
+  return { amount, layers, fullyResisted: amount === 0 && aggression.amount > 0, burden };
+}


### PR DESCRIPTION
## Résumé

**E4a** — fondation du moteur de résistance **multi-couches** (R-1.32 / R-1.33 / R-8.15). Ajoute les
couches **magique** et **élémentaire** que la magie réclame, complémentaires au pipeline de dégâts
physiques déjà présent dans `combat-damage.ts` (bouclier → résistance P/E/C/T → armure → endurance).

- **`rollResistance(layer, percent, amount)`** — primitive **D100 ≤ %** (R-1.32), tout-ou-rien
  (comme le bouclier passif R-1.34). Ne jette pas si `percent` ou `amount` est nul ; borne [0, 100].
- **`resolveSpellResistance(aggression, profile)`** — route par **vecteur d'agression** (R-1.33) :
  - sort **direct** (`direct_magic`) → **résistance magique** (R-8.15) : **bouclier** sur l'offensif
    **ET fardeau** sur le bénéfique — un **soin résisté est perdu** (`burden: true`) ;
  - sort **indirect** avec `element` → **résistance élémentaire** de cet élément (feu/foudre/eau…) ;
  - pas de résistance générique : seules les couches pertinentes s'appliquent.

  L'armure P/E/C/T et l'endurance restent gérées par `combat-damage.ts`.

## Pourquoi maintenant

E1b fait porter le **type de dégât/élément** sur l'issue d'un sort (`spellEffect.scope`). E4a fournit
le moteur qui **consommera** ce type. **E4b** câblera `resolveSpell` (drapeau `direct_magic` du sort +
`effect_model.spec.scope`) pour interposer cette couche **avant** `applyDamage`.

## Portée

Pur rules-core (3 fichiers, additif) — aucune source canonique touchée.

## Test plan

- [x] `vitest run packages/rules-core` — 244/244 (résistance 13/13)
- [x] `tsc -b` rules-core (typecheck)
- [x] eslint + prettier
- [ ] CI : Validate + 3 gates canonical/NOMOS verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
