### PR TITLE
fix(rules-core): R-8.19 - sens du test de volonte (D20 >= cible)

### DIFF
--- a/docs/canonical/canonical-matrix.yaml
+++ b/docs/canonical/canonical-matrix.yaml
@@ -189540,8 +189540,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 121"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 126"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "TI exprimé en DT (1 DT = 0,2 s, R-1 / R-2.13) from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -189792,8 +189792,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 104"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 108"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "Modificateurs de circonstances habituels (R-1.11) from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -190404,8 +190404,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 573"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 596"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "*Différence avec R-1.2** : ceci est une **exception au pattern standard** (pool = aptitude + compétence + spé). Les jets de résistance aux sorts utilisent l'aptitude **seule** parce qu'ils représentent la **résilience naturelle** de la cible, pas son entraînement spécifique. from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -190508,14 +190508,14 @@ units:
   - unit_id: "R-1.20#2"
     unit_type: "rule"
     domain: "D8-magie"
-    title: "| `difficulty` | Difficulté convenue du jet | int (peut > 9, R-1.20) |"
+    title: "| `difficulty`       | Difficulté convenue du jet                                                    | int (peut > 9, R-1.20) |"
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 76"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 78"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
-      summary: "| `difficulty` | Difficulté convenue du jet | int (peut > 9, R-1.20) | from docs/rules/08-magie.md."
+      summary: "| `difficulty`       | Difficulté convenue du jet                                                    | int (peut > 9, R-1.20) | from docs/rules/08-magie.md."
       ambiguity_ref: null
     yaml:
       status: not_applicable
@@ -190764,8 +190764,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 141"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 147"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "*Action conservée** (R-1.24) : un sort en cours **peut être conservé** si le magicien subit des dégâts — la difficulté du sort augmente alors de +1 par point de dégât subi pendant le TI (cf. règles d'action conservée, le magicien choisit de poursuivre malgré la perturbation). from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -190944,8 +190944,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 578"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 602"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "Cible fait un **test de volonté D20** (R-1.26 à R-1.29) from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -191016,8 +191016,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 580"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 604"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "1 = échec auto, 20 = réussite auto (R-1.27) from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -191124,8 +191124,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 579"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 603"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "Difficulté = `F.Volonté + réussites du sort attaquant` (R-1.28, le pont D10 → D20) from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -191444,14 +191444,14 @@ units:
   - unit_id: "R-1.32#3"
     unit_type: "rule"
     domain: "D8-magie"
-    title: "| `damage_type` | Si dégâts : P/E/C/T (R-1.32) | enum nullable |"
+    title: "| `damage_type`      | Si dégâts : P/E/C/T (R-1.32)                                                  | enum nullable          |"
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 81"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 83"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
-      summary: "| `damage_type` | Si dégâts : P/E/C/T (R-1.32) | enum nullable | from docs/rules/08-magie.md."
+      summary: "| `damage_type`      | Si dégâts : P/E/C/T (R-1.32)                                                  | enum nullable          | from docs/rules/08-magie.md."
       ambiguity_ref: null
     yaml:
       status: not_applicable
@@ -191588,14 +191588,14 @@ units:
   - unit_id: "R-1.33#3"
     unit_type: "rule"
     domain: "D8-magie"
-    title: "| `direct_magic` | Booléen : cible vivante directement (oui/non), pour résistance magique R-1.33 | bool |"
+    title: "| `direct_magic`     | Booléen : cible vivante directement (oui/non), pour résistance magique R-1.33 | bool                   |"
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 80"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 82"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
-      summary: "| `direct_magic` | Booléen : cible vivante directement (oui/non), pour résistance magique R-1.33 | bool | from docs/rules/08-magie.md."
+      summary: "| `direct_magic`     | Booléen : cible vivante directement (oui/non), pour résistance magique R-1.33 | bool                   | from docs/rules/08-magie.md."
       ambiguity_ref: null
     yaml:
       status: not_applicable
@@ -191844,8 +191844,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 98"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 101"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "*Difficulté** : la difficulté convenue du sort, modifiable par les modificateurs habituels (D1 R-1.36) : from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -196452,8 +196452,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 182"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 190"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "Partie D — Énergie (rappel D2 R-2.11) from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -196736,14 +196736,14 @@ units:
   - unit_id: "R-2.17#2"
     unit_type: "rule"
     domain: "D8-magie"
-    title: "| **Jet d'aptitude brute** | Aptitude seule (D10s) | **Résistance naturelle** : encaissement (R-2.17 endurance), résistance à un sort (« Contre jet d'X »), réflexe pur dans certains cas, etc. |"
+    title: "| **Jet d'aptitude brute**          | Aptitude seule (D10s)                     | **Résistance naturelle** : encaissement (R-2.17 endurance), résistance à un sort (« Contre jet d'X »), réflexe pur dans certains cas, etc. |"
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 591"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 615"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
-      summary: "| **Jet d'aptitude brute** | Aptitude seule (D10s) | **Résistance naturelle** : encaissement (R-2.17 endurance), résistance à un sort (« Contre jet d'X »), réflexe pur dans certains cas, etc. | from docs/rules/08-magie.md."
+      summary: "| **Jet d'aptitude brute**          | Aptitude seule (D10s)                     | **Résistance naturelle** : encaissement (R-2.17 endurance), résistance à un sort (« Contre jet d'X »), réflexe pur dans certains cas, etc. | from docs/rules/08-magie.md."
       ambiguity_ref: null
     yaml:
       status: not_applicable
@@ -198577,7 +198577,7 @@ units:
     sources:
       - path: "docs/rules/08-magie.md"
         ref: "line 3"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "> Système magique du jeu. 11 écoles, ~889 sorts catalogués (web), magicien comme orientation exclusive (sauf exceptions D4 R-4.9), familiers, mécanique de drain et de captage. Reprend les règles déjà actées en D1 (résistance), D2 (énergie), D4 (orientation magicien), D5 (apprentissage), D7 (résurrection). from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -199224,8 +199224,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 96"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 99"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "*Pas de compétence d'utilisation** — les sorts ne sont pas des compétences (cf. D5 R-5.6-bis). Pas de spécialisations sur les sorts. from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -199296,8 +199296,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 439"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 457"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "*Durée d'apprentissage en jours** : règle D5 R-5.6-ter. from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -199836,8 +199836,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 31"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 32"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "*Statut** : 🟢 claire (cf. D6 R-6.3) from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201348,8 +201348,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 17"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 18"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.1 — Définition de la magie from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201384,8 +201384,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 184"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 192"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.10 — Modèle d'énergie consolidé from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201456,8 +201456,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 208"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 216"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.11 — Variantes de sort (mineur, majeur, masse, distance) from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201492,8 +201492,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 228"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 238"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.12 — Développement de sort (atouts Magicien) from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201564,8 +201564,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 258"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 270"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.13-a — Forme, taille et vitalité from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201600,8 +201600,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 269"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 281"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.13-b — Feuille et budget de création du familier from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201636,8 +201636,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 307"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 319"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.13-c — Restrictions propres au familier from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201672,8 +201672,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 316"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 328"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.13-d — Coût des atouts et handicaps du familier from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201708,8 +201708,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 337"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 349"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.13-e — Passage de niveau, mort et renaissance from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201744,8 +201744,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 354"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 366"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.13-f — Atouts liés au familier from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201780,8 +201780,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 369"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 381"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.13-g — Statut from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201852,8 +201852,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 242"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 253"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.13 — Familier : entité magique distincte des compagnons/montures from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201960,8 +201960,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 381"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 394"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.14 — Sorts et atouts de manipulation d'énergie / vie from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -201996,8 +201996,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 402"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 415"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.15 — Résistance magique (rappel D1 R-1.33) from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -202032,8 +202032,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 416"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 430"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.16 — Spécificités de l'apprentissage de sorts from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -202068,8 +202068,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 457"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 476"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.17 — Catalogue des atouts magiciens from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -202104,8 +202104,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 502"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 521"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.18 — Tables et liaisons from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -202140,8 +202140,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 584"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 608"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.19 — Nouveau type de jet : aptitude brute from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -202212,8 +202212,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 25"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 26"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.2 — Engagement à vie de la voie magique from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -202248,8 +202248,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 675"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 706"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "*Voir nouvelle règle structurante R-8.20 ci-dessous** — c'est un système qui dépasse la magie et structure tout le moteur de jeu. from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -202320,8 +202320,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 38"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 40"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.3 — Les 11 écoles de magie from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -202356,8 +202356,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 66"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 68"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.4 — Schéma d'un sort from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -202392,8 +202392,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 89"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 91"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.5 — Lancement d'un sort (rappel D1 R-1.4) from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -202460,14 +202460,14 @@ units:
   - unit_id: "R-8.6"
     unit_type: "rule"
     domain: "D8-magie"
-    title: "| `incantation_time` | TI — Temps d'Incantation en DT (R-8.6) | int ≥ 1 |"
+    title: "| `incantation_time` | TI — Temps d'Incantation en DT (R-8.6)                                        | int ≥ 1                |"
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 75"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 77"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
-      summary: "| `incantation_time` | TI — Temps d'Incantation en DT (R-8.6) | int ≥ 1 | from docs/rules/08-magie.md."
+      summary: "| `incantation_time` | TI — Temps d'Incantation en DT (R-8.6)                                        | int ≥ 1                | from docs/rules/08-magie.md."
       ambiguity_ref: null
     yaml:
       status: not_applicable
@@ -202536,8 +202536,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 123"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 128"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "Pendant l'incantation, le magicien est **vulnérable** (concentration requise, R-8.7) from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -202572,8 +202572,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 145"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 151"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.8 — Réduction du TI par dépense d'énergie from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -202608,8 +202608,8 @@ units:
     status: partial
     sources:
       - path: "docs/rules/08-magie.md"
-        ref: "line 167"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        ref: "line 175"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "R-8.9 — Atouts qui modifient le TI ou la concentration from docs/rules/08-magie.md."
       ambiguity_ref: null
@@ -349439,7 +349439,7 @@ units:
     sources:
       - path: "docs/rules/08-magie.md"
         ref: "docs/rules/08-magie.md"
-        sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+        sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     business_rule:
       summary: "docs/rules/08-magie.md from docs/rules/08-magie.md."
       ambiguity_ref: null

--- a/docs/canonical/nomos/canonical-matrix.yaml
+++ b/docs/canonical/nomos/canonical-matrix.yaml
@@ -102384,8 +102384,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 121
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 126
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: TI exprimé en DT (1 DT = 0,2 s, R-1 / R-2.13) from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -102521,8 +102521,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 104
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 108
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: Modificateurs de circonstances habituels (R-1.11) from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -102881,8 +102881,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 573
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 596
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: >-
       *Différence avec R-1.2** : ceci est une **exception au pattern standard** (pool = aptitude + compétence + spé).
       Les jets de résistance aux sorts utilisent l'aptitude **seule** parce qu'ils représentent la **résilience
