### PR TITLE
feat(rules-core): E4b - resolveSpell interpose la resistance (R-8.15)

### DIFF
--- a/packages/rules-core/src/combat.test.ts
+++ b/packages/rules-core/src/combat.test.ts
@@ -900,13 +900,15 @@ describe('structured spell effects applied on resolution (E1b, R-8.5)', () => {
 
     const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
     expect(spellEvent?.successes).toBe(3);
-    expect(spellEvent?.spellEffect).toEqual({
+    // Target carries no resistances: the elemental layer rolls nothing (percent 0) and passes through.
+    expect(spellEvent?.spellEffect).toMatchObject({
       target: 'damage',
       op: 'add',
       scope: 'C',
       value: 6,
       applied: true
     });
+    expect(spellEvent?.spellEffect?.resistance?.amount).toBe(6);
     // 10 vitality - (3 successes * 2) = 4
     expect(resolved.timeline.find((e) => e.id === 'orc')?.vitality.current).toBe(4);
   });
@@ -938,7 +940,7 @@ describe('structured spell effects applied on resolution (E1b, R-8.5)', () => {
     const resolved = resolveNextAction(declared, { randomInteger: threeSuccesses() });
 
     const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
-    expect(spellEvent?.spellEffect).toEqual({
+    expect(spellEvent?.spellEffect).toMatchObject({
       target: 'vitality',
       op: 'add',
       value: 3,
@@ -1010,6 +1012,180 @@ describe('structured spell effects applied on resolution (E1b, R-8.5)', () => {
     const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
     expect(spellEvent?.successes).toBe(3);
     expect(spellEvent?.spellEffect).toBeUndefined();
+    expect(resolved.timeline.find((e) => e.id === 'orc')?.vitality.current).toBe(10);
+  });
+});
+
+describe('spell resistance interposition (E4b, R-8.15 / R-1.33)', () => {
+  const spell = (overrides: Partial<SpellAction> = {}): SpellAction => ({
+    type: 'spell',
+    intelligence: 4,
+    spellPoints: 2,
+    difficulty: 7,
+    energyCost: 10,
+    castingTimeDT: 12,
+    ...overrides
+  });
+  const mage = () => ({
+    ...combatant({ id: 'mage', speedFactor: 7 }),
+    energy: { current: 60, max: 60 }
+  });
+  const target = (overrides: Partial<Combatant> = {}) =>
+    combatant({ id: 'orc', speedFactor: 6, nextActionAt: 999, ...overrides });
+
+  // Indirect elemental fire damage: 2/R -> 6 at 3 successes, scope feu.
+  const fireEffect = parseEffectModel({
+    source: { prose: '2 dégâts de feu par réussite.', ref: 'spells:fleche-de-feu' },
+    spec: {
+      target: 'damage',
+      scope: 'feu',
+      op: 'add',
+      value: '2 * successes',
+      activation: 'active',
+      duration: 'ephemeral'
+    },
+    fidelity: 'covered',
+    ambiguity_ref: null
+  });
+  // Cast: 3 successes from [7,8,9,2,3,4]; the trailing value is the resistance D100.
+  const cast = (d100: number) => scriptedRolls([7, 8, 9, 2, 3, 4, d100]);
+
+  it('elemental resistance fully blocks the damage on a successful D100 (R-1.32)', () => {
+    const state = addCombatant(
+      addCombatant(createCombatState(1), mage()),
+      target({ resistances: { elementalPercent: { feu: 50 } } })
+    );
+    const declared = declareSpellCast(
+      state,
+      'mage',
+      spell({ targetId: 'orc', effect: fireEffect })
+    );
+
+    // D100 30 <= 50 -> resisted.
+    const resolved = resolveNextAction(declared, { randomInteger: cast(30) });
+
+    const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
+    expect(spellEvent?.spellEffect?.resistance).toMatchObject({
+      amount: 0,
+      fullyResisted: true,
+      burden: false,
+      layers: [{ layer: 'elemental', percent: 50, roll: 30, resisted: true }]
+    });
+    // No damage applied: vitality intact.
+    expect(resolved.timeline.find((e) => e.id === 'orc')?.vitality.current).toBe(10);
+  });
+
+  it('elemental resistance lets the damage through when the D100 fails', () => {
+    const state = addCombatant(
+      addCombatant(createCombatState(1), mage()),
+      target({ resistances: { elementalPercent: { feu: 50 } } })
+    );
+    const declared = declareSpellCast(
+      state,
+      'mage',
+      spell({ targetId: 'orc', effect: fireEffect })
+    );
+
+    // D100 80 > 50 -> not resisted.
+    const resolved = resolveNextAction(declared, { randomInteger: cast(80) });
+
+    const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
+    expect(spellEvent?.spellEffect?.resistance).toMatchObject({ amount: 6, fullyResisted: false });
+    expect(resolved.timeline.find((e) => e.id === 'orc')?.vitality.current).toBe(4); // 10 - 6
+  });
+
+  it('routes by element: resistance to a different element does not block the damage', () => {
+    const state = addCombatant(
+      addCombatant(createCombatState(1), mage()),
+      target({ resistances: { elementalPercent: { foudre: 90 } } }) // resists lightning, not fire
+    );
+    const declared = declareSpellCast(
+      state,
+      'mage',
+      spell({ targetId: 'orc', effect: fireEffect })
+    );
+
+    // D100 1 would resist if lightning were checked; fire layer is percent 0 (no roll).
+    const resolved = resolveNextAction(declared, {
+      randomInteger: scriptedRolls([7, 8, 9, 2, 3, 4])
+    });
+
+    const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
+    expect(spellEvent?.spellEffect?.resistance?.amount).toBe(6);
+    expect(resolved.timeline.find((e) => e.id === 'orc')?.vitality.current).toBe(4);
+  });
+
+  it('magic resistance is a BURDEN: a direct beneficial heal can be blocked (R-8.15)', () => {
+    const healEffect = parseEffectModel({
+      source: { prose: '1 point de vitalité par réussite.', ref: 'spells:soin' },
+      spec: {
+        target: 'vitality',
+        op: 'add',
+        value: 'successes',
+        activation: 'active',
+        duration: 'ephemeral'
+      },
+      fidelity: 'covered',
+      ambiguity_ref: null
+    });
+    const state = addCombatant(
+      addCombatant(createCombatState(1), mage()),
+      target({ id: 'ally', vitality: { current: 4, max: 10 }, resistances: { magicPercent: 60 } })
+    );
+    const declared = declareSpellCast(
+      state,
+      'mage',
+      spell({ targetId: 'ally', effect: healEffect, directMagic: true })
+    );
+
+    // D100 20 <= 60 -> the magic resistance blocks the (beneficial) heal: burden.
+    const resolved = resolveNextAction(declared, { randomInteger: cast(20) });
+
+    const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
+    expect(spellEvent?.spellEffect?.resistance).toMatchObject({
+      amount: 0,
+      fullyResisted: true,
+      burden: true,
+      layers: [{ layer: 'magic', percent: 60, roll: 20, resisted: true }]
+    });
+    expect(resolved.timeline.find((e) => e.id === 'ally')?.vitality.current).toBe(4); // heal blocked
+  });
+
+  it('magic resistance is a SHIELD against a direct offensive spell', () => {
+    const mindCrush = parseEffectModel({
+      source: {
+        prose: '2 dégâts directs par réussite (contrôle mental).',
+        ref: 'spells:broiement'
+      },
+      spec: {
+        target: 'damage',
+        op: 'add',
+        value: '2 * successes',
+        activation: 'active',
+        duration: 'ephemeral'
+      },
+      fidelity: 'covered',
+      ambiguity_ref: null
+    });
+    const state = addCombatant(
+      addCombatant(createCombatState(1), mage()),
+      target({ resistances: { magicPercent: 50 } })
+    );
+    const declared = declareSpellCast(
+      state,
+      'mage',
+      spell({ targetId: 'orc', effect: mindCrush, directMagic: true })
+    );
+
+    const resolved = resolveNextAction(declared, { randomInteger: cast(30) }); // 30 <= 50 -> resisted
+
+    const spellEvent = resolved.log.find((e) => e.type === 'spell_resolved');
+    expect(spellEvent?.spellEffect?.resistance).toMatchObject({
+      amount: 0,
+      fullyResisted: true,
+      burden: false,
+      layers: [{ layer: 'magic', percent: 50, roll: 30, resisted: true }]
+    });
     expect(resolved.timeline.find((e) => e.id === 'orc')?.vitality.current).toBe(10);
   });
 });

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -18,6 +18,11 @@ import {
   evaluateValue
 } from './effect-model.js';
 import { applyEffectiveModifiers, computeEffectiveModifiers, effectiveValue } from './effects.js';
+import {
+  resolveSpellResistance,
+  type SpellResistanceResult,
+  type TargetResistanceProfile
+} from './resistance.js';
 
 export const COMBAT_ROUND_LENGTH_DT = DEFAULT_RULES_CONFIG.combat.roundLengthDT;
 
@@ -111,6 +116,13 @@ export interface SpellAction {
    * resolved outcome (`spellEffect.scope`) so the resistance layer (E4) can interpose.
    */
   effect?: EffectModel;
+  /**
+   * R-8.15 — whether the spell acts DIRECTLY on the living target (control, transformation, heal,
+   * blessing). Routes resistance: a direct spell is gated by magic resistance (shield offensively,
+   * burden on a beneficial spell); an indirect spell (e.g. a projected element) is gated by
+   * elemental resistance instead. Defaults to `false` (indirect). Provenance: spell `direct_magic`.
+   */
+  directMagic?: boolean;
   /** Post-cast recovery in DT; defaults to the caster's effective speed factor. */
   costDT?: number;
 }
@@ -170,6 +182,8 @@ export interface Combatant {
   carriedWeightKg?: number;
   /** R-1.38 — active effects that may modify the speed factor (haste, slowness, atouts). */
   activeEffects?: EffectModel[];
+  /** R-8.15 / R-1.33 — per-type resistance profile (magic %, elemental % by element). */
+  resistances?: TargetResistanceProfile;
 }
 
 export interface CombatEvent {
@@ -216,8 +230,15 @@ export interface SpellEffectOutcome {
   target: EffectTarget;
   op: EffectOperation;
   scope?: string;
+  /** Evaluated magnitude BEFORE resistance (successes-scaled). */
   value: number;
   applied: boolean;
+  /**
+   * E4b — resistance outcome (magic/elemental layers, R-8.15) when the effect is applied to a
+   * target. `resistance.amount` is the magnitude actually applied after the layers; `value` stays
+   * the pre-resistance magnitude. Absent when no target / not applied.
+   */
+  resistance?: SpellResistanceResult;
 }
 
 export interface CombatState {
@@ -721,10 +742,32 @@ function resolveSpell(
 
   // E1b — the spell takes effect only on a successful cast (≥1 net success, R-8.5). The structured
   // effect is then evaluated with `successes` = net successes (per-réussite scaling, R-8.15).
-  const spellEffect =
+  let spellEffect =
     action.effect !== undefined && spellCast.netSuccesses > 0
       ? evaluateSpellEffect(action.effect, actor, action, spellCast.netSuccesses)
       : undefined;
+
+  // E4b — interpose the magic/elemental resistance layers (R-8.15 / R-1.33) before applying the
+  // effect to the target. A direct spell is gated by magic resistance (shield, or burden on a
+  // beneficial spell); an indirect spell with an element is gated by elemental resistance. The
+  // applied magnitude is `resistance.amount` (0 if a layer fully resists).
+  let appliedDelta = 0;
+  if (spellEffect?.applied === true && action.targetId !== undefined) {
+    const target = findCombatant(state, action.targetId);
+    const beneficial = spellEffect.target === 'vitality' && spellEffect.op === 'add';
+    const resistance = resolveSpellResistance(
+      {
+        directMagic: action.directMagic ?? false,
+        beneficial,
+        ...(spellEffect.scope !== undefined ? { element: spellEffect.scope } : {}),
+        amount: spellEffect.value
+      },
+      target.resistances ?? {},
+      { randomInteger }
+    );
+    spellEffect = { ...spellEffect, resistance };
+    appliedDelta = spellEffectSign(spellEffect) * resistance.amount;
+  }
 
   const event: CombatEvent = {
     type: 'spell_resolved',
@@ -744,13 +787,8 @@ function resolveSpell(
     log: [...state.log, event]
   };
 
-  // Apply the vitality delta (positive = damage of type `scope`, negative = heal) to the target.
-  // The damage type is preserved on `spellEffect.scope`; resistance interposition is E4.
-  if (spellEffect?.applied === true && action.targetId !== undefined) {
-    const delta = spellVitalityDelta(spellEffect);
-    if (delta !== 0) {
-      return applyDamage(loggedState, action.targetId, delta, config);
-    }
+  if (appliedDelta !== 0 && action.targetId !== undefined) {
+    return applyDamage(loggedState, action.targetId, appliedDelta, config);
   }
 
   return loggedState;
@@ -806,15 +844,16 @@ function spellEffectContext(
 }
 
 /**
- * Signed vitality delta for `applyDamage` (positive = damage, negative = heal). `damage` and a
- * `vitality` reduction (`sub`) deal damage; a `vitality` increase (`add`) heals.
+ * Sign of the vitality delta for `applyDamage` (+1 = damage, -1 = heal). `damage` and a `vitality`
+ * reduction (`sub`) deal damage; a `vitality` increase (`add`) heals. Multiplied by the
+ * post-resistance magnitude to get the signed delta.
  */
-function spellVitalityDelta(outcome: SpellEffectOutcome): number {
+function spellEffectSign(outcome: SpellEffectOutcome): number {
   if (outcome.target === 'damage') {
-    return outcome.value;
+    return 1;
   }
   if (outcome.target === 'vitality') {
-    return outcome.op === 'add' ? -outcome.value : outcome.value;
+    return outcome.op === 'add' ? -1 : 1;
   }
   return 0;
 }


### PR DESCRIPTION
## Résumé

**E4b** — câble le moteur de résistance (E4a #214) dans `resolveSpell`, fermant la boucle
**dégâts/soin → résistance** dans le combat (R-8.15 / R-1.33).

- **`Combatant.resistances?`** : profil de résistance de la cible (`magicPercent`, `elementalPercent`
  par élément — somme des `character_resistances`, R-3.5).
- **`SpellAction.directMagic?`** : drapeau R-8.15 routant la couche de résistance (direct → magique ;
  indirect avec élément → élémentaire). Défaut `false`. Provenance : `direct_magic` du sort (audit Q-D8.2).
- **`resolveSpell`** : avant `applyDamage`, interpose `resolveSpellResistance` avec le vecteur
  d'agression `{ directMagic, beneficial (vitality+add), element (spellEffect.scope), amount }` et le
  profil de la cible. Magnitude appliquée = `signe(effet) × resistance.amount` (0 si une couche résiste).
- **`SpellEffectOutcome.resistance?`** : l'issue (couches D100, `fullyResisted`, `burden`) portée sur
  l'event `spell_resolved`. `value` reste la magnitude **avant** résistance.

## Comportement

- **Élémentaire** : un sort indirect avec `scope` (feu/foudre/eau…) passe par la résistance de cet
  élément — D100 ≤ % bloque entièrement, routé par élément.
- **Magie directe (R-8.15)** : **bouclier** contre un sort direct offensif ; **fardeau** sur un sort
  direct **bénéfique** — un soin peut être *résisté donc perdu* (`burden: true`).

## Test plan

- [x] `vitest run packages/rules-core` — 249/249 (combat 51/51, dont 5 E4b ; 2 E1b mis à jour)
- [x] `pnpm typecheck` (turbo) — 7/7 (champs additifs optionnels, game/server/cms inchangés)
- [x] eslint + prettier
- [ ] CI : Validate + 3 gates canonical/NOMOS verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