@@ -102942,14 +102942,18 @@ units:
       - collection: knowledge_chunks
   - unit_id: R-1-20-2
     unit_type: rule
-    name: '| `difficulty` | Difficulté convenue du jet | int (peut > 9, R-1.20) |'
+    name: >-
+      | `difficulty`       | Difficulté convenue du jet                                                    | int (peut >
+      9, R-1.20) |
     domain: d8-magie
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 76
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
-    business_rule: '| `difficulty` | Difficulté convenue du jet | int (peut > 9, R-1.20) | from docs/rules/08-magie.md.'
+        locator: line 78
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
+    business_rule: >-
+      | `difficulty`       | Difficulté convenue du jet                                                    | int (peut >
+      9, R-1.20) | from docs/rules/08-magie.md.
     status: partial
     gaps:
       - 'relational_db: Canonical relational tables/import evidence pending.'
@@ -103092,8 +103096,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 141
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 147
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: >-
       *Action conservée** (R-1.24) : un sort en cours **peut être conservé** si le magicien subit des dégâts — la
       difficulté du sort augmente alors de +1 par point de dégât subi pendant le TI (cf. règles d'action conservée, le
@@ -103196,8 +103200,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 578
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 602
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: Cible fait un **test de volonté D20** (R-1.26 à R-1.29) from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -103234,8 +103238,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 580
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 604
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: 1 = échec auto, 20 = réussite auto (R-1.27) from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -103302,8 +103306,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 579
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 603
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: Difficulté = `F.Volonté + réussites du sort attaquant` (R-1.28, le pont D10 → D20) from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -103476,14 +103480,18 @@ units:
       - collection: knowledge_chunks
   - unit_id: R-1-32-3
     unit_type: rule
-    name: '| `damage_type` | Si dégâts : P/E/C/T (R-1.32) | enum nullable |'
+    name: >-
+      | `damage_type`      | Si dégâts : P/E/C/T (R-1.32)                                                  | enum
+      nullable          |
     domain: d8-magie
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 81
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
-    business_rule: '| `damage_type` | Si dégâts : P/E/C/T (R-1.32) | enum nullable | from docs/rules/08-magie.md.'
+        locator: line 83
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
+    business_rule: >-
+      | `damage_type`      | Si dégâts : P/E/C/T (R-1.32)                                                  | enum
+      nullable          | from docs/rules/08-magie.md.
     status: partial
     gaps:
       - 'relational_db: Canonical relational tables/import evidence pending.'
@@ -103560,16 +103568,18 @@ units:
       - collection: knowledge_chunks
   - unit_id: R-1-33-3
     unit_type: rule
-    name: '| `direct_magic` | Booléen : cible vivante directement (oui/non), pour résistance magique R-1.33 | bool |'
+    name: >-
+      | `direct_magic`     | Booléen : cible vivante directement (oui/non), pour résistance magique R-1.33 |
+      bool                   |
     domain: d8-magie
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 80
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 82
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: >-
-      | `direct_magic` | Booléen : cible vivante directement (oui/non), pour résistance magique R-1.33 | bool | from
-      docs/rules/08-magie.md.
+      | `direct_magic`     | Booléen : cible vivante directement (oui/non), pour résistance magique R-1.33 |
+      bool                   | from docs/rules/08-magie.md.
     status: partial
     gaps:
       - 'relational_db: Canonical relational tables/import evidence pending.'
@@ -103713,8 +103723,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 98
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 101
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: >-
       *Difficulté** : la difficulté convenue du sort, modifiable par les modificateurs habituels (D1 R-1.36) : from
       docs/rules/08-magie.md.
@@ -106216,8 +106226,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 182
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 190
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: Partie D — Énergie (rappel D2 R-2.11) from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -106364,17 +106374,18 @@ units:
   - unit_id: R-2-17-2
     unit_type: rule
     name: >-
-      | **Jet d'aptitude brute** | Aptitude seule (D10s) | **Résistance naturelle** : encaissement (R-2.17 endurance),
-      résistance à un sort (« Contre jet d'X »), réflexe pur dans certains cas, etc. |
+      | **Jet d'aptitude brute**          | Aptitude seule (D10s)                     | **Résistance naturelle** :
+      encaissement (R-2.17 endurance), résistance à un sort (« Contre jet d'X »), réflexe pur dans certains cas, etc. |
     domain: d8-magie
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 591
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 615
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: >-
-      | **Jet d'aptitude brute** | Aptitude seule (D10s) | **Résistance naturelle** : encaissement (R-2.17 endurance),
-      résistance à un sort (« Contre jet d'X »), réflexe pur dans certains cas, etc. | from docs/rules/08-magie.md.
+      | **Jet d'aptitude brute**          | Aptitude seule (D10s)                     | **Résistance naturelle** :
+      encaissement (R-2.17 endurance), résistance à un sort (« Contre jet d'X »), réflexe pur dans certains cas, etc. |
+      from docs/rules/08-magie.md.
     status: partial
     gaps:
       - 'relational_db: Canonical relational tables/import evidence pending.'
@@ -107410,7 +107421,7 @@ units:
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
         locator: line 3
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: >-
       > Système magique du jeu. 11 écoles, ~889 sorts catalogués (web), magicien comme orientation exclusive (sauf
       exceptions D4 R-4.9), familiers, mécanique de drain et de captage. Reprend les règles déjà actées en D1
@@ -107767,8 +107778,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 96
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 99
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: >-
       *Pas de compétence d'utilisation** — les sorts ne sont pas des compétences (cf. D5 R-5.6-bis). Pas de
       spécialisations sur les sorts. from docs/rules/08-magie.md.
@@ -107807,8 +107818,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 439
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 457
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: '*Durée d''apprentissage en jours** : règle D5 R-5.6-ter. from docs/rules/08-magie.md.'
     status: partial
     gaps:
@@ -108098,8 +108109,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 31
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 32
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: '*Statut** : 🟢 claire (cf. D6 R-6.3) from docs/rules/08-magie.md.'
     status: partial
     gaps:
@@ -108929,8 +108940,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 17
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 18
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.1 — Définition de la magie from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -108948,8 +108959,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 184
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 192
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.10 — Modèle d'énergie consolidé from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -108988,8 +108999,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 208
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 216
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.11 — Variantes de sort (mineur, majeur, masse, distance) from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109007,8 +109018,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 228
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 238
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.12 — Développement de sort (atouts Magicien) from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109049,8 +109060,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 258
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 270
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.13-a — Forme, taille et vitalité from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109068,8 +109079,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 269
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 281
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.13-b — Feuille et budget de création du familier from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109087,8 +109098,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 307
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 319
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.13-c — Restrictions propres au familier from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109106,8 +109117,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 316
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 328
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.13-d — Coût des atouts et handicaps du familier from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109125,8 +109136,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 337
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 349
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.13-e — Passage de niveau, mort et renaissance from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109144,8 +109155,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 354
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 366
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.13-f — Atouts liés au familier from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109163,8 +109174,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 369
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 381
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.13-g — Statut from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109205,8 +109216,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 242
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 253
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: 'R-8.13 — Familier : entité magique distincte des compagnons/montures from docs/rules/08-magie.md.'
     status: partial
     gaps:
@@ -109262,8 +109273,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 381
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 394
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.14 — Sorts et atouts de manipulation d'énergie / vie from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109281,8 +109292,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 402
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 415
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.15 — Résistance magique (rappel D1 R-1.33) from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109300,8 +109311,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 416
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 430
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.16 — Spécificités de l'apprentissage de sorts from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109319,8 +109330,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 457
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 476
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.17 — Catalogue des atouts magiciens from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109338,8 +109349,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 502
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 521
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.18 — Tables et liaisons from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109357,8 +109368,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 584
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 608
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: 'R-8.19 — Nouveau type de jet : aptitude brute from docs/rules/08-magie.md.'
     status: partial
     gaps:
@@ -109397,8 +109408,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 25
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 26
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.2 — Engagement à vie de la voie magique from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109418,8 +109429,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 675
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 706
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: >-
       *Voir nouvelle règle structurante R-8.20 ci-dessous** — c'est un système qui dépasse la magie et structure tout le
       moteur de jeu. from docs/rules/08-magie.md.
@@ -109466,8 +109477,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 38
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 40
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.3 — Les 11 écoles de magie from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109485,8 +109496,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 66
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 68
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.4 — Schéma d'un sort from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109504,8 +109515,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 89
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 91
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.5 — Lancement d'un sort (rappel D1 R-1.4) from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109541,14 +109552,18 @@ units:
       - collection: knowledge_chunks
   - unit_id: R-8-6
     unit_type: rule
-    name: '| `incantation_time` | TI — Temps d''Incantation en DT (R-8.6) | int ≥ 1 |'
+    name: >-
+      | `incantation_time` | TI — Temps d'Incantation en DT (R-8.6)                                        | int ≥
+      1                |
     domain: d8-magie
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 75
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
-    business_rule: '| `incantation_time` | TI — Temps d''Incantation en DT (R-8.6) | int ≥ 1 | from docs/rules/08-magie.md.'
+        locator: line 77
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
+    business_rule: >-
+      | `incantation_time` | TI — Temps d'Incantation en DT (R-8.6)                                        | int ≥
+      1                | from docs/rules/08-magie.md.
     status: partial
     gaps:
       - 'relational_db: Canonical relational tables/import evidence pending.'
@@ -109588,8 +109603,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 123
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 128
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: Pendant l'incantation, le magicien est **vulnérable** (concentration requise, R-8.7) from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109607,8 +109622,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 145
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 151
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.8 — Réduction du TI par dépense d'énergie from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -109626,8 +109641,8 @@ units:
     criticality: critical
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
-        locator: line 167
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        locator: line 175
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: R-8.9 — Atouts qui modifient le TI ou la concentration from docs/rules/08-magie.md.
     status: partial
     gaps:
@@ -183158,7 +183173,7 @@ units:
     source_refs:
       - source_id: DOCS-RULES-08-MAGIE
         locator: docs/rules/08-magie.md
-        hash: sha256:9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+        hash: sha256:54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     business_rule: docs/rules/08-magie.md from docs/rules/08-magie.md.
     status: partial
     gaps:

--- a/docs/canonical/nomos/source-manifest.yaml
+++ b/docs/canonical/nomos/source-manifest.yaml
@@ -21060,7 +21060,7 @@ sources:
     domain: D8-magie
     priority: primary
     status: active
-    hash: 9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288
+    hash: 54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0
     owner: decarvalhoe
     license: proprietary
     confidentiality: internal

--- a/docs/canonical/source-manifest.yaml
+++ b/docs/canonical/source-manifest.yaml
@@ -13450,7 +13450,7 @@ sources:
     notes: "Canonical rule document."
   - id: "docs-rules-08-magie"
     path: "docs/rules/08-magie.md"
-    sha256: "9073e72b6e899c8ea3d24033012c19dd86fe10bee71b914e51d17b33fad9d288"
+    sha256: "54c877b72a39492cd81755470bb16dbe1bbe33b49bd78aaa31332902f266ead0"
     source_type: canonical_rule
     priority: 100
     status: active

--- a/docs/rules/08-magie.md
+++ b/docs/rules/08-magie.md
@@ -3,12 +3,13 @@
 > Système magique du jeu. 11 écoles, ~889 sorts catalogués (web), magicien comme orientation exclusive (sauf exceptions D4 R-4.9), familiers, mécanique de drain et de captage. Reprend les règles déjà actées en D1 (résistance), D2 (énergie), D4 (orientation magicien), D5 (apprentissage), D7 (résurrection).
 
 **Sources** :
+
 - [documents/regles/index.md:91-134](documents/regles/index.md) — section Magie + Énergie + TI + Familier + Repos
 - [documents/grimoire/index.md](documents/grimoire/index.md) — 2621 lignes, 11 écoles, ~889 entrées (web canonique)
 - [regles-papier/extracted/listes/grand-grimoire.md](regles-papier/extracted/listes/grand-grimoire.md) — version paper (448 lignes, plus condensée)
 - [regles-papier/extracted/listes/lexique.md](regles-papier/extracted/listes/lexique.md) — atouts liés à la magie
 - [regles-papier/extracted/listes/atouts-de-niveaux.md](regles-papier/extracted/listes/atouts-de-niveaux.md) — atouts magiciens par niveau
-- [site/includes/managers/_DBManager.php:820-851](site/includes/managers/_DBManager.php) — `getAllSpells`, `insertSpell`
+- [site/includes/managers/\_DBManager.php:820-851](site/includes/managers/_DBManager.php) — `getAllSpells`, `insertSpell`
 
 ---
 
@@ -31,6 +32,7 @@
 **Statut** : 🟢 claire (cf. D6 R-6.3)
 
 **Exceptions au principe** (cf. D4 R-4.9) :
+
 - **Vampire + Art occulte** (atout racial N2) : non-magicien acquiert un sort + 40 energy
 - **Polyvalence** : non-magicien peut accéder aux atouts magiciens d'autres orientations
 - **Effets liés à la race** : Dryade (Lingua vegetalis, Vegothropie), Ondine (Chant envoûtant) — mécaniques magico-inspirées sans nécessiter l'orientation magicien
@@ -41,19 +43,19 @@
 
 > Il existe 11 sources d'énergie qui donnent lieu à 11 types de magies, avec chacune leurs couleurs et leurs magiciens.
 
-| # | École | Couleur | Magicien spécialiste | Source d'énergie / domaine |
-|---|---|---|---|---|
-| 1 | Abjuration | Jaune | Abjurateur | Anti-magie : annule, dévie, perturbe les sorts d'autrui |
-| 2 | Altération | Rouge | Altérateur | Évolution / changement / transformation physique |
-| 3 | Magie blanche | Blanc | Clerc | Vibrations positives : restaure, protège, augmente |
-| 4 | Divination | Brun | Devin | Temps et réalité : informations, perception |
-| 5 | Enchantement | Turquoise | Enchanteur | Désir et espoir : contournement de la réalité |
-| 6 | Élémentaire | Bleu | Élémentariste | Feu, air, terre, eau, roche, foudre, lave, glace, fumée |
-| 7 | Illusion | Violet | Illusionniste | Esprit : fausse réalité |
-| 8 | Invocation | Orange | Invocateur | Espace : juxtaposer lieux/distances pour invoquer |
-| 9 | Magie naturelle | Vert | Druide ou Chaman | Organique et vie : alliance avec la nature |
-| 10 | Magie noire | Noir | Sorcier | Vibrations négatives : dégrade, affaiblit, diminue |
-| 11 | Nécromancie | Gris | Nécromancien | Mort : contrôle des morts |
+| #   | École           | Couleur   | Magicien spécialiste | Source d'énergie / domaine                              |
+| --- | --------------- | --------- | -------------------- | ------------------------------------------------------- |
+| 1   | Abjuration      | Jaune     | Abjurateur           | Anti-magie : annule, dévie, perturbe les sorts d'autrui |
+| 2   | Altération      | Rouge     | Altérateur           | Évolution / changement / transformation physique        |
+| 3   | Magie blanche   | Blanc     | Clerc                | Vibrations positives : restaure, protège, augmente      |
+| 4   | Divination      | Brun      | Devin                | Temps et réalité : informations, perception             |
+| 5   | Enchantement    | Turquoise | Enchanteur           | Désir et espoir : contournement de la réalité           |
+| 6   | Élémentaire     | Bleu      | Élémentariste        | Feu, air, terre, eau, roche, foudre, lave, glace, fumée |
+| 7   | Illusion        | Violet    | Illusionniste        | Esprit : fausse réalité                                 |
+| 8   | Invocation      | Orange    | Invocateur           | Espace : juxtaposer lieux/distances pour invoquer       |
+| 9   | Magie naturelle | Vert      | Druide ou Chaman     | Organique et vie : alliance avec la nature              |
+| 10  | Magie noire     | Noir      | Sorcier              | Vibrations négatives : dégrade, affaiblit, diminue      |
+| 11  | Nécromancie     | Gris      | Nécromancien         | Mort : contrôle des morts                               |
 
 **Tous les magiciens peuvent lancer n'importe quel sort** ([regles:106](documents/regles/index.md)). Les magiciens spécialisés ont juste **plus de facilité** sur les sorts de leur école (-1 difficulté via l'atout permanent de classe « Magie X »).
 
@@ -67,20 +69,20 @@
 
 D'après le Grand Grimoire, chaque sort a les attributs suivants :
 
-| Attribut | Description | Type |
-|---|---|---|
-| `name` | Nom du sort | string |
-| `school` | École (Abj, Alt, Bla, Bru, Ble, Enc, Ill, Inv, Nat, Noi, Nec) | enum |
-| `energy_cost` | Coût en points d'énergie pour lancer | int ≥ 0 |
-| `incantation_time` | TI — Temps d'Incantation en DT (R-8.6) | int ≥ 1 |
-| `difficulty` | Difficulté convenue du jet | int (peut > 9, R-1.20) |
-| `effect` | Description courte de l'effet | text |
-| `value` | Valeur (richesse) du sort, ex: prix d'achat ou de vente | int |
-| `description_full` | Description complète (lexique) | text (optionnel) |
-| `direct_magic` | Booléen : cible vivante directement (oui/non), pour résistance magique R-1.33 | bool |
-| `damage_type` | Si dégâts : P/E/C/T (R-1.32) | enum nullable |
-| `range` | Portée (mètres / rayon) — souvent paramétrée par niveau du lanceur | string |
-| `duration` | Durée d'effet (souvent en min/niveau ou DT/réussite) | string |
+| Attribut           | Description                                                                   | Type                   |
+| ------------------ | ----------------------------------------------------------------------------- | ---------------------- |
+| `name`             | Nom du sort                                                                   | string                 |
+| `school`           | École (Abj, Alt, Bla, Bru, Ble, Enc, Ill, Inv, Nat, Noi, Nec)                 | enum                   |
+| `energy_cost`      | Coût en points d'énergie pour lancer                                          | int ≥ 0                |
+| `incantation_time` | TI — Temps d'Incantation en DT (R-8.6)                                        | int ≥ 1                |
+| `difficulty`       | Difficulté convenue du jet                                                    | int (peut > 9, R-1.20) |
+| `effect`           | Description courte de l'effet                                                 | text                   |
+| `value`            | Valeur (richesse) du sort, ex: prix d'achat ou de vente                       | int                    |
+| `description_full` | Description complète (lexique)                                                | text (optionnel)       |
+| `direct_magic`     | Booléen : cible vivante directement (oui/non), pour résistance magique R-1.33 | bool                   |
+| `damage_type`      | Si dégâts : P/E/C/T (R-1.32)                                                  | enum nullable          |
+| `range`            | Portée (mètres / rayon) — souvent paramétrée par niveau du lanceur            | string                 |
+| `duration`         | Durée d'effet (souvent en min/niveau ou DT/réussite)                          | string                 |
 
 **Statut** : 🟢 claire
 
@@ -89,6 +91,7 @@ D'après le Grand Grimoire, chaque sort a les attributs suivants :
 ### R-8.5 — Lancement d'un sort (rappel D1 R-1.4)
 
 **Pool de dés** :
+
 ```
 pool = Intelligence + points dans le sort
 ```
@@ -96,6 +99,7 @@ pool = Intelligence + points dans le sort
 **Pas de compétence d'utilisation** — les sorts ne sont pas des compétences (cf. D5 R-5.6-bis). Pas de spécialisations sur les sorts.
 
 **Difficulté** : la difficulté convenue du sort, modifiable par les modificateurs habituels (D1 R-1.36) :
+
 - Atout « Magie X » de la classe magicien spécialiste : -1 sur les sorts de l'école
 - Atout « Énergie à l'honneur » : -1 sur une école choisie pendant 10 min/niveau (Magicien N4)
 - Atout « Énergie au déshonneur » (abjurateur N4) : +1 sur une école adverse (saboté)
@@ -118,6 +122,7 @@ pool = Intelligence + points dans le sort
 > Abrévié TI, le temps d'incantation représente le temps nécessaire à l'incantation d'un sort, en **DT** (division de temps, 0,2 s par DT). Il s'agit d'un laps de temps durant lequel le magicien récitera une formule magique et effectuera un mouvement de la main.
 
 **Modèle** :
+
 - TI exprimé en DT (1 DT = 0,2 s, R-1 / R-2.13)
 - Variable selon le sort : de 4 DT (sorts simples) à 192 DT (Contact divin) — soit 0,8 s à ~38 s
 - Pendant l'incantation, le magicien est **vulnérable** (concentration requise, R-8.7)
@@ -133,6 +138,7 @@ pool = Intelligence + points dans le sort
 > Pour relancer un sort annulé, il faut reprendre celui-ci depuis le début.
 
 **Mécanique** :
+
 - Un sort interrompu (bousculade, son, dégâts subis) → **annulation totale**
 - Énergie dépensée = **perdue** (pas remboursée)
 - Aucun effet ne se produit
@@ -149,12 +155,14 @@ pool = Intelligence + points dans le sort
 > Pour avoir plus de chances de réussir à lancer son sort (voir en être certain), le magicien a la possibilité de **diminuer son temps d'incantation**. Pour se faire, le lanceur devra dépenser **2 points d'énergie supplémentaires par division de temps (DT) en moins**. Une incantation ne peut être descendue en dessous du **facteur de vitesse du personnage**.
 
 **⚠️ Divergence web/paper** déjà notée en sources.md :
+
 - **Web (canonique)** : minimum = facteur de vitesse du perso
 - **Paper** : minimum = **1 DT** (toujours possible)
 
 **Décision** : web fait foi → minimum = `speedFactor` du magicien.
 
 **Mécanique** :
+
 ```
 TI_effectif = max(speedFactor, TI_base - DT_supprimées)
 coût_énergie_total = energy_cost + 2 × DT_supprimées
@@ -185,19 +193,19 @@ coût_énergie_total = energy_cost + 2 × DT_supprimées
 
 Déjà acté en D2 R-2.11 (extensible "exception est la règle") :
 
-| Attribut | Source | Effet |
-|---|---|---|
-| `energyMax` base | Magicien orientation : 60. Non-magicien : 0. | Plafond standard |
-| Progression XP | 3 XP par +1 (Experience.doc) | Augmente le plafond |
-| Atout « Énergie latente » (Magicien N2 perm) | +3 × niveau d'atout par passage de niveau | Augmente le plafond |
-| Atout « Art occulte » (Vampire N2 racial) | +40 (cumulable pour plusieurs sorts) | Cas exception : non-magicien acquiert energy |
-| Potions d'énergie | Variables (D10) | Restaure ou ajoute temporairement |
-| Atout « Débordement d'énergie » (Magicien N5 perm) | Permet de dépasser energyMax via potions ou drain | Pas de plafond de fait |
-| Sort « Captage d'énergie » (Abjuration) | Vol d'énergie sur un magicien en cours d'incantation : +3 par R | Source temporaire |
-| Sort « Don d'énergie » (Magie blanche) | Donne 3 d'énergie/R à une cible | Transfert volontaire |
-| Atout « Sacrifice d'énergie » (Magicien N3 perm) | Drain d'énergie sur un autre magicien (1m/niveau) | Vol direct |
-| Atout « Inversion des énergies » (Magicien N12 perm) | Lance des sorts en consommant la **vitalité** au lieu de l'énergie | Conversion énergie ↔ vitalité |
-| Repos (R-2.11 confirmé R-2.10 révisé D3) | 8h = 100% restauration de `energy` jusqu'à `energyMax` | Récupération naturelle |
+| Attribut                                             | Source                                                             | Effet                                        |
+| ---------------------------------------------------- | ------------------------------------------------------------------ | -------------------------------------------- |
+| `energyMax` base                                     | Magicien orientation : 60. Non-magicien : 0.                       | Plafond standard                             |
+| Progression XP                                       | 3 XP par +1 (Experience.doc)                                       | Augmente le plafond                          |
+| Atout « Énergie latente » (Magicien N2 perm)         | +3 × niveau d'atout par passage de niveau                          | Augmente le plafond                          |
+| Atout « Art occulte » (Vampire N2 racial)            | +40 (cumulable pour plusieurs sorts)                               | Cas exception : non-magicien acquiert energy |
+| Potions d'énergie                                    | Variables (D10)                                                    | Restaure ou ajoute temporairement            |
+| Atout « Débordement d'énergie » (Magicien N5 perm)   | Permet de dépasser energyMax via potions ou drain                  | Pas de plafond de fait                       |
+| Sort « Captage d'énergie » (Abjuration)              | Vol d'énergie sur un magicien en cours d'incantation : +3 par R    | Source temporaire                            |
+| Sort « Don d'énergie » (Magie blanche)               | Donne 3 d'énergie/R à une cible                                    | Transfert volontaire                         |
+| Atout « Sacrifice d'énergie » (Magicien N3 perm)     | Drain d'énergie sur un autre magicien (1m/niveau)                  | Vol direct                                   |
+| Atout « Inversion des énergies » (Magicien N12 perm) | Lance des sorts en consommant la **vitalité** au lieu de l'énergie | Conversion énergie ↔ vitalité                |
+| Repos (R-2.11 confirmé R-2.10 révisé D3)             | 8h = 100% restauration de `energy` jusqu'à `energyMax`             | Récupération naturelle                       |
 
 **Statut** : 🟢 claire
 
@@ -208,6 +216,7 @@ Déjà acté en D2 R-2.11 (extensible "exception est la règle") :
 ### R-8.11 — Variantes de sort (mineur, majeur, masse, distance)
 
 **Indice grimoire** : on voit dans le catalogue des variantes nommées :
+
 - « Bouclier mineur » / « Bouclier » / « Bouclier majeur »
 - « Branchies » / « Branchies de masse »
 - « Bénédiction » / « Bénédiction de masse »
@@ -215,6 +224,7 @@ Déjà acté en D2 R-2.11 (extensible "exception est la règle") :
 - « Corrosion » / « Corrosion de masse »
 
 **Mécanique** : un sort peut avoir des variantes :
+
 - **Mineur** : version simplifiée, moins puissante, moins coûteuse
 - **(Standard)** : version normale
 - **Majeur** : version améliorée, plus puissante, plus coûteuse
@@ -228,7 +238,8 @@ Chaque variante est un **sort distinct** dans le grimoire, avec ses propres éne
 ### R-8.12 — Développement de sort (atouts Magicien)
 
 **Atouts** :
-- **Développement** ([lexique:356](regles-papier/extracted/listes/lexique.md), Magicien) : *« Le magicien peut développer et apprendre un sort qu'il possède en sort mineur, majeur ou standard. Le temps du développement dure le double du temps d'apprentissage du sort sur lequel travaille le personnage. »* — coût XP web : 4000 (table de pondération)
+
+- **Développement** ([lexique:356](regles-papier/extracted/listes/lexique.md), Magicien) : _« Le magicien peut développer et apprendre un sort qu'il possède en sort mineur, majeur ou standard. Le temps du développement dure le double du temps d'apprentissage du sort sur lequel travaille le personnage. »_ — coût XP web : 4000 (table de pondération)
 - **Développement avancé** ([lexique:358](regles-papier/extracted/listes/lexique.md), Magicien) : étend à mineur, majeur, standard, **masse**, **distance**. Coût web : 5000.
 
 **Mécanique** : un magicien qui maîtrise « Bouclier » (standard) peut le développer en « Bouclier mineur » ou « Bouclier majeur » via l'atout. Le développement consomme 2× le temps d'apprentissage normal du sort + un jet de développement.
@@ -242,16 +253,17 @@ Chaque variante est un **sort distinct** dans le grimoire, avec ses propres éne
 ### R-8.13 — Familier : entité magique distincte des compagnons/montures
 
 **Sources principales** :
+
 - [documents/regles/index.md:120-134](documents/regles/index.md) — règles générales : forme, vitalité, renaissance, mort.
 - [documents/atouts/index.md:2290](documents/atouts/index.md) — règle complète de feuille, budget, coûts, atouts et handicaps.
 - [data/catalogs/atouts-values.csv](../../data/catalogs/atouts-values.csv) — table générale des valeurs d'atouts utilisée pour le coût `valeur / 10`.
 
 Le familier est un **suivant magique lié au magicien** par l'atout d'orientation `Familier`. Il ne doit pas être confondu avec les compagnons, montures ou animaux non magiques :
 
-| Type | Modèle |
-|---|---|
-| **Familier magique** | Règles R-8.13 : lien magique, budget `niveau × 100`, renaissance au passage de niveau, atouts comme pseudo-raciaux |
-| **Compagnon / monture non magique** | Personnage ou créature autonome, fiche complète, évolution par XP partagé par son propriétaire PJ/PNJ |
+| Type                                | Modèle                                                                                                             |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **Familier magique**                | Règles R-8.13 : lien magique, budget `niveau × 100`, renaissance au passage de niveau, atouts comme pseudo-raciaux |
+| **Compagnon / monture non magique** | Personnage ou créature autonome, fiche complète, évolution par XP partagé par son propriétaire PJ/PNJ              |
 
 Le texte legacy dit que les familiers sont des "personnages secondaires", mais c'est un raccourci historique : pour la spec, le familier utilise **ses propres règles**.
 
@@ -283,24 +295,24 @@ Ces points sont des **points de création/évolution du familier**. La source pa
 Le budget est **total par niveau**, pas ajouté intégralement à chaque passage de niveau :
 
 | Niveau du magicien | Budget total familier |
-|---:|---:|
-| 1 | 100 |
-| 2 | 200 |
-| 3 | 300 |
+| -----------------: | --------------------: |
+|                  1 |                   100 |
+|                  2 |                   200 |
+|                  3 |                   300 |
 
 Ce qui a déjà été dépensé est décompté du budget disponible. Au passage de niveau, le magicien peut conserver, retirer ou remanier les choix de son familier : les points précédemment engagés sont récupérables et peuvent être réattribués dans la limite du nouveau budget total.
 
 Les coûts suivent les pondérations XP du jeu :
 
-| Élément acheté sur la fiche du familier | Coût |
-|---|---:|
-| Aptitude | `NA × 5` |
-| Compétence | `NA × 3` |
-| Spécialisation | `NA × 3` |
-| Vitalité | `10` par point |
-| Facteur de vitesse | `(NA - NB + 1) × 25`, avec `NB = 8` |
-| Facteur de volonté | `(NA - NB + 1) × 25`, avec `NB = 8` |
-| Énergie, si autorisée par effet/atout | `3` par point |
+| Élément acheté sur la fiche du familier |                                Coût |
+| --------------------------------------- | ----------------------------------: |
+| Aptitude                                |                            `NA × 5` |
+| Compétence                              |                            `NA × 3` |
+| Spécialisation                          |                            `NA × 3` |
+| Vitalité                                |                      `10` par point |
+| Facteur de vitesse                      | `(NA - NB + 1) × 25`, avec `NB = 8` |
+| Facteur de volonté                      | `(NA - NB + 1) × 25`, avec `NB = 8` |
+| Énergie, si autorisée par effet/atout   |                       `3` par point |
 
 Les limites physiques normales ne s'appliquent pas aux familiers.
 
@@ -324,13 +336,13 @@ bonus_handicap_familier = abs(valeur_handicap) / 10
 
 Exemples :
 
-| Atout / handicap | Valeur source | Effet budget familier |
-|---|---:|---:|
-| `Vol` | 2000 | coûte 200 points |
-| `Sens du familier` | 2000 | coûte 200 points si porté par le familier ; sinon couche du maître |
-| `Familier vigoureux` | 8000 | coûte 800 points si traité comme atout du familier, ou atout du maître selon build |
-| `Aveugle` | -5000 | donne 500 points supplémentaires |
-| `Sourd` | -2500 | donne 250 points supplémentaires |
+| Atout / handicap     | Valeur source |                                                              Effet budget familier |
+| -------------------- | ------------: | ---------------------------------------------------------------------------------: |
+| `Vol`                |          2000 |                                                                   coûte 200 points |
+| `Sens du familier`   |          2000 |                 coûte 200 points si porté par le familier ; sinon couche du maître |
+| `Familier vigoureux` |          8000 | coûte 800 points si traité comme atout du familier, ou atout du maître selon build |
+| `Aveugle`            |         -5000 |                                                   donne 500 points supplémentaires |
+| `Sourd`              |         -2500 |                                                   donne 250 points supplémentaires |
 
 **Note de spec** : les valeurs très basses ou atypiques de la table source sont conservées telles quelles. Elles doivent être validées par l'admin si elles produisent des coûts familiers absurdes.
 
@@ -353,24 +365,25 @@ Si le familier meurt avant le prochain passage de niveau :
 
 ### R-8.13-f — Atouts liés au familier
 
-| Atout | Valeur source | Coût `valeur/10` | Effet résumé |
-|---|---:|---:|---|
-| Familier | 500 | 50 | Atout d'orientation Magicien, donne accès au familier |
-| Familier supplémentaire | 10000 | 1000 | Ajoute un familier ; les atouts placés sont hérités |
-| Familier vigoureux | 8000 | 800 | Le familier gagne des points de vitalité selon le niveau du propriétaire |
-| Hybridation du familier | 12000 | 1200 | Le magicien peut substituer une zone de son corps par celle du familier rappelé |
-| Main du magicien | 4000 | 400 | Le magicien peut lancer un sort depuis le familier |
-| Passage au familier | 6000 | 600 | Le magicien entre intégralement dans son familier |
-| Rappel du familier | 3000 | 300 | Le familier peut être rappelé en soi ; entrée/sortie prend un facteur de vitesse |
-| Sens du familier | 2000 | 200 | Lien sensoriel sur un sens choisi |
-| Ventre du magicien | 4000 | 400 | Le familier peut nourrir le magicien en se nourrissant |
-| Vol de familier | 20000 | 2000 | Détourne le lien d'un familier adverse tant que l'atout est actif |
+| Atout                   | Valeur source | Coût `valeur/10` | Effet résumé                                                                     |
+| ----------------------- | ------------: | ---------------: | -------------------------------------------------------------------------------- |
+| Familier                |           500 |               50 | Atout d'orientation Magicien, donne accès au familier                            |
+| Familier supplémentaire |         10000 |             1000 | Ajoute un familier ; les atouts placés sont hérités                              |
+| Familier vigoureux      |          8000 |              800 | Le familier gagne des points de vitalité selon le niveau du propriétaire         |
+| Hybridation du familier |         12000 |             1200 | Le magicien peut substituer une zone de son corps par celle du familier rappelé  |
+| Main du magicien        |          4000 |              400 | Le magicien peut lancer un sort depuis le familier                               |
+| Passage au familier     |          6000 |              600 | Le magicien entre intégralement dans son familier                                |
+| Rappel du familier      |          3000 |              300 | Le familier peut être rappelé en soi ; entrée/sortie prend un facteur de vitesse |
+| Sens du familier        |          2000 |              200 | Lien sensoriel sur un sens choisi                                                |
+| Ventre du magicien      |          4000 |              400 | Le familier peut nourrir le magicien en se nourrissant                           |
+| Vol de familier         |         20000 |             2000 | Détourne le lien d'un familier adverse tant que l'atout est actif                |
 
 ### R-8.13-g — Statut
 
 **Statut** : 🟢 règle source structurée et arbitrée.
 
 **À valider par l'équipe** :
+
 - les restrictions automatiques sur les atouts absurdes selon la forme du familier ;
 - la répétabilité exacte de `Familier supplémentaire` et `Familier vigoureux`.
 
@@ -382,26 +395,27 @@ Si le familier meurt avant le prochain passage de niveau :
 
 **Catalogue** (rappel des découvertes D1/D2/D7) :
 
-| Mécanisme | Type | Source | Effet |
-|---|---|---|---|
-| **Captage d'énergie** | Sort Abjuration | grimoire | Le lanceur attire l'énergie d'un magicien en cours d'incantation : +3 énergie au lanceur par réussite. Le magicien cible doit compenser ou voir son sort annulé. |
-| **Don d'énergie** | Sort Magie blanche | grimoire | Transfert volontaire : 3 énergie transmise à la cible par réussite |
-| **Sacrifice d'énergie** | Atout Magicien N3 perm | lexique | Drain volontaire d'énergie sur un magicien cible (1m/niveau) — points perdus pour le sacrifié, gagnés (?) pour le sacrifiant |
-| **Drain de sort majeur / mineur / standard** | Sort Magie noire | grimoire | Drains 4/2/3 PS (Points de Sort = mana courant) absorbés par réussite — **réduit le pool d'énergie courant de la cible**, transfert au lanceur. `energyMax` non affecté. Récupération via repos / potions standard. |
-| **Drain de vie** | Sort Magie noire | grimoire | 1 PV absorbé par réussite |
-| **Augmentation énergétique** | Sort Abjuration | grimoire | Augmente le coût en énergie d'un sort cible de 2 par R |
-| **Complexité magique** | Sort Abjuration | grimoire | Augmente la difficulté d'un sort cible de 2 par R |
-| **Inversion des énergies** | Atout Magicien N12 perm | lexique | Lance des sorts en consommant la vitalité au lieu de l'énergie |
-| **Barrière psychique** | Sort Abjuration | grimoire | Réduit les R des sorts mentaux ciblant le bénéficiaire |
-| **Boomerang** | Sort Abjuration | grimoire | Renvoie un sort au lanceur d'origine |
-| **Substitution de sort** | Sort Abjuration | grimoire | Remplace un sort incanté par un autre |
-| **Contre-X** (11 sorts Abjuration) | Sort Abjuration | grimoire | Annule un sort de l'école X par réussite |
+| Mécanisme                                    | Type                    | Source   | Effet                                                                                                                                                                                                               |
+| -------------------------------------------- | ----------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Captage d'énergie**                        | Sort Abjuration         | grimoire | Le lanceur attire l'énergie d'un magicien en cours d'incantation : +3 énergie au lanceur par réussite. Le magicien cible doit compenser ou voir son sort annulé.                                                    |
+| **Don d'énergie**                            | Sort Magie blanche      | grimoire | Transfert volontaire : 3 énergie transmise à la cible par réussite                                                                                                                                                  |
+| **Sacrifice d'énergie**                      | Atout Magicien N3 perm  | lexique  | Drain volontaire d'énergie sur un magicien cible (1m/niveau) — points perdus pour le sacrifié, gagnés (?) pour le sacrifiant                                                                                        |
+| **Drain de sort majeur / mineur / standard** | Sort Magie noire        | grimoire | Drains 4/2/3 PS (Points de Sort = mana courant) absorbés par réussite — **réduit le pool d'énergie courant de la cible**, transfert au lanceur. `energyMax` non affecté. Récupération via repos / potions standard. |
+| **Drain de vie**                             | Sort Magie noire        | grimoire | 1 PV absorbé par réussite                                                                                                                                                                                           |
+| **Augmentation énergétique**                 | Sort Abjuration         | grimoire | Augmente le coût en énergie d'un sort cible de 2 par R                                                                                                                                                              |
+| **Complexité magique**                       | Sort Abjuration         | grimoire | Augmente la difficulté d'un sort cible de 2 par R                                                                                                                                                                   |
+| **Inversion des énergies**                   | Atout Magicien N12 perm | lexique  | Lance des sorts en consommant la vitalité au lieu de l'énergie                                                                                                                                                      |
+| **Barrière psychique**                       | Sort Abjuration         | grimoire | Réduit les R des sorts mentaux ciblant le bénéficiaire                                                                                                                                                              |
+| **Boomerang**                                | Sort Abjuration         | grimoire | Renvoie un sort au lanceur d'origine                                                                                                                                                                                |
+| **Substitution de sort**                     | Sort Abjuration         | grimoire | Remplace un sort incanté par un autre                                                                                                                                                                               |
+| **Contre-X** (11 sorts Abjuration)           | Sort Abjuration         | grimoire | Annule un sort de l'école X par réussite                                                                                                                                                                            |
 
 **Statut** : 🟢 claire (catalogue connu, descriptions à compléter en lecture du grimoire complet)
 
 ### R-8.15 — Résistance magique (rappel D1 R-1.33)
 
 **Modèle multi-couches** (D1 R-1.33) :
+
 - **Résistance magique** (D100) : protège contre la magie **directe** (contrôle mental, transformation, illusion, soins, bénédictions)
 - **Armure** (P/E/C/T) : absorbe les dégâts physiques/énergétiques (souvent issus de sorts indirects type boule de feu)
 - **Résistances élémentaires** (feu, froid, foudre, etc.) : par type de dégât
@@ -418,21 +432,25 @@ Si le familier meurt avant le prochain passage de niveau :
 Cohérent avec D5 R-5.6-bis (système d'apprentissage à 5 dimensions) :
 
 **Côté élève** :
+
 - Aptitude : Intelligence (le plus souvent)
 - Compétence : « Apprentissage de la magie » (sous Maîtrise de soi du catalogue, [competences:254](documents/competences/index.md))
 - Spécialisation : « Apprentissage de [école] » (à raffiner par école — ex: « Apprentissage de la magie blanche »)
 
 **Côté mentor** :
+
 - Aptitude : Empathie ou Intelligence
 - Compétence : « Enseignement de la magie » ([competences:349](documents/competences/index.md))
 - Spécialisation : « Enseignement de [école] »
 
 **Atouts qui modifient l'apprentissage de sorts** :
+
 - **Affinité arcanique** (Magicien N3 perm, prérequis : connaître 4 sorts) : divise les jours d'apprentissage par (niveau d'atout + 1)
 - **Autodidacte** (perm) : permet d'apprendre un sort vu/entendu sans mentor, mais ×2 le temps. **Interdit aux Chamans** (transmission orale obligatoire)
 - **Apprentissage rapide** (Intellectuel N2) : +niveau aux réussites du jet d'apprentissage
 
 **Coût XP** (Experience.doc) :
+
 - Nouveau sort : 10 XP flat
 - +1 point dans un sort existant : NA × 10
 
@@ -443,6 +461,7 @@ jours_base = coût_XP × 3
 ```
 
 Donc, à titre provisoire :
+
 - Nouveau sort : `10 XP × 3 = 30 jours` avant jets/atouts.
 - +1 point dans un sort existant : `NA × 10 XP × 3` jours avant jets/atouts.
 - Les réussites d'apprentissage et d'enseignement se soustraient aux jours.
@@ -456,42 +475,42 @@ Donc, à titre provisoire :
 
 ### R-8.17 — Catalogue des atouts magiciens
 
-| Atout | Niveau | Type | Effet résumé |
-|---|---|---|---|
-| **Familier** | Orient. perm | Permanent | Atout d'orientation, ouvre la fiche de familier D8 R-8.13 |
-| **Énergie latente** | N2 perm | Permanent | +3 × niveau d'atout d'`energyMax` à chaque passage de niveau |
-| **Sens du familier** | N2 perm | Permanent | Sensoriel via le familier |
-| **Aura magique** | N2 éph | Éphémère | Manifestation visuelle d'énergie |
-| **Désactivation** | N2 perm | Permanent | Contrôle de sort lancé |
-| **Affinité arcanique** | N3 perm | Permanent | ÷ (niveau + 1) jours d'apprentissage des sorts (prérequis : 4 sorts) |
-| **Incantation silencieuse** | N3 perm | Permanent | Sort sans bruit |
-| **Incantation stoïque** | N3 perm | Permanent | Sort sans gesticulation |
-| **Libération d'énergie** | N3 perm | Permanent | Convertit énergie en déflagration (1m/niveau) |
-| **Persistance magique** | N3 perm | Permanent | Re-lancer un sort actif sans incantation |
-| **Rappel du familier** | N3 | — | Le familier peut être rappelé en soi ; entrée/sortie prend un facteur de vitesse |
-| **Sacrifice d'énergie** | N3 perm | Permanent | Drain d'énergie volontaire sur autre magicien |
-| **Énergie à l'honneur** | N4 éph | Éphémère | -1 difficulté sur école choisie pendant 10 min/niveau |
-| **Énergie au déshonneur** | N4 éph (Abjurateur) | Éphémère | +1 difficulté sur école adverse choisie |
-| **Développement** | N4 perm | Permanent | Apprendre variantes mineur/majeur/standard |
-| **Anticipation magique** | N5 éph | Éphémère | Pré-incanter, lancer en 1 DT |
-| **Débordement d'énergie** | N5 perm | Permanent | Dépasser energyMax via potions ou drain |
-| **Développement avancé** | N5 perm | Permanent | Apprendre variantes masse/distance |
-| **Conceptualisation** | N6 perm | Permanent | Création de nouveaux sorts |
-| **Télékinésie** | N6 perm (orient. Magicien, mais conflit avec Intellectuel — D4 Q-D4.5-bis) | Permanent | Soulève 1 kg/niveau au rythme de la marche |
-| **Télépathie** | N6 perm | Permanent | Contact mental |
-| **Conceptualisation étendue** | N7 perm | Permanent | Création de sorts avancés |
-| **Perception des énergies** | N7 perm (prérequis Ressentir + Savoir la magie) | Permanent | Détection et quantification d'énergie |
-| **Aura bénéfique** | N8 perm (Clerc) | Permanent | Empêche magie noire à proximité (1m/niveau, magicien d'un niveau inférieur) |
-| **Aura maléfique** | N8 perm (Sorcier) | Permanent | Empêche magie blanche à proximité |
-| **Bouclier des arcanes** | N9 perm | Permanent | 1 énergie/DT de bouclier total = niveau |
-| **Lévitation** | N9 perm | Permanent | Mouvement via magie |
-| **Transfert spatial** | N9 perm | Permanent | Déplacement spatial |
-| **Maître en sort mineur** | N10 perm | Permanent | -1 difficulté sur les sorts mineurs |
-| **Maître en sort majeur** | N10 perm | Permanent | -1 difficulté sur les sorts majeurs |
-| **Maître en guérison** | N10 perm (Clerc) | Permanent | -1 difficulté sur les sorts de guérison |
-| **Maître en sort de masse** | N11 perm | Permanent | -1 difficulté sur les sorts de masse |
-| **Inversion des énergies** | N12 perm | Permanent | Sorts via vitalité au lieu d'énergie |
-| **Maîtrise de l'énergie** | N15 perm (prérequis Énergie à l'honneur) | Permanent | Bonus +niveau au lieu de +1 sur école choisie |
+| Atout                         | Niveau                                                                     | Type      | Effet résumé                                                                     |
+| ----------------------------- | -------------------------------------------------------------------------- | --------- | -------------------------------------------------------------------------------- |
+| **Familier**                  | Orient. perm                                                               | Permanent | Atout d'orientation, ouvre la fiche de familier D8 R-8.13                        |
+| **Énergie latente**           | N2 perm                                                                    | Permanent | +3 × niveau d'atout d'`energyMax` à chaque passage de niveau                     |
+| **Sens du familier**          | N2 perm                                                                    | Permanent | Sensoriel via le familier                                                        |
+| **Aura magique**              | N2 éph                                                                     | Éphémère  | Manifestation visuelle d'énergie                                                 |
+| **Désactivation**             | N2 perm                                                                    | Permanent | Contrôle de sort lancé                                                           |
+| **Affinité arcanique**        | N3 perm                                                                    | Permanent | ÷ (niveau + 1) jours d'apprentissage des sorts (prérequis : 4 sorts)             |
+| **Incantation silencieuse**   | N3 perm                                                                    | Permanent | Sort sans bruit                                                                  |
+| **Incantation stoïque**       | N3 perm                                                                    | Permanent | Sort sans gesticulation                                                          |
+| **Libération d'énergie**      | N3 perm                                                                    | Permanent | Convertit énergie en déflagration (1m/niveau)                                    |
+| **Persistance magique**       | N3 perm                                                                    | Permanent | Re-lancer un sort actif sans incantation                                         |
+| **Rappel du familier**        | N3                                                                         | —         | Le familier peut être rappelé en soi ; entrée/sortie prend un facteur de vitesse |
+| **Sacrifice d'énergie**       | N3 perm                                                                    | Permanent | Drain d'énergie volontaire sur autre magicien                                    |
+| **Énergie à l'honneur**       | N4 éph                                                                     | Éphémère  | -1 difficulté sur école choisie pendant 10 min/niveau                            |
+| **Énergie au déshonneur**     | N4 éph (Abjurateur)                                                        | Éphémère  | +1 difficulté sur école adverse choisie                                          |
+| **Développement**             | N4 perm                                                                    | Permanent | Apprendre variantes mineur/majeur/standard                                       |
+| **Anticipation magique**      | N5 éph                                                                     | Éphémère  | Pré-incanter, lancer en 1 DT                                                     |
+| **Débordement d'énergie**     | N5 perm                                                                    | Permanent | Dépasser energyMax via potions ou drain                                          |
+| **Développement avancé**      | N5 perm                                                                    | Permanent | Apprendre variantes masse/distance                                               |
+| **Conceptualisation**         | N6 perm                                                                    | Permanent | Création de nouveaux sorts                                                       |
+| **Télékinésie**               | N6 perm (orient. Magicien, mais conflit avec Intellectuel — D4 Q-D4.5-bis) | Permanent | Soulève 1 kg/niveau au rythme de la marche                                       |
+| **Télépathie**                | N6 perm                                                                    | Permanent | Contact mental                                                                   |
+| **Conceptualisation étendue** | N7 perm                                                                    | Permanent | Création de sorts avancés                                                        |
+| **Perception des énergies**   | N7 perm (prérequis Ressentir + Savoir la magie)                            | Permanent | Détection et quantification d'énergie                                            |
+| **Aura bénéfique**            | N8 perm (Clerc)                                                            | Permanent | Empêche magie noire à proximité (1m/niveau, magicien d'un niveau inférieur)      |
+| **Aura maléfique**            | N8 perm (Sorcier)                                                          | Permanent | Empêche magie blanche à proximité                                                |
+| **Bouclier des arcanes**      | N9 perm                                                                    | Permanent | 1 énergie/DT de bouclier total = niveau                                          |
+| **Lévitation**                | N9 perm                                                                    | Permanent | Mouvement via magie                                                              |
+| **Transfert spatial**         | N9 perm                                                                    | Permanent | Déplacement spatial                                                              |
+| **Maître en sort mineur**     | N10 perm                                                                   | Permanent | -1 difficulté sur les sorts mineurs                                              |
+| **Maître en sort majeur**     | N10 perm                                                                   | Permanent | -1 difficulté sur les sorts majeurs                                              |
+| **Maître en guérison**        | N10 perm (Clerc)                                                           | Permanent | -1 difficulté sur les sorts de guérison                                          |
+| **Maître en sort de masse**   | N11 perm                                                                   | Permanent | -1 difficulté sur les sorts de masse                                             |
+| **Inversion des énergies**    | N12 perm                                                                   | Permanent | Sorts via vitalité au lieu d'énergie                                             |
+| **Maîtrise de l'énergie**     | N15 perm (prérequis Énergie à l'honneur)                                   | Permanent | Bonus +niveau au lieu de +1 sur école choisie                                    |
 
 **Statut** : 🟢 claire (catalogue connu, à étendre via lecture exhaustive d'atouts-de-niveaux)
 
@@ -521,6 +540,7 @@ spell_relations (spell_id_a, spell_id_b, relation_type)  -- ex: "Contre-rouge" a
 ```
 
 **Notes architecturales** :
+
 - `spells.school_id` permet de filtrer par école
 - `direct_magic` permet le moteur de résistance (R-8.15)
 - `variant_of_id` + `variant_type` lient un sort à son sort racine (Bouclier mineur → Bouclier)
@@ -548,6 +568,7 @@ Les **~889 entrées** du `documents/grimoire/index.md` sont **toutes validées**
 5. **Mise à jour future** : si un sort est modifié (édition CMS, ajout d'une nuance), le tag est ré-évalué (LLM propose à nouveau, auteur valide).
 
 **Critères de classification** (rappel D1 R-1.33) :
+
 - **Direct** : le sort agit **directement sur la cible vivante** (contrôle mental, transformation, illusion, soins, bénédictions, malédictions personnelles)
 - **Indirect** : le sort **crée, transforme ou invoque** quelque chose qui agit ensuite (boule de feu, enchantement d'objet, invocation, divination)
 
@@ -558,12 +579,14 @@ Les **~889 entrées** du `documents/grimoire/index.md` sont **toutes validées**
 ### ~~Q-D8.3~~ — Jet de résistance opposé ✅ **Tranché (2026-04-25)** : Option (d) **variable selon le sort** + clarification critique sur les types de jet.
 
 **Mécanique** :
+
 1. Chaque sort spécifie son **jet de résistance opposé** dans sa description (« Contre jet d'X », « Si R > jet d'X »).
 2. Selon le type de jet demandé, deux mécaniques distinctes :
 
 #### Jet d'aptitude brute (D10)
 
 Quand un sort dit « **Contre jet d'endurance / force / intelligence / dextérité / etc.** » :
+
 - La cible roule **uniquement les points d'aptitude** comme nombre de D10s
 - **PAS de compétence ajoutée**, **PAS de spécialisation**
 - C'est un jet **sans contexte d'expertise** — l'aptitude « brute » du perso pour résister
@@ -575,6 +598,7 @@ Quand un sort dit « **Contre jet d'endurance / force / intelligence / dextérit
 #### Jet de volonté (D20)
 
 Quand un sort dit « **Contre jet de volonté** » ou affecte le mental/l'esprit :
+
 - Cible fait un **test de volonté D20** (R-1.26 à R-1.29)
 - Difficulté = `F.Volonté + réussites du sort attaquant` (R-1.28, le pont D10 → D20)
 - 1 = échec auto, 20 = réussite auto (R-1.27)
@@ -585,11 +609,13 @@ Quand un sort dit « **Contre jet de volonté** » ou affecte le mental/l'esprit
 
 **Acté 2026-04-25** : il existe **trois types de jets** dans Knight and Wizard, pas seulement deux comme initialement modélisé en D1.
 
-| Type | Formule | Usage |
-|---|---|---|
-| **Jet d'action standard (R-1.2)** | Aptitude + Compétence + Σ Spécialisations | Toute action qui mobilise compétence/expertise (combat, métier, perception, social…) |
-| **Jet d'aptitude brute** | Aptitude seule (D10s) | **Résistance naturelle** : encaissement (R-2.17 endurance), résistance à un sort (« Contre jet d'X »), réflexe pur dans certains cas, etc. |
-| **Test de volonté (D20)** | D20 vs F.Volonté + modificateurs | Réactions émotionnelles, charme, peur, contrôle mental |
+| Type                              | Formule                                   | Usage                                                                                                                                      |
+| --------------------------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Jet d'action standard (R-1.2)** | Aptitude + Compétence + Σ Spécialisations | Toute action qui mobilise compétence/expertise (combat, métier, perception, social…)                                                       |
+| **Jet d'aptitude brute**          | Aptitude seule (D10s)                     | **Résistance naturelle** : encaissement (R-2.17 endurance), résistance à un sort (« Contre jet d'X »), réflexe pur dans certains cas, etc. |
+| **Test de volonté (D20)**         | D20 vs F.Volonté + modificateurs          | Réactions émotionnelles, charme, peur, contrôle mental                                                                                     |
+
+**Direction du test de volonté (acté MJ 2026-05-28)** : réussite si **D20 ≥ (F.Volonté + modificateurs)**. Un **Facteur de Volonté plus bas réussit plus souvent** (comme les autres « facteurs » K&W, bas = avantageux ; cf. facteur de vitesse). Un modificateur **positif** rend la situation **plus difficile** (relève le seuil), un modificateur **négatif** facilite (ex. le sort `courage`, « FVol –1/R »). → `rules-core` `rollWillpowerTest`.
 
 **Extensibilité** : d'autres usages du « jet d'aptitude brute » peuvent exister hors magie (à découvrir dans le grimoire et autres règles). À retenir comme une catégorie de jet à part entière.
 
@@ -599,24 +625,26 @@ Quand un sort dit « **Contre jet de volonté** » ou affecte le mental/l'esprit
 
 **Mécanique** :
 
-| Mode | Politique de création de sort |
-|---|---|
-| **MJ humain (papier)** | Création **locale à la fiche** du joueur. Le MJ valide narrativement. Sort non partagé au catalogue global. |
-| **MJ LLM** | Le joueur **propose** un sort (nom, école, énergie, TI, difficulté, effet). LLM analyse cohérence vs catalogue existant, propose des ajustements (équilibrage). Admin valide la publication au catalogue partagé. |
-| **MJ auto strict** | **Pas de création** — catalogue figé, le joueur ne peut pas inventer de nouveau sort en cours de session. |
+| Mode                   | Politique de création de sort                                                                                                                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **MJ humain (papier)** | Création **locale à la fiche** du joueur. Le MJ valide narrativement. Sort non partagé au catalogue global.                                                                                                       |
+| **MJ LLM**             | Le joueur **propose** un sort (nom, école, énergie, TI, difficulté, effet). LLM analyse cohérence vs catalogue existant, propose des ajustements (équilibrage). Admin valide la publication au catalogue partagé. |
+| **MJ auto strict**     | **Pas de création** — catalogue figé, le joueur ne peut pas inventer de nouveau sort en cours de session.                                                                                                         |
 
 **+ Workflow de promotion communautaire** (cohérent avec Q-D5.1-a) :
+
 - Un sort créé en mode papier ou LLM peut être **proposé au catalogue canonique** par son créateur
 - Validation par seuil (N joueurs / M MJ qui l'utilisent et le valident) + curation finale par admin/auteur
 - Une fois promu, le sort devient accessible à tous
 
 **Implications architecturales** :
+
 - `spells.is_canonical` (déjà prévu en R-8.18) : false par défaut pour les créations joueurs, true après promotion
 - `spells.created_by` : identifiant du créateur
 - `spells.parent_template_id` (nullable) : si le sort dérive d'un sort existant via Conceptualisation étendue
 - Workflow de promotion : table `spell_promotion_proposals (spell_id, votes_yes, votes_no, status)`
 
-**+ CMS de gestion du catalogue de sorts** *(précisé par l'auteur 2026-04-25)* :
+**+ CMS de gestion du catalogue de sorts** _(précisé par l'auteur 2026-04-25)_ :
 
 Cohérent avec le **CMS du catalogue de compétences** (Q-D5.3) et le méta-principe **règles vivantes**, le catalogue de sorts (`spells`, `spell_schools`, `spell_relations`) est géré via un **CMS d'admin** :
 
@@ -633,6 +661,7 @@ Cette décision résout aussi par cohérence l'équivalent pour les écoles de m
 ### ~~Q-D8.5~~ — Mécanique des variantes ✅ **Tranché (2026-04-25)** : Option (a) **sorts distincts à apprendre séparément** par défaut, avec **CMS + validation communautaire** comme infrastructure opérationnelle.
 
 **Mécanique mécanique de base** :
+
 - Chaque variante (mineur, standard, majeur, masse, distance) est un **sort distinct** dans le catalogue, avec ses propres `energy/TI/difficulty/effet`.
 - Apprentissage **séparé** : un magicien qui connaît « Bouclier » doit apprendre indépendamment « Bouclier majeur » (10 XP nouveau sort + NA × 10 pour monter).
 - Atouts **Développement** (N4) / **Développement avancé** (N5) : permettent au magicien de **développer** une variante d'un sort qu'il possède déjà — ils ne lui donnent pas la variante automatiquement, mais débloquent la **possibilité** de l'apprendre.
@@ -641,6 +670,7 @@ Cette décision résout aussi par cohérence l'équivalent pour les écoles de m
 **Infrastructure prioritaire (méta-principe règles vivantes — réaffirmé par l'auteur 2026-04-25)** :
 
 Le **CMS** + **validation communautaire** sont la base de tout :
+
 - L'admin peut **éditer** la mécanique des variantes (ex: décider qu'une école particulière fonctionne en "modes" plutôt qu'en sorts distincts)
 - Les **propositions communautaires** peuvent faire évoluer la mécanique au fil du temps (vote sur "et si Bouclier majeur s'accédait automatiquement à partir de Bouclier ?")
 - Le **versioning** permet le rollback si une mécanique modifiée s'avère mauvaise
@@ -659,6 +689,7 @@ Le **CMS** + **validation communautaire** sont la base de tout :
 > « Le magicien peut, en **1 DT**, renouveler un sort actif **sans faire d'incantation**. Ce qui signifie qu'un sort à 3 réussites qui durait 10 minutes sera renouvelé dès le moment où le magicien utilisera son atout, et repartira pour 10 minutes, **en conservant ses 3 réussites**. Les **points d'énergie du sort sont dépensés normalement**. (Permanent) (Atout de niveau 3 de l'orientation : Magicien) »
 
 **Mécanique** :
+
 - **TI = 1 DT** (au lieu du TI normal du sort) — extrêmement rapide en combat
 - **Pas d'incantation** (donc pas de risque d'interruption R-8.7)
 - **Conserve les réussites** du jet d'origine (l'effet/qualité du sort ne change pas)
@@ -680,10 +711,10 @@ Le **CMS** + **validation communautaire** sont la base de tout :
 
 #### Deux échelles temporelles coexistantes
 
-| Échelle | Granularité | Usage |
-|---|---|---|
-| **Temps narratif** | Heures, journées, semaines | Hors combat — exploration, voyage, dialogues, repos, gestion de campagne, durée des sorts en min/heures/jours |
-| **Temps de combat (DT)** | 1 DT = 0,2 s | En combat — actions, initiative, durée des sorts en DT, résolution séquentielle |
+| Échelle                  | Granularité                | Usage                                                                                                         |
+| ------------------------ | -------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Temps narratif**       | Heures, journées, semaines | Hors combat — exploration, voyage, dialogues, repos, gestion de campagne, durée des sorts en min/heures/jours |
+| **Temps de combat (DT)** | 1 DT = 0,2 s               | En combat — actions, initiative, durée des sorts en DT, résolution séquentielle                               |
 
 **Imbrication** : le **temps de combat s'inscrit dans le temps narratif**. Un combat de 50 DT = 10 secondes de temps narratif. Quand le combat se termine, l'horloge narrative avance du temps cumulé de la scène de combat.
 
@@ -697,6 +728,7 @@ Le **CMS** + **validation communautaire** sont la base de tout :
 #### Switch tour-par-tour ↔ temps réel (mode combat)
 
 En mode combat, deux sous-modes possibles :
+
 - **Tour par tour** : le moteur attend l'input des joueurs avant chaque DT (ou groupe de DT). Pédagogique, accessible.
 - **Temps réel** : les DT s'enchaînent en temps réel, les joueurs doivent réagir vite. Immersif mais tendu.
 
@@ -707,6 +739,7 @@ Le switch est **trivial** dans le moteur digital car la base sous-jacente (DT) e
 **Cas d'usage** : adapter la cadence du jeu aux contraintes pratiques (joueurs en ligne, latence réseau, sessions longues à compresser, etc.).
 
 **Mécanique** :
+
 - Un **multiplicateur de temps** est paramétrable **par instance / campagne / session** (pas globalement pour tout le jeu)
 - Exemples :
   - Temps réel × 1.0 (référence)
@@ -719,11 +752,13 @@ Le switch est **trivial** dans le moteur digital car la base sous-jacente (DT) e
 #### Implication pour les durées de sort
 
 Chaque sort a une **durée intrinsèque** exprimée dans son unité naturelle :
+
 - DT (durée courte, en combat) : conservé tel quel, conversion automatique en temps narratif si combat se termine avant expiration
 - Minutes / heures / jours (durée narrative) : tracké en heures de jeu narratives
 - « Permanent » : pas de durée, dissipation uniquement via dispel actif (sort Abjuration, atout, etc.)
 
 **Modèle de données** (à préciser en spec phase 2) :
+
 ```sql
 character_active_spells (
   id, character_id, spell_id, target_id,
@@ -738,11 +773,11 @@ character_active_spells (
 
 #### Implication pour la cohabitation modes
 
-| Mode | Échelle dominante | Combat |
-|---|---|---|
-| **Async (forum-RP)** | Temps narratif, transitions par scène | Combat résolu DT par DT mais asynchrone (chaque joueur poste son action quand il peut) |
-| **Tour par tour digital** | Mix narratif (hors combat) + DT (combat) | Mode tour-par-tour explicite |
-| **Temps réel digital** | Mix narratif (hors combat) + DT (combat) | Mode temps réel, multiplicateur ajustable |
+| Mode                      | Échelle dominante                        | Combat                                                                                 |
+| ------------------------- | ---------------------------------------- | -------------------------------------------------------------------------------------- |
+| **Async (forum-RP)**      | Temps narratif, transitions par scène    | Combat résolu DT par DT mais asynchrone (chaque joueur poste son action quand il peut) |
+| **Tour par tour digital** | Mix narratif (hors combat) + DT (combat) | Mode tour-par-tour explicite                                                           |
+| **Temps réel digital**    | Mix narratif (hors combat) + DT (combat) | Mode temps réel, multiplicateur ajustable                                              |
 
 **Renvoi D9 (Combat)** : ce système de temps est le squelette du moteur de combat — à élaborer plus en détail là-bas.
 
@@ -752,21 +787,22 @@ character_active_spells (
 
 **Règle par défaut** : Option (c) — seul le sort avec le **meilleur effet** (plus de réussites) s'applique. L'autre est ignoré. **Si le sort entrant a un meilleur effet, il remplace** le précédent et le timer est refresh à la durée du nouveau sort.
 
-**Différenciation par catégorie** *(précisé par l'auteur 2026-04-25)* — il faut une **vraie typologie des sorts** dans le catalogue, car le drain n'est pas un debuff strict. Catégories proposées :
+**Différenciation par catégorie** _(précisé par l'auteur 2026-04-25)_ — il faut une **vraie typologie des sorts** dans le catalogue, car le drain n'est pas un debuff strict. Catégories proposées :
 
-| Catégorie | Cumul | Exemples |
-|---|---|---|
-| **Buff** (bonus passif sur cible) | (c) Max + refresh | Bénédiction, Bouclier, Force physique, Esthétisme, Rapidité, Courage, Force mentale |
-| **Debuff classique** (malus passif sur cible) | (c) Max + refresh | Corrosion (sur cible vivante), Pétrification, Changement de sexe |
-| **Drain** (transfert/vol de ressource) | Cumul **total** | Drain de sort, Drain de vie, Sacrifice d'énergie, Captage d'énergie |
-| **Dégât direct** (effet ponctuel) | Cumul **total** (chaque lancer = nouveau dégât) | Boule de feu, Flèche de foudre, Châtiment de la matière |
-| **Transformation** (modifie la nature de la cible) | Une seule transformation à la fois (la plus récente l'emporte) | Changement en corbeau / lapin / humain, Pétrification |
-| **Soin** (récupère vitalité) | Cumul **total** (chaque lancer ajoute du PV jusqu'à `vitalityMax`) | Guérison absolue, Guérison de la peau/muscles/os |
-| **Invocation** (appelle une créature) | Plusieurs invocations en parallèle si capacité | Sorts d'invocation orange |
-| **Illusion** | À ajuster — probablement (c) refresh | Sorts violet |
-| **Effet permanent** (changement définitif) | Une seule application, pas de re-application | Résurrection, Auto régénération créée par sort |
+| Catégorie                                          | Cumul                                                              | Exemples                                                                            |
+| -------------------------------------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| **Buff** (bonus passif sur cible)                  | (c) Max + refresh                                                  | Bénédiction, Bouclier, Force physique, Esthétisme, Rapidité, Courage, Force mentale |
+| **Debuff classique** (malus passif sur cible)      | (c) Max + refresh                                                  | Corrosion (sur cible vivante), Pétrification, Changement de sexe                    |
+| **Drain** (transfert/vol de ressource)             | Cumul **total**                                                    | Drain de sort, Drain de vie, Sacrifice d'énergie, Captage d'énergie                 |
+| **Dégât direct** (effet ponctuel)                  | Cumul **total** (chaque lancer = nouveau dégât)                    | Boule de feu, Flèche de foudre, Châtiment de la matière                             |
+| **Transformation** (modifie la nature de la cible) | Une seule transformation à la fois (la plus récente l'emporte)     | Changement en corbeau / lapin / humain, Pétrification                               |
+| **Soin** (récupère vitalité)                       | Cumul **total** (chaque lancer ajoute du PV jusqu'à `vitalityMax`) | Guérison absolue, Guérison de la peau/muscles/os                                    |
+| **Invocation** (appelle une créature)              | Plusieurs invocations en parallèle si capacité                     | Sorts d'invocation orange                                                           |
+| **Illusion**                                       | À ajuster — probablement (c) refresh                               | Sorts violet                                                                        |
+| **Effet permanent** (changement définitif)         | Une seule application, pas de re-application                       | Résurrection, Auto régénération créée par sort                                      |
 
 **Implication architecturale** :
+
 - Ajouter `spells.cumul_type` à R-8.18 :
   ```
   cumul_type ENUM(buff, debuff, drain, damage, transformation, heal, summon, illusion, permanent_effect)
@@ -784,6 +820,7 @@ character_active_spells (
 **Clarification critique de l'auteur** : « PS » = **Points de Sort** = synonyme de **points d'énergie** (mana) du magicien. Le drain **puise dans le pool de mana courant** (`energy`), pas dans la **capacité** (`energyMax`).
 
 **Mécanique** :
+
 - **Drain de sort majeur** : 4 PS absorbés/R → la cible perd 4 points de `energy` par réussite du lanceur, le lanceur les **gagne** (transfert)
 - **Drain de sort mineur** : 2 PS absorbés/R
 - **Drain de sort standard** : 3 PS absorbés/R
@@ -814,6 +851,7 @@ character_active_spells (
 **D8 complet** ✅ (10/10 tranchées ; familier complet + 2 nouvelles règles structurantes R-8.19 jet aptitude brute / R-8.20 système de temps double).
 
 **Nouvelles découvertes structurantes** :
+
 - **R-8.19 Trois types de jets** distincts (action standard, aptitude brute, volonté D20) — étend D1
 - **R-8.20 Système de temps double** (narratif heures/jours + DT 0.2s combat) avec instanciation — architecture fondamentale pour D9 et le moteur global
 - **Typologie `cumul_type`** des sorts (9 catégories) pour la mécanique de cumul

--- a/packages/rules-core/src/dice.test.ts
+++ b/packages/rules-core/src/dice.test.ts
@@ -174,23 +174,30 @@ function scriptedRolls(values: number[]) {
   };
 }
 
-describe('willpower test D20 (R-8.19)', () => {
-  it('succeeds when the D20 is at or under will factor + modifiers', () => {
+describe('willpower test D20 (R-8.19, MJ 2026-05-28: D20 >= cible)', () => {
+  it('succeeds when the D20 is at or above will factor + modifiers', () => {
     expect(rollWillpowerTest(10, 0, { randomInteger: () => 10 })).toEqual({
       roll: 10,
       target: 10,
       success: true
     });
-    expect(rollWillpowerTest(10, 0, { randomInteger: () => 11 })).toEqual({
-      roll: 11,
+    expect(rollWillpowerTest(10, 0, { randomInteger: () => 9 })).toEqual({
+      roll: 9,
       target: 10,
       success: false
     });
   });
 
-  it('applies modifiers to the target', () => {
-    expect(rollWillpowerTest(10, 5, { randomInteger: () => 14 }).success).toBe(true);
-    expect(rollWillpowerTest(10, -5, { randomInteger: () => 6 }).success).toBe(false);
+  it('a LOWER will factor succeeds more often (facteur bas = avantageux)', () => {
+    // Même D20 = 8 : FVol 5 réussit (8 >= 5), FVol 15 échoue (8 < 15).
+    expect(rollWillpowerTest(5, 0, { randomInteger: () => 8 }).success).toBe(true);
+    expect(rollWillpowerTest(15, 0, { randomInteger: () => 8 }).success).toBe(false);
+  });
+
+  it('positive modifier = harder (raises the threshold), negative = easier', () => {
+    // +5 → cible 15 : D20 14 échoue. -5 (ex. courage) → cible 5 : D20 6 réussit.
+    expect(rollWillpowerTest(10, 5, { randomInteger: () => 14 }).success).toBe(false);
+    expect(rollWillpowerTest(10, -5, { randomInteger: () => 6 }).success).toBe(true);
   });
 
   it('rejects an out-of-range D20 value', () => {

--- a/packages/rules-core/src/dice.ts
+++ b/packages/rules-core/src/dice.ts
@@ -348,8 +348,11 @@ export interface WillpowerTestResult {
  * émotionnelles (charme, peur, contrôle mental). C'est une catégorie de jet distincte du pool D10
  * (jet d'action) et du jet d'aptitude brute.
  *
- * Convention (À CONFIRMER avec le propriétaire) : réussite si le D20 est <= la cible (roll-under ;
- * une F.Volonté élevée résiste mieux). R-8.19 fixe la formule mais pas la direction du test.
+ * Direction du test (**actée par le MJ 2026-05-28**) : réussite si le **D20 ≥ la cible**. Un
+ * **Facteur de Volonté plus BAS réussit plus souvent** (FVol 5 → réussite sur 5..20 ; FVol 15 →
+ * 15..20). C'est cohérent avec les « facteurs » K&W (bas = avantageux, cf. facteur de vitesse).
+ * Convention de modificateur : un modificateur **positif** relève le seuil = situation **plus
+ * difficile** ; un modificateur **négatif** facilite (ex. le sort `courage`, « FVol –1/R »).
  */
 export function rollWillpowerTest(
   willFactor: number,
@@ -371,5 +374,5 @@ export function rollWillpowerTest(
 
   const target = willFactor + modifiers;
 
-  return { roll, target, success: roll <= target };
+  return { roll, target, success: roll >= target };
 }


### PR DESCRIPTION
## Résumé

Corrige le **sens du test de volonté (R-8.19)** — la convention était explicitement flaggée « À
CONFIRMER avec le propriétaire » dans le code. Le MJ a tranché : un **Facteur de Volonté plus bas
réussit plus souvent** (cohérent avec les « facteurs » K&W, où bas = avantageux, cf. facteur de vitesse).

- **`rollWillpowerTest`** : `success = roll >= (FVol + modificateurs)` (était `roll <=`, sens inverse).
  Ex. FVol 5 → réussite sur 5..20 ; FVol 15 → 15..20.
- **Convention de modificateur** : un modificateur **positif** = situation **plus difficile** (relève
  le seuil) ; **négatif** = facilite (ex. le sort `courage`, « FVol –1/R », validé en E2d).
- **Doc R-8.19** (`08-magie.md`) : sens du test documenté (acté MJ 2026-05-28).
- **Tests** `dice.test.ts` : direction, contraste FVol bas/haut, sens des modificateurs.

## Portée

`rollWillpowerTest` n'a **aucun appelant en production** (primitive) → correction isolée. Canonical
+ NOMOS régénérés (08-magie.md est une source canonique). 250 tests rules-core verts.

## Test plan

- [x] `vitest run packages/rules-core` — 250/250
- [x] `tsc -b` + eslint + prettier
- [x] `canonical:check` vert
- [ ] CI : Validate + 3 gates verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
