### PR TITLE
feat(catalogs): E2k - ecole necromancie (summon + status + damage)

### DIFF
--- a/data/catalogs/spells.yaml
+++ b/data/catalogs/spells.yaml
@@ -6314,6 +6314,20 @@ spells:
         entry_id: appel
         term: Appel
     derived_from: appel
+    effect_model:
+      source:
+        prose: Relève 1 mort par niveau (portée 3 m/R ; catégorie max 20).
+        ref: spells:appel-des-morts
+      spec:
+        target: summon
+        scope: mort
+        op: grant
+        value: level
+        activation: active
+        duration: until_dispel
+        requires_mj_validation: true
+      fidelity: pending
+      ambiguity_ref: null
   - id: appel-des-morts-de-masse
     name: Appel des morts de masse
     status: active
@@ -6332,6 +6346,22 @@ spells:
         entry_id: appel
         term: Appel
     derived_from: appel
+    effect_model:
+      source:
+        prose: >-
+          Relève 1 mort par niveau, +1 par réussite au-delà de la première (portée 3 m/R ; catégorie
+          max 20).
+        ref: spells:appel-des-morts-de-masse
+      spec:
+        target: summon
+        scope: mort
+        op: grant
+        value: level + (successes - 1)
+        activation: active
+        duration: until_dispel
+        requires_mj_validation: true
+      fidelity: pending
+      ambiguity_ref: null
   - id: appel-des-morts-majeur
     name: Appel des morts majeur
     status: active
@@ -6350,6 +6380,20 @@ spells:
         entry_id: appel
         term: Appel
     derived_from: appel
+    effect_model:
+      source:
+        prose: Relève 1 mort par niveau (portée 3 m/R ; catégorie max 30).
+        ref: spells:appel-des-morts-majeur
+      spec:
+        target: summon
+        scope: mort
+        op: grant
+        value: level
+        activation: active
+        duration: until_dispel
+        requires_mj_validation: true
+      fidelity: pending
+      ambiguity_ref: null
   - id: armure-d-os
     name: Armure d’os
     status: active
@@ -6400,6 +6444,22 @@ spells:
       - catalog: lexique
         entry_id: changement-spectral
         term: Changement spectral
+    effect_model:
+      source:
+        prose: Forme spectrale, 10 minutes par réussite.
+        ref: spells:changement-spectral
+      spec:
+        target: status
+        scope: spectral
+        op: grant
+        value: 1
+        activation: active
+        duration:
+          amount: successes * 10
+          unit: minute
+        requires_mj_validation: true
+      fidelity: pending
+      ambiguity_ref: null
   - id: corruption-de-l-air
     name: Corruption de l'air
     status: active
@@ -6417,6 +6477,19 @@ spells:
       - catalog: lexique
         entry_id: corruption-de-lair
         term: Corruption de l’air
+    effect_model:
+      source:
+        prose: 'Empoisonne l’air (nuage 5 m³/R, 10 min/niv) : 2 dégâts par réussite.'
+        ref: spells:corruption-de-l-air
+      spec:
+        target: vitality
+        op: sub
+        value: 2 * successes
+        activation: active
+        duration: ephemeral
+        requires_mj_validation: true
+      fidelity: pending
+      ambiguity_ref: null
   - id: corruption-de-l-eau
     name: Corruption de l'eau
     status: active
@@ -6434,6 +6507,19 @@ spells:
       - catalog: lexique
         entry_id: corruption-de-leau
         term: Corruption de l’eau
+    effect_model:
+      source:
+        prose: 'Empoisonne l’eau (5 m³/R, 10 min/niv) : 2 dégâts par réussite.'
+        ref: spells:corruption-de-l-eau
+      spec:
+        target: vitality
+        op: sub
+        value: 2 * successes
+        activation: active
+        duration: ephemeral
+        requires_mj_validation: true
+      fidelity: pending
+      ambiguity_ref: null
   - id: corruption-vegetale
     name: Corruption végétale
     status: active
@@ -6451,6 +6537,19 @@ spells:
       - catalog: lexique
         entry_id: corruption-vegetale
         term: Corruption végétale
+    effect_model:
+      source:
+        prose: 2 dégâts par réussite aux plantes (portée 3 m/niv).
+        ref: spells:corruption-vegetale
+      spec:
+        target: vitality
+        op: sub
+        value: 2 * successes
+        activation: active
+        duration: ephemeral
+        requires_mj_validation: true
+      fidelity: pending
+      ambiguity_ref: null
   - id: crane-hurlant
     name: Crâne hurlant
     status: active
@@ -6467,6 +6566,20 @@ spells:
     generated_prose: 'Sort de nécromancie : Peur + 2 dégâts de feu par réussite.'
     prose_origin: templated
     validation: pending
+    effect_model:
+      source:
+        prose: 2 dégâts de feu par réussite (+ effet de peur, noté à part).
+        ref: spells:crane-hurlant
+      spec:
+        target: damage
+        scope: feu
+        op: add
+        value: 2 * successes
+        activation: active
+        duration: ephemeral
+        requires_mj_validation: true
+      fidelity: pending
+      ambiguity_ref: null
   - id: decret-de-non-repos
     name: Décret de non repos
     status: active
@@ -6518,6 +6631,22 @@ spells:
       - catalog: lexique
         entry_id: piege-dos
         term: Piège d’os
+    effect_model:
+      source:
+        prose: Immobilise 10 min/niveau (force du piège 1/R pour se libérer ; enforcement différé).
+        ref: spells:piege-d-os
+      spec:
+        target: status
+        scope: immobilized
+        op: grant
+        value: 1
+        activation: active
+        duration:
+          amount: level * 10
+          unit: minute
+        requires_mj_validation: true
+      fidelity: pending
+      ambiguity_ref: null
   - id: putrefaction
     name: Putréfaction
     status: active
@@ -6535,6 +6664,23 @@ spells:
       - catalog: lexique
         entry_id: putrefaction
         term: Putréfaction
+    effect_model:
+      source:
+        prose: >-
+          Putréfaction : 1 dégât par réussite et par jour, pendant 1 jour par niveau (DoT ; tick
+          quotidien noté).
+        ref: spells:putrefaction
+      spec:
+        target: vitality
+        op: sub
+        value: successes
+        activation: active
+        duration:
+          amount: level
+          unit: day
+        requires_mj_validation: true
+      fidelity: pending
+      ambiguity_ref: null
   - id: raideur-cadaverique
     name: Raideur cadavérique
     status: active
@@ -6551,6 +6697,23 @@ spells:
     generated_prose: 'Sort de nécromancie : Paralyse 50DT par réussite, si R sup à jet d’endu.'
     prose_origin: templated
     validation: pending
+    effect_model:
+      source:
+        prose: >-
+          Paralysie 50 DT par réussite. Résistance : R supérieures au jet d’endurance (enforcement
+          différé).
+        ref: spells:raideur-cadaverique
+      spec:
+        target: status
+        scope: paralyzed
+        op: grant
+        value: 1
+        activation: active
+        duration:
+          dt: successes * 50
+        requires_mj_validation: true
+      fidelity: pending
+      ambiguity_ref: null
   - id: reanimation-des-membres
     name: Réanimation des membres
     status: active
@@ -6567,6 +6730,20 @@ spells:
     generated_prose: 'Sort de nécromancie : 1 membre par niveau du lanceur, 3m par réussite, catégorie max 20.'
     prose_origin: templated
     validation: pending
+    effect_model:
+      source:
+        prose: Réanime 1 membre par niveau (portée 3 m/R ; catégorie max 20).
+        ref: spells:reanimation-des-membres
+      spec:
+        target: summon
+        scope: membre
+        op: grant
+        value: level
+        activation: active
+        duration: until_dispel
+        requires_mj_validation: true
+      fidelity: pending
+      ambiguity_ref: null
   - id: renvoi
     name: Renvoi
     status: active

--- a/data/spell-effects/necromancie.yaml
+++ b/data/spell-effects/necromancie.yaml
@@ -1,0 +1,229 @@
+# E2k — Overlay d'effets structurés AUTHORÉS, école nécromancie.
+#
+# Source autorité : la ligne `effect` du grimoire (spells.yaml). PROPOSÉ, **À VALIDER par le MJ**
+# (règles vivantes, Q-D8.2) : `fidelity: pending` + `spec.requires_mj_validation: true`.
+#
+# Cibles utilisées : `summon` (mort/membre relevés), `status` (spectral, paralysie, immobilisation),
+# `damage`/`vitality` (corruptions, putréfaction DoT, crâne hurlant). Jets de résistance (endurance)
+# et contraintes (catégorie max, portée, aire) notés en PROSE ; enforcement différé (E3/E4).
+#
+# NON inclus (arbitrage) : renvoi/renvoie-de-masse (bannissement = anti-summon), armure-d-os (chance
+# 1/3), cage-d-os (objet), decret-de-non-repos / mort-temporaire / touche-mortel (mort/résurrection),
+# terre-sterile (narratif), vieillissement (malus générique ambigu + âge).
+#
+# Mergé dans spells.yaml (champ `effect_model`) par `tools/link-spell-effects.ts`.
+version: 1
+school_id: necromancie
+effects:
+  # --- Relèvement de morts (summon) ---
+  appel-des-morts:
+    source:
+      {
+        prose: 'Relève 1 mort par niveau (portée 3 m/R ; catégorie max 20).',
+        ref: 'spells:appel-des-morts'
+      }
+    spec:
+      {
+        target: summon,
+        scope: mort,
+        op: grant,
+        value: 'level',
+        activation: active,
+        duration: until_dispel,
+        requires_mj_validation: true
+      }
+    fidelity: pending
+    ambiguity_ref: null
+  appel-des-morts-majeur:
+    source:
+      {
+        prose: 'Relève 1 mort par niveau (portée 3 m/R ; catégorie max 30).',
+        ref: 'spells:appel-des-morts-majeur'
+      }
+    spec:
+      {
+        target: summon,
+        scope: mort,
+        op: grant,
+        value: 'level',
+        activation: active,
+        duration: until_dispel,
+        requires_mj_validation: true
+      }
+    fidelity: pending
+    ambiguity_ref: null
+  appel-des-morts-de-masse:
+    source:
+      {
+        prose: 'Relève 1 mort par niveau, +1 par réussite au-delà de la première (portée 3 m/R ; catégorie max 20).',
+        ref: 'spells:appel-des-morts-de-masse'
+      }
+    spec:
+      {
+        target: summon,
+        scope: mort,
+        op: grant,
+        value: 'level + (successes - 1)',
+        activation: active,
+        duration: until_dispel,
+        requires_mj_validation: true
+      }
+    fidelity: pending
+    ambiguity_ref: null
+  reanimation-des-membres:
+    source:
+      {
+        prose: 'Réanime 1 membre par niveau (portée 3 m/R ; catégorie max 20).',
+        ref: 'spells:reanimation-des-membres'
+      }
+    spec:
+      {
+        target: summon,
+        scope: membre,
+        op: grant,
+        value: 'level',
+        activation: active,
+        duration: until_dispel,
+        requires_mj_validation: true
+      }
+    fidelity: pending
+    ambiguity_ref: null
+  # --- Statuts ---
+  changement-spectral:
+    source:
+      { prose: 'Forme spectrale, 10 minutes par réussite.', ref: 'spells:changement-spectral' }
+    spec:
+      {
+        target: status,
+        scope: spectral,
+        op: grant,
+        value: 1,
+        activation: active,
+        duration: { amount: 'successes * 10', unit: minute },
+        requires_mj_validation: true
+      }
+    fidelity: pending
+    ambiguity_ref: null
+  raideur-cadaverique:
+    source:
+      {
+        prose: 'Paralysie 50 DT par réussite. Résistance : R supérieures au jet d’endurance (enforcement différé).',
+        ref: 'spells:raideur-cadaverique'
+      }
+    spec:
+      {
+        target: status,
+        scope: paralyzed,
+        op: grant,
+        value: 1,
+        activation: active,
+        duration: { dt: 'successes * 50' },
+        requires_mj_validation: true
+      }
+    fidelity: pending
+    ambiguity_ref: null
+  piege-d-os:
+    source:
+      {
+        prose: 'Immobilise 10 min/niveau (force du piège 1/R pour se libérer ; enforcement différé).',
+        ref: 'spells:piege-d-os'
+      }
+    spec:
+      {
+        target: status,
+        scope: immobilized,
+        op: grant,
+        value: 1,
+        activation: active,
+        duration: { amount: 'level * 10', unit: minute },
+        requires_mj_validation: true
+      }
+    fidelity: pending
+    ambiguity_ref: null
+  # --- Dégâts (poison / putréfaction / feu) ---
+  corruption-vegetale:
+    source:
+      {
+        prose: '2 dégâts par réussite aux plantes (portée 3 m/niv).',
+        ref: 'spells:corruption-vegetale'
+      }
+    spec:
+      {
+        target: vitality,
+        op: sub,
+        value: '2 * successes',
+        activation: active,
+        duration: ephemeral,
+        requires_mj_validation: true
+      }
+    fidelity: pending
+    ambiguity_ref: null
+  corruption-de-l-air:
+    source:
+      {
+        prose: 'Empoisonne l’air (nuage 5 m³/R, 10 min/niv) : 2 dégâts par réussite.',
+        ref: 'spells:corruption-de-l-air'
+      }
+    spec:
+      {
+        target: vitality,
+        op: sub,
+        value: '2 * successes',
+        activation: active,
+        duration: ephemeral,
+        requires_mj_validation: true
+      }
+    fidelity: pending
+    ambiguity_ref: null
+  corruption-de-l-eau:
+    source:
+      {
+        prose: 'Empoisonne l’eau (5 m³/R, 10 min/niv) : 2 dégâts par réussite.',
+        ref: 'spells:corruption-de-l-eau'
+      }
+    spec:
+      {
+        target: vitality,
+        op: sub,
+        value: '2 * successes',
+        activation: active,
+        duration: ephemeral,
+        requires_mj_validation: true
+      }
+    fidelity: pending
+    ambiguity_ref: null
+  crane-hurlant:
+    source:
+      {
+        prose: '2 dégâts de feu par réussite (+ effet de peur, noté à part).',
+        ref: 'spells:crane-hurlant'
+      }
+    spec:
+      {
+        target: damage,
+        scope: feu,
+        op: add,
+        value: '2 * successes',
+        activation: active,
+        duration: ephemeral,
+        requires_mj_validation: true
+      }
+    fidelity: pending
+    ambiguity_ref: null
+  putrefaction:
+    source:
+      {
+        prose: 'Putréfaction : 1 dégât par réussite et par jour, pendant 1 jour par niveau (DoT ; tick quotidien noté).',
+        ref: 'spells:putrefaction'
+      }
+    spec:
+      {
+        target: vitality,
+        op: sub,
+        value: 'successes',
+        activation: active,
+        duration: { amount: 'level', unit: day },
+        requires_mj_validation: true
+      }
+    fidelity: pending
+    ambiguity_ref: null

--- a/docs/canonical/canonical-matrix.yaml
+++ b/docs/canonical/canonical-matrix.yaml
@@ -183691,7 +183691,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.1.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-1-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -183729,7 +183729,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.104.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-104-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -183767,7 +183767,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.107.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-107-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -183805,7 +183805,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.108.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-108-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -183843,7 +183843,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.110.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-110-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -183881,7 +183881,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.114.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-114-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -183919,7 +183919,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.116.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-116-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -183957,7 +183957,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.117.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-117-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -183995,7 +183995,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.118.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-118-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184033,7 +184033,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.119.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-119-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184071,7 +184071,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.122.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-122-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184109,7 +184109,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.123.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-123-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184147,7 +184147,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.124.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-124-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184185,7 +184185,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.125.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-125-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184223,7 +184223,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.126.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-126-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184261,7 +184261,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.127.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-127-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184299,7 +184299,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.128.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-128-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184337,7 +184337,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.130.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-130-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184375,7 +184375,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.131.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-131-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184413,7 +184413,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.154.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-154-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184451,7 +184451,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.159.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-159-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184489,7 +184489,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.160.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-160-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184527,7 +184527,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.163.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-163-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184565,7 +184565,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.164.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-164-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184603,7 +184603,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.165.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-165-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184641,7 +184641,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.166.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-166-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184679,7 +184679,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.167.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-167-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184717,7 +184717,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.168.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-168-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184755,7 +184755,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.170.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-170-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184793,7 +184793,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.171.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-171-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184831,7 +184831,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.172.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-172-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184869,7 +184869,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.174.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-174-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184907,7 +184907,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.175.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-175-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184945,7 +184945,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.176.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-176-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -184983,7 +184983,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.177.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-177-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185021,7 +185021,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.178.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-178-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185059,7 +185059,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.179.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-179-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185097,7 +185097,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.18.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-18-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185135,7 +185135,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.180.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-180-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185173,7 +185173,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.181.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-181-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185211,7 +185211,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.182.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-182-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185249,7 +185249,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.183.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-183-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185287,7 +185287,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.184.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-184-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185325,7 +185325,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.185.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-185-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185363,7 +185363,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.187.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-187-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185401,7 +185401,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.188.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-188-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185439,7 +185439,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.189.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-189-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185477,7 +185477,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.19.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-19-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185515,7 +185515,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.190.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-190-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185553,7 +185553,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.191.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-191-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185591,7 +185591,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.192.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-192-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185629,7 +185629,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.193.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-193-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185667,7 +185667,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.194.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-194-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185705,7 +185705,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.195.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-195-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185743,7 +185743,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.196.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-196-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185781,7 +185781,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.197.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-197-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185819,7 +185819,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.198.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-198-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185857,7 +185857,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.199.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-199-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185895,7 +185895,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.2.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-2-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185933,7 +185933,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.20.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-20-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -185971,7 +185971,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.200.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-200-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186009,7 +186009,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.201.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-201-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186047,7 +186047,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.202.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-202-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186085,7 +186085,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.203.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-203-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186123,7 +186123,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.204.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-204-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186161,7 +186161,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.205.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-205-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186199,7 +186199,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.206.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-206-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186237,7 +186237,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.207.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-207-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186275,7 +186275,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.208.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-208-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186313,7 +186313,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.209.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-209-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186351,7 +186351,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.210.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-210-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186389,7 +186389,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.211.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-211-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186427,7 +186427,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.212.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-212-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186465,7 +186465,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.23.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-23-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186503,7 +186503,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.24.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-24-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186541,7 +186541,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.243.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-243-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186579,7 +186579,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.244.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-244-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186617,7 +186617,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.245.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-245-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186655,7 +186655,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.246.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-246-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186693,7 +186693,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.247.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-247-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186731,7 +186731,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.248.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-248-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186769,7 +186769,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.249.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-249-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186807,7 +186807,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.25.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-25-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186845,7 +186845,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.250.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-250-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186883,7 +186883,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.251.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-251-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186921,7 +186921,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.252.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-252-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186959,7 +186959,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.253.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-253-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -186997,7 +186997,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.255.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-255-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187035,7 +187035,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.256.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-256-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187073,7 +187073,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.257.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-257-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187111,7 +187111,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.259.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-259-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187149,7 +187149,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.260.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-260-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187187,7 +187187,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.261.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-261-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187225,7 +187225,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.262.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-262-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187263,7 +187263,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.263.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-263-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187301,7 +187301,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.264.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-264-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187339,7 +187339,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.265.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-265-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187377,7 +187377,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.266.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-266-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187415,7 +187415,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.268.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-268-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187453,7 +187453,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.269.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-269-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187491,7 +187491,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.27.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-27-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187529,7 +187529,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.270.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-270-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187567,7 +187567,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.271.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-271-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187605,7 +187605,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.272.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-272-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187643,7 +187643,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.274.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-274-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187681,7 +187681,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.275.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-275-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187719,7 +187719,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.276.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-276-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187757,7 +187757,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.277.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-277-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187795,7 +187795,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.28.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-28-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187833,7 +187833,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.280.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-280-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187871,7 +187871,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.282.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-282-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187909,7 +187909,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.283.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-283-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187947,7 +187947,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.284.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-284-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -187985,7 +187985,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.288.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-288-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188023,7 +188023,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.29.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-29-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188061,7 +188061,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.292.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-292-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188099,7 +188099,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.3.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-3-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188137,7 +188137,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.30.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-30-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188175,7 +188175,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.305.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-305-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188213,7 +188213,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.316.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-316-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188251,7 +188251,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.319.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-319-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188289,7 +188289,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.32.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-32-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188327,7 +188327,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.322.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-322-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188365,7 +188365,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.323.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-323-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188403,7 +188403,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.36.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-36-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188441,7 +188441,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.37.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-37-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188479,7 +188479,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.38.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-38-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188517,7 +188517,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.39.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-39-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188555,7 +188555,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.40.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-40-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188593,7 +188593,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.41.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-41-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188631,7 +188631,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.44.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-44-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188669,7 +188669,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.45.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-45-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188707,7 +188707,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.46.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-46-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188745,7 +188745,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.47.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-47-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188783,7 +188783,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.48.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-48-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188821,7 +188821,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.49.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-49-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188859,7 +188859,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.5.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-5-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188897,7 +188897,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.50.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-50-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188935,7 +188935,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.51.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-51-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -188973,7 +188973,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.52.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-52-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189011,7 +189011,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.53.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-53-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189049,7 +189049,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.54.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-54-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189087,7 +189087,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.57.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-57-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189125,7 +189125,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.6.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-6-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189163,7 +189163,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.61.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-61-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189201,7 +189201,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.62.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-62-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189239,7 +189239,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.90.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-90-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189277,7 +189277,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.91.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-91-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189315,7 +189315,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.92.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-92-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189353,7 +189353,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.93.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-93-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189391,7 +189391,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.94.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-94-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189429,7 +189429,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.95.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-95-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -189467,7 +189467,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.96.prose_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-96-prose-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279277,7 +279277,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.0.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-0-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279315,7 +279315,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.1.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-1-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279353,7 +279353,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.10.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-10-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279391,7 +279391,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.100.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-100-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279429,7 +279429,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.101.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-101-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279467,7 +279467,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.102.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-102-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279505,7 +279505,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.103.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-103-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279543,7 +279543,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.104.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-104-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279581,7 +279581,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.105.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-105-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279619,7 +279619,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.106.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-106-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279657,7 +279657,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.107.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-107-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279695,7 +279695,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.108.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-108-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279733,7 +279733,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.109.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-109-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279771,7 +279771,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.11.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-11-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279809,7 +279809,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.110.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-110-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279847,7 +279847,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.111.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-111-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279885,7 +279885,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.112.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-112-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279923,7 +279923,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.113.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-113-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279961,7 +279961,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.114.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-114-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -279999,7 +279999,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.115.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-115-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280037,7 +280037,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.116.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-116-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280075,7 +280075,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.117.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-117-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280113,7 +280113,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.118.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-118-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280151,7 +280151,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.119.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-119-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280189,7 +280189,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.12.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-12-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280227,7 +280227,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.120.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-120-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280265,7 +280265,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.121.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-121-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280303,7 +280303,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.122.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-122-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280341,7 +280341,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.123.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-123-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280379,7 +280379,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.124.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-124-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280417,7 +280417,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.125.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-125-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280455,7 +280455,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.126.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-126-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280493,7 +280493,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.127.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-127-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280531,7 +280531,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.128.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-128-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280569,7 +280569,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.129.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-129-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280607,7 +280607,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.13.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-13-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280645,7 +280645,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.130.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-130-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280683,7 +280683,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.131.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-131-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280721,7 +280721,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.132.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-132-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280759,7 +280759,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.133.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-133-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280797,7 +280797,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.134.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-134-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280835,7 +280835,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.135.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-135-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280873,7 +280873,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.136.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-136-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280911,7 +280911,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.137.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-137-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280949,7 +280949,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.138.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-138-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -280987,7 +280987,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.139.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-139-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281025,7 +281025,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.14.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-14-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281063,7 +281063,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.140.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-140-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281101,7 +281101,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.141.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-141-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281139,7 +281139,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.142.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-142-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281177,7 +281177,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.143.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-143-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281215,7 +281215,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.144.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-144-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281253,7 +281253,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.145.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-145-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281291,7 +281291,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.146.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-146-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281329,7 +281329,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.147.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-147-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281367,7 +281367,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.148.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-148-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281405,7 +281405,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.149.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-149-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281443,7 +281443,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.15.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-15-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281481,7 +281481,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.150.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-150-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281519,7 +281519,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.151.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-151-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281557,7 +281557,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.152.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-152-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281595,7 +281595,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.153.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-153-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281633,7 +281633,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.154.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-154-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281671,7 +281671,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.155.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-155-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281709,7 +281709,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.156.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-156-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281747,7 +281747,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.157.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-157-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281785,7 +281785,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.158.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-158-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281823,7 +281823,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.159.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-159-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281861,7 +281861,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.16.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-16-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281899,7 +281899,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.160.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-160-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281937,7 +281937,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.161.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-161-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -281975,7 +281975,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.162.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-162-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282013,7 +282013,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.163.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-163-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282051,7 +282051,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.164.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-164-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282089,7 +282089,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.165.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-165-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282127,7 +282127,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.166.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-166-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282165,7 +282165,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.167.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-167-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282203,7 +282203,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.168.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-168-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282241,7 +282241,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.169.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-169-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282279,7 +282279,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.17.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-17-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282317,7 +282317,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.170.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-170-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282355,7 +282355,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.171.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-171-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282393,7 +282393,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.172.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-172-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282431,7 +282431,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.173.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-173-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282469,7 +282469,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.174.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-174-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282507,7 +282507,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.175.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-175-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282545,7 +282545,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.176.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-176-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282583,7 +282583,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.177.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-177-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282621,7 +282621,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.178.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-178-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282659,7 +282659,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.179.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-179-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282697,7 +282697,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.18.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-18-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282735,7 +282735,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.180.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-180-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282773,7 +282773,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.181.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-181-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282811,7 +282811,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.182.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-182-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282849,7 +282849,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.183.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-183-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282887,7 +282887,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.184.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-184-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282925,7 +282925,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.185.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-185-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -282963,7 +282963,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.186.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-186-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283001,7 +283001,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.187.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-187-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283039,7 +283039,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.188.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-188-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283077,7 +283077,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.189.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-189-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283115,7 +283115,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.19.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-19-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283153,7 +283153,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.190.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-190-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283191,7 +283191,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.191.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-191-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283229,7 +283229,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.192.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-192-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283267,7 +283267,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.193.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-193-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283305,7 +283305,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.194.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-194-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283343,7 +283343,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.195.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-195-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283381,7 +283381,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.196.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-196-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283419,7 +283419,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.197.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-197-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283457,7 +283457,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.198.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-198-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283495,7 +283495,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.199.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-199-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283533,7 +283533,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.2.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-2-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283571,7 +283571,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.20.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-20-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283609,7 +283609,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.200.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-200-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283647,7 +283647,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.201.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-201-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283685,7 +283685,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.202.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-202-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283723,7 +283723,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.203.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-203-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283761,7 +283761,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.204.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-204-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283799,7 +283799,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.205.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-205-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283837,7 +283837,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.206.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-206-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283875,7 +283875,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.207.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-207-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283913,7 +283913,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.208.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-208-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283951,7 +283951,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.209.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-209-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -283989,7 +283989,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.21.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-21-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284027,7 +284027,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.210.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-210-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284065,7 +284065,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.211.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-211-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284103,7 +284103,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.212.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-212-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284141,7 +284141,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.213.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-213-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284179,7 +284179,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.214.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-214-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284217,7 +284217,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.215.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-215-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284255,7 +284255,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.216.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-216-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284293,7 +284293,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.217.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-217-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284331,7 +284331,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.218.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-218-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284369,7 +284369,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.219.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-219-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284407,7 +284407,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.22.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-22-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284445,7 +284445,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.220.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-220-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284483,7 +284483,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.221.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-221-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284521,7 +284521,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.222.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-222-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284559,7 +284559,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.223.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-223-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284597,7 +284597,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.224.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-224-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284635,7 +284635,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.225.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-225-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284673,7 +284673,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.226.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-226-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284711,7 +284711,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.227.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-227-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284749,7 +284749,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.228.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-228-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284787,7 +284787,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.229.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-229-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284825,7 +284825,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.23.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-23-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284863,7 +284863,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.230.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-230-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284901,7 +284901,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.231.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-231-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284939,7 +284939,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.232.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-232-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -284977,7 +284977,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.233.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-233-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285015,7 +285015,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.234.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-234-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285053,7 +285053,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.235.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-235-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285091,7 +285091,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.236.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-236-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285129,7 +285129,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.237.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-237-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285167,7 +285167,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.238.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-238-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285205,7 +285205,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.239.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-239-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285243,7 +285243,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.24.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-24-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285281,7 +285281,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.240.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-240-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285319,7 +285319,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.241.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-241-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285357,7 +285357,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.242.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-242-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285395,7 +285395,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.243.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-243-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285433,7 +285433,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.244.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-244-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285471,7 +285471,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.245.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-245-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285509,7 +285509,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.246.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-246-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285547,7 +285547,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.247.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-247-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285585,7 +285585,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.248.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-248-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285623,7 +285623,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.249.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-249-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285661,7 +285661,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.25.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-25-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285699,7 +285699,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.250.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-250-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285737,7 +285737,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.251.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-251-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285775,7 +285775,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.252.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-252-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285813,7 +285813,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.253.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-253-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285851,7 +285851,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.254.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-254-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285889,7 +285889,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.255.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-255-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285927,7 +285927,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.256.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-256-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -285965,7 +285965,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.257.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-257-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286003,7 +286003,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.258.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-258-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286041,7 +286041,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.259.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-259-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286079,7 +286079,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.26.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-26-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286117,7 +286117,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.260.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-260-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286155,7 +286155,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.261.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-261-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286193,7 +286193,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.262.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-262-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286231,7 +286231,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.263.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-263-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286269,7 +286269,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.264.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-264-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286307,7 +286307,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.265.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-265-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286345,7 +286345,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.266.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-266-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286383,7 +286383,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.267.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-267-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286421,7 +286421,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.268.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-268-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286459,7 +286459,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.269.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-269-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286497,7 +286497,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.27.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-27-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286535,7 +286535,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.270.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-270-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286573,7 +286573,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.271.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-271-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286611,7 +286611,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.272.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-272-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286649,7 +286649,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.273.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-273-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286687,7 +286687,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.274.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-274-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286725,7 +286725,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.275.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-275-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286763,7 +286763,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.276.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-276-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286801,7 +286801,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.277.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-277-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286839,7 +286839,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.278.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-278-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286877,7 +286877,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.279.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-279-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286915,7 +286915,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.28.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-28-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286953,7 +286953,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.280.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-280-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -286991,7 +286991,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.281.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-281-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287029,7 +287029,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.282.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-282-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287067,7 +287067,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.283.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-283-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287105,7 +287105,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.284.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-284-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287143,7 +287143,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.285.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-285-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287181,7 +287181,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.286.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-286-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287219,7 +287219,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.287.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-287-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287257,7 +287257,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.288.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-288-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287295,7 +287295,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.289.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-289-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287333,7 +287333,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.29.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-29-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287371,7 +287371,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.290.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-290-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287409,7 +287409,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.291.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-291-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287447,7 +287447,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.292.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-292-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287485,7 +287485,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.293.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-293-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287523,7 +287523,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.294.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-294-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287561,7 +287561,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.295.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-295-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287599,7 +287599,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.296.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-296-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287637,7 +287637,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.297.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-297-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287675,7 +287675,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.298.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-298-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287713,7 +287713,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.299.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-299-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287751,7 +287751,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.3.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-3-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287789,7 +287789,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.30.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-30-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287827,7 +287827,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.300.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-300-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287865,7 +287865,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.301.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-301-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287903,7 +287903,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.302.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-302-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287941,7 +287941,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.303.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-303-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -287979,7 +287979,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.304.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-304-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288017,7 +288017,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.305.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-305-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288055,7 +288055,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.306.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-306-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288093,7 +288093,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.307.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-307-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288131,7 +288131,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.308.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-308-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288169,7 +288169,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.309.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-309-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288207,7 +288207,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.31.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-31-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288245,7 +288245,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.310.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-310-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288283,7 +288283,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.311.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-311-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288321,7 +288321,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.312.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-312-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288359,7 +288359,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.313.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-313-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288397,7 +288397,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.314.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-314-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288435,7 +288435,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.315.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-315-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288473,7 +288473,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.316.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-316-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288511,7 +288511,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.317.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-317-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288549,7 +288549,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.318.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-318-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288587,7 +288587,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.319.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-319-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288625,7 +288625,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.32.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-32-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288663,7 +288663,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.320.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-320-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288701,7 +288701,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.321.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-321-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288739,7 +288739,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.322.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-322-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288777,7 +288777,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.323.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-323-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288815,7 +288815,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.33.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-33-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288853,7 +288853,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.34.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-34-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288891,7 +288891,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.35.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-35-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288929,7 +288929,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.36.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-36-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -288967,7 +288967,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.37.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-37-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289005,7 +289005,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.38.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-38-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289043,7 +289043,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.39.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-39-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289081,7 +289081,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.4.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-4-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289119,7 +289119,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.40.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-40-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289157,7 +289157,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.41.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-41-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289195,7 +289195,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.42.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-42-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289233,7 +289233,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.43.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-43-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289271,7 +289271,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.44.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-44-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289309,7 +289309,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.45.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-45-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289347,7 +289347,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.46.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-46-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289385,7 +289385,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.47.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-47-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289423,7 +289423,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.48.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-48-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289461,7 +289461,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.49.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-49-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289499,7 +289499,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.5.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-5-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289537,7 +289537,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.50.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-50-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289575,7 +289575,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.51.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-51-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289613,7 +289613,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.52.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-52-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289651,7 +289651,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.53.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-53-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289689,7 +289689,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.54.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-54-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289727,7 +289727,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.55.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-55-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289765,7 +289765,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.56.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-56-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289803,7 +289803,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.57.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-57-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289841,7 +289841,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.58.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-58-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289879,7 +289879,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.59.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-59-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289917,7 +289917,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.6.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-6-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289955,7 +289955,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.60.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-60-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -289993,7 +289993,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.61.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-61-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290031,7 +290031,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.62.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-62-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290069,7 +290069,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.63.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-63-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290107,7 +290107,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.64.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-64-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290145,7 +290145,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.65.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-65-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290183,7 +290183,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.66.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-66-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290221,7 +290221,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.67.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-67-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290259,7 +290259,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.68.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-68-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290297,7 +290297,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.69.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-69-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290335,7 +290335,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.7.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-7-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290373,7 +290373,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.70.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-70-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290411,7 +290411,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.71.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-71-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290449,7 +290449,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.72.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-72-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290487,7 +290487,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.73.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-73-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290525,7 +290525,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.74.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-74-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290563,7 +290563,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.75.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-75-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290601,7 +290601,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.76.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-76-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290639,7 +290639,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.77.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-77-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290677,7 +290677,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.78.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-78-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290715,7 +290715,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.79.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-79-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290753,7 +290753,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.8.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-8-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290791,7 +290791,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.80.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-80-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290829,7 +290829,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.81.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-81-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290867,7 +290867,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.82.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-82-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290905,7 +290905,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.83.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-83-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290943,7 +290943,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.84.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-84-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -290981,7 +290981,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.85.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-85-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291019,7 +291019,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.86.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-86-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291057,7 +291057,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.87.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-87-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291095,7 +291095,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.88.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-88-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291133,7 +291133,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.89.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-89-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291171,7 +291171,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.9.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-9-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291209,7 +291209,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.90.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-90-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291247,7 +291247,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.91.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-91-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291285,7 +291285,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.92.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-92-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291323,7 +291323,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.93.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-93-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291361,7 +291361,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.94.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-94-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291399,7 +291399,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.95.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-95-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291437,7 +291437,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.96.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-96-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291475,7 +291475,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.97.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-97-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291513,7 +291513,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.98.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-98-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -291551,7 +291551,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.99.source_refs.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "spells-99-source-refs-0 from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -328127,7 +328127,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "data/catalogs/spells.yaml"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "data/catalogs/spells.yaml from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -349805,7 +349805,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.285"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Affaiblissement from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -349843,7 +349843,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.286"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Affaiblissement de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -349881,7 +349881,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.33"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Agrandissement from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -349919,7 +349919,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.159"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Animation des armures from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -349957,7 +349957,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.0"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Annihilation from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -349995,7 +349995,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.287"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Antipathisme from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350033,7 +350033,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.288"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Apathie from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350071,7 +350071,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.130"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Appel de la foudre from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350109,7 +350109,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.131"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Appel de la pluie from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350147,7 +350147,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.243"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Appel des chats from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350185,7 +350185,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.244"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Appel des chevaux from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350223,7 +350223,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.245"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Appel des colombes from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350261,7 +350261,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.246"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Appel des corbeaux from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350299,7 +350299,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.247"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Appel des insectes from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350337,7 +350337,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.248"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Appel des loups from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350375,7 +350375,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.249"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Appel des mammifères from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350413,7 +350413,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.264"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Appel des morts from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350451,7 +350451,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.265"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Appel des morts de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350489,7 +350489,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.266"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Appel des morts majeur from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350527,7 +350527,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.160"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Arc-en-ciel from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350565,7 +350565,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.267"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Armure d’os from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350603,7 +350603,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.289"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Arrêt du temps from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350641,7 +350641,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.1"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Augmentation énergétique from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350679,7 +350679,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.181"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Auto clonage from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350717,7 +350717,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.290"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Autodestruction from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350755,7 +350755,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.62"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Barrière de Höln from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350793,7 +350793,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.2"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Barrière psychique from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350831,7 +350831,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.3"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Barrière psychique de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350869,7 +350869,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.63"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Bénédiction from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350907,7 +350907,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.64"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Bénédiction de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350945,7 +350945,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.291"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Bêtise from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -350983,7 +350983,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.4"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Boomerang from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351021,7 +351021,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.65"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Bouclier from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351059,7 +351059,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.66"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Bouclier anti-feu from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351097,7 +351097,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.67"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Bouclier anti-foudre from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351135,7 +351135,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.68"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Bouclier anti-froid from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351173,7 +351173,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.69"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Bouclier anti-lave from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351211,7 +351211,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.70"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Bouclier anti-mal from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351249,7 +351249,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.133"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Bouclier d’eau from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351287,7 +351287,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.132"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Bouclier de foudre from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351325,7 +351325,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.134"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Boule de feu from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351363,7 +351363,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.135"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Boule de feu majeure from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351401,7 +351401,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.136"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Boule de foudre from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351439,7 +351439,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.137"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Boule de foudre majeure from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351477,7 +351477,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.34"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Branchie from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351515,7 +351515,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.35"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Branchie de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351553,7 +351553,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.138"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Brasier from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351591,7 +351591,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.268"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Cage d'os from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351629,7 +351629,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.5"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Captage d'énergie from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351667,7 +351667,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.161"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Cauchemard from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351705,7 +351705,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.162"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Cauchemard de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351743,7 +351743,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.182"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Centaure illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351781,7 +351781,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.139"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Cercle de feu from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351819,7 +351819,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.250"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Cercle de fleur from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351857,7 +351857,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.140"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Chaîne d’éclairs from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351895,7 +351895,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.141"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Champs de boue from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351933,7 +351933,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.36"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Changement de sexe from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -351971,7 +351971,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.37"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Changement en corbeau from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352009,7 +352009,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.38"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Changement en crapaud from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352047,7 +352047,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.39"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Changement en furet from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352085,7 +352085,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.40"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Changement en humain from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352123,7 +352123,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.41"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Changement en lapin from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352161,7 +352161,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.269"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Changement spectral from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352199,7 +352199,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.42"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Changer l’eau en vin from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352237,7 +352237,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.71"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Charisme from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352275,7 +352275,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.72"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Charisme de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352313,7 +352313,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.183"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Chat illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352351,7 +352351,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.43"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Châtiment de la matière from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352389,7 +352389,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.184"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Cheval illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352427,7 +352427,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.185"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Chigr Illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352465,7 +352465,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.186"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Clonage from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352503,7 +352503,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.163"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Cocon thermique from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352541,7 +352541,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.142"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Colère divine from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352579,7 +352579,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.6"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Complexité magique from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352617,7 +352617,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.108"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Connaître le vice from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352655,7 +352655,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.109"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contact from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352693,7 +352693,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.110"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contact de Morphée from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352731,7 +352731,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.111"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contact divin from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352769,7 +352769,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.112"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contacter l’au-delà from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352807,7 +352807,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.292"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contagion du péché from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352845,7 +352845,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.7"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contre-blanc from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352883,7 +352883,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.8"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contre-bleu from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352921,7 +352921,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.9"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contre-brun from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352959,7 +352959,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.10"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contre-gris from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -352997,7 +352997,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.11"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contre-jaune from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353035,7 +353035,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.12"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contre-noir from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353073,7 +353073,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.13"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contre-orange from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353111,7 +353111,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.14"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contre-rouge from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353149,7 +353149,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.15"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contre-turquoise from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353187,7 +353187,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.16"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contre-vert from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353225,7 +353225,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.17"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contre-violet from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353263,7 +353263,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.293"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Control charnel from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353301,7 +353301,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.294"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Contrôle mental from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353339,7 +353339,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.164"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Corde from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353377,7 +353377,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.44"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Corrosion from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353415,7 +353415,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.45"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Corrosion de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353453,7 +353453,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.270"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Corruption de l'air from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353491,7 +353491,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.271"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Corruption de l'eau from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353529,7 +353529,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.272"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Corruption végétale from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353567,7 +353567,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.73"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Courage from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353605,7 +353605,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.187"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Couteau illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353643,7 +353643,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.273"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Crâne hurlant from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353681,7 +353681,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.46"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Création d'aile from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353719,7 +353719,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.47"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Création d'oeil from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353757,7 +353757,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.48"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Création de bras from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353795,7 +353795,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.49"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Création de dent from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353833,7 +353833,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.50"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Création de jambe from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353871,7 +353871,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.51"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Création de kyste from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353909,7 +353909,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.52"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Création de main from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353947,7 +353947,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.53"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Création de pied from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -353985,7 +353985,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.54"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Création de queue from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354023,7 +354023,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.251"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Croissance from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354061,7 +354061,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.274"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Décret de non repos from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354099,7 +354099,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.188"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Demi-elfe illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354137,7 +354137,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.18"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Déplacement magique from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354175,7 +354175,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.19"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Déplacement magique de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354213,7 +354213,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.113"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Détection du danger from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354251,7 +354251,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.20"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Détournement du lien du mort-vivant from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354289,7 +354289,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.74"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Déviation from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354327,7 +354327,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.75"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Déviation de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354365,7 +354365,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.76"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Déviation des projectiles from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354403,7 +354403,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.77"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Déviation majeure from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354441,7 +354441,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.78"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Déviation mineure from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354479,7 +354479,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.79"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Dextérité from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354517,7 +354517,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.80"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Dextérité de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354555,7 +354555,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.21"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Dispersion du familier from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354593,7 +354593,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.22"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Dissipation from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354631,7 +354631,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.81"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Don d’énergie from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354669,7 +354669,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.295"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Douleur from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354707,7 +354707,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.296"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Douleur à distance from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354745,7 +354745,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.297"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Douleur de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354783,7 +354783,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.298"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Douleur majeure from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354821,7 +354821,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.299"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Douleur mineure from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354859,7 +354859,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.300"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Drain de jeunesse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354897,7 +354897,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.301"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Drain de sort from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354935,7 +354935,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.302"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Drain de sort majeur from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -354973,7 +354973,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.303"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Drain de sort mineur from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355011,7 +355011,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.304"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Drain de vie from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355049,7 +355049,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.189"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Dryade illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355087,7 +355087,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.252"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Eclosion from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355125,7 +355125,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.253"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Effacement des traces from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355163,7 +355163,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.254"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Effacement des traces de masses from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355201,7 +355201,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.190"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Elfe illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355239,7 +355239,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.82"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Empathie from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355277,7 +355277,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.83"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Empathie de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355315,7 +355315,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.305"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Emprise corporelle from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355353,7 +355353,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.165"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Enchantement de livre from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355391,7 +355391,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.84"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Endurance from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355429,7 +355429,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.85"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Endurance de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355467,7 +355467,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.86"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Esthétique from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355505,7 +355505,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.87"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Esthétique de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355543,7 +355543,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.55"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Evaporation from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355581,7 +355581,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.166"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Extase from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355619,7 +355619,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.306"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Faiblesse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355657,7 +355657,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.191"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Fantôme illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355695,7 +355695,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.255"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Fertilité from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355733,7 +355733,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.143"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Flash from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355771,7 +355771,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.144"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Flèche de feu from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355809,7 +355809,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.145"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Flèche de foudre from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355847,7 +355847,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.307"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Folie from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355885,7 +355885,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.88"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Force from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355923,7 +355923,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.89"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Force de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355961,7 +355961,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.192"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Fortune illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -355999,7 +355999,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.146"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Foudroiement from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356037,7 +356037,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.56"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Gel from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356075,7 +356075,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.193"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Gnome illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356113,7 +356113,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.194"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Gobelin illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356151,7 +356151,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.90"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Guérison absolue from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356189,7 +356189,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.91"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Guérison de la chair from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356227,7 +356227,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.92"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Guérison de la peau from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356265,7 +356265,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.93"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Guérison des muscles from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356303,7 +356303,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.94"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Guérison des muscles mineure from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356341,7 +356341,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.95"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Guérison des organes from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356379,7 +356379,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.96"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Guérison des os from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356417,7 +356417,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.308"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Hibernation from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356455,7 +356455,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.195"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Hobbit illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356493,7 +356493,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.196"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Homme lézard illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356531,7 +356531,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.197"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Homme oiseau illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356569,7 +356569,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.198"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Homme rat illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356607,7 +356607,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.309"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Horreur from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356645,7 +356645,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.199"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Humain illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356683,7 +356683,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.114"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Identification from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356721,7 +356721,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.147"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Immolation from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356759,7 +356759,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.310"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Implosion from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356797,7 +356797,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.256"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Instinct de reproduction from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356835,7 +356835,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.257"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Instinct de survie from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356873,7 +356873,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.97"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Intelligence from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356911,7 +356911,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.98"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Intelligence de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356949,7 +356949,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.23"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Interdiction magique from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -356987,7 +356987,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.167"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invisibilité from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357025,7 +357025,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.238"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation d’abeilles from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357063,7 +357063,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.213"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation d'elfe from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357101,7 +357101,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.214"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation d'homme lézard from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357139,7 +357139,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.215"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation d'homme oiseau from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357177,7 +357177,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.216"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation d'homme rat from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357215,7 +357215,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.217"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation d'humain from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357253,7 +357253,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.239"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation d’ogres from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357291,7 +357291,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.218"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation d'ondine from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357329,7 +357329,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.240"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation d’orc from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357367,7 +357367,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.219"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de centaure from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357405,7 +357405,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.220"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de chat from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357443,7 +357443,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.221"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de cheval from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357481,7 +357481,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.222"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de chigr from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357519,7 +357519,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.223"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de demi elfe from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357557,7 +357557,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.224"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de dryade from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357595,7 +357595,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.225"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de gnome from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357633,7 +357633,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.226"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de gobelin from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357671,7 +357671,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.227"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de guêpe from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357709,7 +357709,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.228"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de hobbit from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357747,7 +357747,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.229"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de khochigr from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357785,7 +357785,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.230"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de khogr from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357823,7 +357823,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.231"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de loup from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357861,7 +357861,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.232"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de loup-garou from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357899,7 +357899,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.233"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de nain from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357937,7 +357937,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.234"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de squelette from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -357975,7 +357975,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.235"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de termite from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358013,7 +358013,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.236"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de troll from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358051,7 +358051,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.237"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Invocation de vampire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358089,7 +358089,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.24"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Irréductibilité from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358127,7 +358127,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.25"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Irréductibilité de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358165,7 +358165,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.200"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Khochigr illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358203,7 +358203,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.201"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Khogr illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358241,7 +358241,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.311"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Lâcheté from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358279,7 +358279,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.312"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Laideur from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358317,7 +358317,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.168"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Légèreté from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358355,7 +358355,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.313"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Lenteur from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358393,7 +358393,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.314"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Lenteur de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358431,7 +358431,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.241"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Lien d'invocation from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358469,7 +358469,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.115"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Localisation from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358507,7 +358507,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.203"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Loup-garou illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358545,7 +358545,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.202"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Loup illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358583,7 +358583,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.169"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Lourdeur from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358621,7 +358621,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.99"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Lumière from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358659,7 +358659,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.315"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Malédiction from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358697,7 +358697,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.170"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Marche sur l'eau from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358735,7 +358735,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.258"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Marécage from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358773,7 +358773,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.57"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Membre téléscopique from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358811,7 +358811,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.58"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Miniaturisation from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358849,7 +358849,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.275"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Mort temporaire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358887,7 +358887,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.148"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Multi-flamme from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358925,7 +358925,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.171"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Multilinguisme from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -358963,7 +358963,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.149"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Mur de flammes from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359001,7 +359001,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.204"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Mur illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359039,7 +359039,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.259"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Mûrissement from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359077,7 +359077,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.205"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Nain illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359115,7 +359115,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.172"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Nettoyage magique from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359153,7 +359153,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.116"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Nouvelle du monde from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359191,7 +359191,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.117"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Nouvelle nationale from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359229,7 +359229,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.118"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Nouvelle régionale from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359267,7 +359267,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.260"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Obstacles végétaux from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359305,7 +359305,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.206"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Ogre illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359343,7 +359343,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.207"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Ondine illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359381,7 +359381,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.208"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Orc illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359419,7 +359419,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.316"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Oubli from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359457,7 +359457,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.317"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Paralysie from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359495,7 +359495,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.173"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Parler aux oiseaux from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359533,7 +359533,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.174"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Passe-partout from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359571,7 +359571,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.318"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Pénombre from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359609,7 +359609,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.26"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Perturbation from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359647,7 +359647,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.59"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Pétrification from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359685,7 +359685,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.319"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Peur from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359723,7 +359723,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.276"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Piège d'os from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359761,7 +359761,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.27"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Piégeage magique from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359799,7 +359799,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.150"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Pilier de feu from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359837,7 +359837,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.320"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Pluie de sang from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359875,7 +359875,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.175"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Porte de secours from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359913,7 +359913,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.119"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Prémonition from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359951,7 +359951,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.100"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Purification de l'air from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -359989,7 +359989,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.101"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Purification de l'eau from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360027,7 +360027,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.277"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Putréfaction from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360065,7 +360065,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.151"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Pyramide de feu from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360103,7 +360103,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.278"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Raideur cadavérique from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360141,7 +360141,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.28"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Ralentissement magique from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360179,7 +360179,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.102"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Rapidité from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360217,7 +360217,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.103"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Rapidité de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360255,7 +360255,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.152"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Rayon d’eau from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360293,7 +360293,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.153"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Raz de marée from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360331,7 +360331,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.279"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Réanimation des membres from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360369,7 +360369,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.120"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Regard de puissance from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360407,7 +360407,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.60"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Rendre forme from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360445,7 +360445,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.280"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Renvoi from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360483,7 +360483,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.104"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Renvoi du démon from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360521,7 +360521,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.281"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Renvoie de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360559,7 +360559,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.105"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Respiration from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360597,7 +360597,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.106"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Respiration de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360635,7 +360635,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.321"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Resserrement des murs from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360673,7 +360673,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.107"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Résurrection from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360711,7 +360711,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.29"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Rets des âmes from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360749,7 +360749,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.30"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Rets des cadavres from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360787,7 +360787,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.261"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Réveil de la bête from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360825,7 +360825,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.242"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Révocation from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360863,7 +360863,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.176"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Rire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360901,7 +360901,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.177"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Rire de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360939,7 +360939,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.31"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Rupture de lien d'invocation from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -360977,7 +360977,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.154"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Sables mouvants from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361015,7 +361015,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.121"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Savoir l'aptitude from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361053,7 +361053,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.122"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Savoir l'énergie from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361091,7 +361091,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.123"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Savoir la vitalité from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361129,7 +361129,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.124"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Savoir la vitesse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361167,7 +361167,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.125"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Savoir la volonté from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361205,7 +361205,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.126"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Savoir le nom from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361243,7 +361243,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.127"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Savoir les compétences from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361281,7 +361281,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.262"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Sol fertile from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361319,7 +361319,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.178"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Sommeil from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361357,7 +361357,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.61"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Soudure from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361395,7 +361395,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.209"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Squelette illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361433,7 +361433,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.32"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Substitution de sort from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361471,7 +361471,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.282"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Terre stérile from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361509,7 +361509,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.155"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Tornade from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361547,7 +361547,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.156"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Tornade de feu from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361585,7 +361585,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.263"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Torsion du bois from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361623,7 +361623,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.157"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Touché ardant from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361661,7 +361661,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.283"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Touché mortel from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361699,7 +361699,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.210"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Troll illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361737,7 +361737,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.158"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Vague de feu from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361775,7 +361775,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.211"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Vampire illusoire from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361813,7 +361813,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.322"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Vengeance from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361851,7 +361851,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.323"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Vengeance en masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361889,7 +361889,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.212"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Vide sidéral from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361927,7 +361927,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.284"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Vieillissement from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -361965,7 +361965,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.128"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Vision ante mortem from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -362003,7 +362003,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.129"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Vision de rêve from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -362041,7 +362041,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.179"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Vol de masse from data/catalogs/spells.yaml."
       ambiguity_ref: null
@@ -362079,7 +362079,7 @@ units:
     sources:
       - path: "data/catalogs/spells.yaml"
         ref: "spells.180"
-        sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+        sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     business_rule:
       summary: "Vol magique from data/catalogs/spells.yaml."
       ambiguity_ref: null

--- a/docs/canonical/nomos/canonical-matrix.yaml
+++ b/docs/canonical/nomos/canonical-matrix.yaml
@@ -99307,7 +99307,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.1.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-1-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99327,7 +99327,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.104.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-104-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99347,7 +99347,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.107.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-107-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99367,7 +99367,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.108.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-108-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99387,7 +99387,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.110.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-110-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99407,7 +99407,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.114.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-114-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99427,7 +99427,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.116.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-116-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99447,7 +99447,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.117.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-117-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99467,7 +99467,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.118.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-118-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99487,7 +99487,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.119.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-119-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99507,7 +99507,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.122.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-122-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99527,7 +99527,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.123.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-123-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99547,7 +99547,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.124.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-124-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99567,7 +99567,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.125.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-125-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99587,7 +99587,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.126.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-126-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99607,7 +99607,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.127.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-127-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99627,7 +99627,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.128.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-128-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99647,7 +99647,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.130.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-130-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99667,7 +99667,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.131.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-131-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99687,7 +99687,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.154.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-154-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99707,7 +99707,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.159.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-159-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99727,7 +99727,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.160.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-160-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99747,7 +99747,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.163.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-163-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99767,7 +99767,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.164.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-164-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99787,7 +99787,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.165.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-165-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99807,7 +99807,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.166.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-166-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99827,7 +99827,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.167.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-167-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99847,7 +99847,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.168.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-168-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99867,7 +99867,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.170.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-170-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99887,7 +99887,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.171.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-171-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99907,7 +99907,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.172.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-172-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99927,7 +99927,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.174.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-174-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99947,7 +99947,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.175.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-175-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99967,7 +99967,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.176.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-176-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -99987,7 +99987,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.177.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-177-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100007,7 +100007,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.178.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-178-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100027,7 +100027,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.179.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-179-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100047,7 +100047,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.18.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-18-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100067,7 +100067,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.180.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-180-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100087,7 +100087,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.181.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-181-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100107,7 +100107,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.182.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-182-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100127,7 +100127,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.183.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-183-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100147,7 +100147,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.184.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-184-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100167,7 +100167,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.185.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-185-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100187,7 +100187,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.187.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-187-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100207,7 +100207,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.188.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-188-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100227,7 +100227,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.189.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-189-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100247,7 +100247,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.19.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-19-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100267,7 +100267,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.190.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-190-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100287,7 +100287,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.191.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-191-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100307,7 +100307,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.192.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-192-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100327,7 +100327,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.193.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-193-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100347,7 +100347,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.194.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-194-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100367,7 +100367,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.195.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-195-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100387,7 +100387,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.196.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-196-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100407,7 +100407,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.197.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-197-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100427,7 +100427,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.198.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-198-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100447,7 +100447,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.199.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-199-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100467,7 +100467,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.2.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-2-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100487,7 +100487,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.20.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-20-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100507,7 +100507,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.200.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-200-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100527,7 +100527,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.201.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-201-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100547,7 +100547,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.202.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-202-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100567,7 +100567,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.203.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-203-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100587,7 +100587,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.204.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-204-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100607,7 +100607,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.205.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-205-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100627,7 +100627,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.206.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-206-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100647,7 +100647,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.207.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-207-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100667,7 +100667,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.208.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-208-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100687,7 +100687,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.209.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-209-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100707,7 +100707,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.210.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-210-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100727,7 +100727,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.211.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-211-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100747,7 +100747,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.212.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-212-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100767,7 +100767,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.23.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-23-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100787,7 +100787,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.24.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-24-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100807,7 +100807,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.243.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-243-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100827,7 +100827,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.244.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-244-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100847,7 +100847,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.245.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-245-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100867,7 +100867,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.246.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-246-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100887,7 +100887,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.247.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-247-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100907,7 +100907,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.248.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-248-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100927,7 +100927,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.249.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-249-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100947,7 +100947,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.25.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-25-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100967,7 +100967,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.250.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-250-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -100987,7 +100987,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.251.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-251-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101007,7 +101007,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.252.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-252-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101027,7 +101027,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.253.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-253-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101047,7 +101047,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.255.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-255-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101067,7 +101067,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.256.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-256-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101087,7 +101087,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.257.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-257-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101107,7 +101107,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.259.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-259-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101127,7 +101127,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.260.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-260-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101147,7 +101147,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.261.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-261-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101167,7 +101167,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.262.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-262-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101187,7 +101187,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.263.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-263-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101207,7 +101207,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.264.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-264-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101227,7 +101227,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.265.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-265-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101247,7 +101247,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.266.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-266-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101267,7 +101267,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.268.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-268-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101287,7 +101287,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.269.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-269-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101307,7 +101307,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.27.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-27-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101327,7 +101327,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.270.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-270-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101347,7 +101347,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.271.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-271-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101367,7 +101367,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.272.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-272-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101387,7 +101387,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.274.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-274-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101407,7 +101407,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.275.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-275-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101427,7 +101427,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.276.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-276-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101447,7 +101447,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.277.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-277-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101467,7 +101467,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.28.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-28-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101487,7 +101487,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.280.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-280-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101507,7 +101507,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.282.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-282-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101527,7 +101527,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.283.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-283-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101547,7 +101547,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.284.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-284-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101567,7 +101567,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.288.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-288-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101587,7 +101587,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.29.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-29-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101607,7 +101607,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.292.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-292-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101627,7 +101627,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.3.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-3-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101647,7 +101647,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.30.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-30-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101667,7 +101667,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.305.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-305-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101687,7 +101687,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.316.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-316-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101707,7 +101707,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.319.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-319-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101727,7 +101727,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.32.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-32-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101747,7 +101747,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.322.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-322-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101767,7 +101767,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.323.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-323-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101787,7 +101787,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.36.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-36-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101807,7 +101807,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.37.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-37-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101827,7 +101827,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.38.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-38-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101847,7 +101847,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.39.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-39-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101867,7 +101867,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.40.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-40-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101887,7 +101887,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.41.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-41-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101907,7 +101907,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.44.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-44-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101927,7 +101927,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.45.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-45-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101947,7 +101947,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.46.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-46-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101967,7 +101967,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.47.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-47-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -101987,7 +101987,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.48.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-48-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102007,7 +102007,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.49.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-49-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102027,7 +102027,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.5.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-5-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102047,7 +102047,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.50.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-50-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102067,7 +102067,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.51.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-51-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102087,7 +102087,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.52.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-52-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102107,7 +102107,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.53.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-53-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102127,7 +102127,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.54.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-54-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102147,7 +102147,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.57.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-57-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102167,7 +102167,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.6.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-6-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102187,7 +102187,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.61.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-61-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102207,7 +102207,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.62.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-62-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102227,7 +102227,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.90.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-90-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102247,7 +102247,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.91.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-91-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102267,7 +102267,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.92.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-92-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102287,7 +102287,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.93.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-93-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102307,7 +102307,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.94.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-94-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102327,7 +102327,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.95.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-95-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -102347,7 +102347,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.96.prose_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-96-prose-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150555,7 +150555,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.0.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-0-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150574,7 +150574,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.1.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-1-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150593,7 +150593,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.10.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-10-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150612,7 +150612,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.100.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-100-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150631,7 +150631,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.101.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-101-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150650,7 +150650,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.102.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-102-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150669,7 +150669,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.103.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-103-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150688,7 +150688,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.104.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-104-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150707,7 +150707,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.105.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-105-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150726,7 +150726,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.106.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-106-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150745,7 +150745,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.107.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-107-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150764,7 +150764,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.108.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-108-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150783,7 +150783,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.109.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-109-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150802,7 +150802,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.11.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-11-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150821,7 +150821,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.110.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-110-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150840,7 +150840,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.111.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-111-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150859,7 +150859,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.112.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-112-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150878,7 +150878,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.113.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-113-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150897,7 +150897,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.114.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-114-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150916,7 +150916,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.115.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-115-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150935,7 +150935,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.116.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-116-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150954,7 +150954,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.117.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-117-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150973,7 +150973,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.118.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-118-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -150992,7 +150992,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.119.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-119-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151011,7 +151011,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.12.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-12-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151030,7 +151030,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.120.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-120-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151049,7 +151049,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.121.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-121-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151068,7 +151068,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.122.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-122-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151087,7 +151087,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.123.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-123-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151106,7 +151106,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.124.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-124-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151125,7 +151125,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.125.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-125-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151144,7 +151144,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.126.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-126-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151163,7 +151163,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.127.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-127-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151182,7 +151182,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.128.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-128-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151201,7 +151201,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.129.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-129-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151220,7 +151220,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.13.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-13-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151239,7 +151239,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.130.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-130-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151258,7 +151258,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.131.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-131-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151277,7 +151277,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.132.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-132-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151296,7 +151296,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.133.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-133-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151315,7 +151315,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.134.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-134-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151334,7 +151334,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.135.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-135-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151353,7 +151353,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.136.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-136-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151372,7 +151372,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.137.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-137-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151391,7 +151391,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.138.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-138-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151410,7 +151410,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.139.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-139-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151429,7 +151429,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.14.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-14-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151448,7 +151448,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.140.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-140-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151467,7 +151467,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.141.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-141-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151486,7 +151486,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.142.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-142-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151505,7 +151505,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.143.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-143-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151524,7 +151524,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.144.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-144-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151543,7 +151543,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.145.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-145-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151562,7 +151562,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.146.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-146-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151581,7 +151581,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.147.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-147-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151600,7 +151600,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.148.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-148-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151619,7 +151619,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.149.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-149-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151638,7 +151638,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.15.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-15-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151657,7 +151657,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.150.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-150-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151676,7 +151676,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.151.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-151-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151695,7 +151695,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.152.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-152-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151714,7 +151714,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.153.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-153-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151733,7 +151733,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.154.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-154-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151752,7 +151752,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.155.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-155-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151771,7 +151771,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.156.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-156-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151790,7 +151790,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.157.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-157-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151809,7 +151809,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.158.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-158-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151828,7 +151828,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.159.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-159-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151847,7 +151847,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.16.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-16-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151866,7 +151866,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.160.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-160-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151885,7 +151885,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.161.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-161-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151904,7 +151904,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.162.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-162-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151923,7 +151923,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.163.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-163-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151942,7 +151942,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.164.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-164-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151961,7 +151961,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.165.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-165-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151980,7 +151980,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.166.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-166-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -151999,7 +151999,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.167.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-167-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152018,7 +152018,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.168.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-168-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152037,7 +152037,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.169.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-169-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152056,7 +152056,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.17.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-17-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152075,7 +152075,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.170.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-170-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152094,7 +152094,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.171.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-171-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152113,7 +152113,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.172.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-172-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152132,7 +152132,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.173.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-173-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152151,7 +152151,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.174.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-174-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152170,7 +152170,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.175.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-175-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152189,7 +152189,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.176.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-176-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152208,7 +152208,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.177.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-177-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152227,7 +152227,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.178.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-178-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152246,7 +152246,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.179.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-179-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152265,7 +152265,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.18.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-18-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152284,7 +152284,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.180.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-180-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152303,7 +152303,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.181.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-181-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152322,7 +152322,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.182.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-182-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152341,7 +152341,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.183.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-183-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152360,7 +152360,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.184.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-184-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152379,7 +152379,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.185.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-185-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152398,7 +152398,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.186.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-186-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152417,7 +152417,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.187.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-187-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152436,7 +152436,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.188.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-188-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152455,7 +152455,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.189.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-189-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152474,7 +152474,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.19.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-19-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152493,7 +152493,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.190.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-190-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152512,7 +152512,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.191.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-191-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152531,7 +152531,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.192.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-192-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152550,7 +152550,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.193.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-193-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152569,7 +152569,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.194.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-194-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152588,7 +152588,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.195.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-195-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152607,7 +152607,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.196.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-196-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152626,7 +152626,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.197.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-197-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152645,7 +152645,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.198.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-198-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152664,7 +152664,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.199.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-199-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152683,7 +152683,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.2.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-2-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152702,7 +152702,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.20.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-20-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152721,7 +152721,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.200.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-200-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152740,7 +152740,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.201.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-201-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152759,7 +152759,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.202.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-202-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152778,7 +152778,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.203.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-203-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152797,7 +152797,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.204.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-204-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152816,7 +152816,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.205.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-205-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152835,7 +152835,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.206.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-206-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152854,7 +152854,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.207.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-207-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152873,7 +152873,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.208.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-208-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152892,7 +152892,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.209.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-209-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152911,7 +152911,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.21.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-21-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152930,7 +152930,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.210.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-210-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152949,7 +152949,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.211.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-211-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152968,7 +152968,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.212.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-212-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -152987,7 +152987,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.213.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-213-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153006,7 +153006,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.214.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-214-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153025,7 +153025,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.215.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-215-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153044,7 +153044,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.216.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-216-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153063,7 +153063,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.217.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-217-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153082,7 +153082,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.218.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-218-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153101,7 +153101,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.219.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-219-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153120,7 +153120,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.22.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-22-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153139,7 +153139,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.220.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-220-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153158,7 +153158,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.221.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-221-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153177,7 +153177,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.222.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-222-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153196,7 +153196,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.223.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-223-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153215,7 +153215,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.224.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-224-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153234,7 +153234,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.225.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-225-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153253,7 +153253,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.226.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-226-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153272,7 +153272,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.227.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-227-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153291,7 +153291,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.228.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-228-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153310,7 +153310,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.229.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-229-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153329,7 +153329,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.23.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-23-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153348,7 +153348,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.230.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-230-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153367,7 +153367,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.231.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-231-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153386,7 +153386,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.232.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-232-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153405,7 +153405,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.233.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-233-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153424,7 +153424,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.234.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-234-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153443,7 +153443,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.235.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-235-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153462,7 +153462,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.236.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-236-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153481,7 +153481,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.237.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-237-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153500,7 +153500,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.238.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-238-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153519,7 +153519,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.239.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-239-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153538,7 +153538,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.24.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-24-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153557,7 +153557,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.240.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-240-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153576,7 +153576,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.241.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-241-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153595,7 +153595,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.242.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-242-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153614,7 +153614,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.243.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-243-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153633,7 +153633,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.244.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-244-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153652,7 +153652,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.245.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-245-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153671,7 +153671,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.246.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-246-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153690,7 +153690,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.247.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-247-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153709,7 +153709,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.248.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-248-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153728,7 +153728,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.249.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-249-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153747,7 +153747,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.25.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-25-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153766,7 +153766,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.250.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-250-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153785,7 +153785,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.251.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-251-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153804,7 +153804,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.252.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-252-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153823,7 +153823,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.253.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-253-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153842,7 +153842,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.254.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-254-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153861,7 +153861,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.255.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-255-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153880,7 +153880,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.256.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-256-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153899,7 +153899,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.257.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-257-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153918,7 +153918,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.258.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-258-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153937,7 +153937,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.259.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-259-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153956,7 +153956,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.26.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-26-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153975,7 +153975,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.260.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-260-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -153994,7 +153994,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.261.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-261-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154013,7 +154013,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.262.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-262-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154032,7 +154032,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.263.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-263-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154051,7 +154051,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.264.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-264-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154070,7 +154070,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.265.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-265-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154089,7 +154089,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.266.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-266-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154108,7 +154108,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.267.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-267-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154127,7 +154127,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.268.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-268-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154146,7 +154146,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.269.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-269-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154165,7 +154165,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.27.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-27-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154184,7 +154184,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.270.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-270-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154203,7 +154203,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.271.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-271-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154222,7 +154222,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.272.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-272-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154241,7 +154241,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.273.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-273-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154260,7 +154260,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.274.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-274-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154279,7 +154279,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.275.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-275-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154298,7 +154298,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.276.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-276-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154317,7 +154317,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.277.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-277-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154336,7 +154336,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.278.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-278-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154355,7 +154355,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.279.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-279-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154374,7 +154374,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.28.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-28-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154393,7 +154393,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.280.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-280-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154412,7 +154412,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.281.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-281-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154431,7 +154431,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.282.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-282-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154450,7 +154450,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.283.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-283-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154469,7 +154469,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.284.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-284-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154488,7 +154488,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.285.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-285-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154507,7 +154507,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.286.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-286-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154526,7 +154526,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.287.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-287-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154545,7 +154545,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.288.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-288-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154564,7 +154564,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.289.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-289-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154583,7 +154583,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.29.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-29-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154602,7 +154602,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.290.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-290-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154621,7 +154621,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.291.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-291-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154640,7 +154640,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.292.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-292-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154659,7 +154659,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.293.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-293-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154678,7 +154678,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.294.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-294-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154697,7 +154697,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.295.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-295-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154716,7 +154716,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.296.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-296-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154735,7 +154735,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.297.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-297-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154754,7 +154754,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.298.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-298-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154773,7 +154773,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.299.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-299-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154792,7 +154792,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.3.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-3-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154811,7 +154811,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.30.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-30-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154830,7 +154830,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.300.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-300-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154849,7 +154849,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.301.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-301-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154868,7 +154868,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.302.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-302-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154887,7 +154887,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.303.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-303-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154906,7 +154906,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.304.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-304-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154925,7 +154925,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.305.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-305-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154944,7 +154944,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.306.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-306-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154963,7 +154963,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.307.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-307-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -154982,7 +154982,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.308.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-308-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155001,7 +155001,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.309.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-309-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155020,7 +155020,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.31.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-31-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155039,7 +155039,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.310.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-310-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155058,7 +155058,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.311.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-311-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155077,7 +155077,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.312.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-312-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155096,7 +155096,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.313.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-313-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155115,7 +155115,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.314.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-314-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155134,7 +155134,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.315.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-315-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155153,7 +155153,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.316.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-316-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155172,7 +155172,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.317.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-317-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155191,7 +155191,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.318.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-318-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155210,7 +155210,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.319.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-319-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155229,7 +155229,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.32.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-32-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155248,7 +155248,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.320.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-320-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155267,7 +155267,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.321.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-321-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155286,7 +155286,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.322.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-322-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155305,7 +155305,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.323.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-323-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155324,7 +155324,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.33.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-33-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155343,7 +155343,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.34.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-34-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155362,7 +155362,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.35.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-35-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155381,7 +155381,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.36.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-36-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155400,7 +155400,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.37.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-37-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155419,7 +155419,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.38.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-38-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155438,7 +155438,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.39.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-39-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155457,7 +155457,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.4.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-4-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155476,7 +155476,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.40.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-40-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155495,7 +155495,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.41.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-41-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155514,7 +155514,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.42.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-42-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155533,7 +155533,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.43.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-43-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155552,7 +155552,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.44.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-44-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155571,7 +155571,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.45.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-45-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155590,7 +155590,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.46.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-46-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155609,7 +155609,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.47.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-47-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155628,7 +155628,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.48.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-48-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155647,7 +155647,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.49.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-49-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155666,7 +155666,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.5.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-5-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155685,7 +155685,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.50.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-50-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155704,7 +155704,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.51.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-51-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155723,7 +155723,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.52.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-52-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155742,7 +155742,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.53.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-53-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155761,7 +155761,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.54.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-54-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155780,7 +155780,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.55.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-55-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155799,7 +155799,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.56.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-56-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155818,7 +155818,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.57.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-57-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155837,7 +155837,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.58.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-58-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155856,7 +155856,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.59.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-59-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155875,7 +155875,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.6.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-6-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155894,7 +155894,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.60.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-60-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155913,7 +155913,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.61.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-61-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155932,7 +155932,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.62.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-62-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155951,7 +155951,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.63.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-63-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155970,7 +155970,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.64.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-64-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -155989,7 +155989,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.65.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-65-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156008,7 +156008,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.66.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-66-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156027,7 +156027,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.67.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-67-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156046,7 +156046,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.68.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-68-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156065,7 +156065,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.69.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-69-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156084,7 +156084,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.7.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-7-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156103,7 +156103,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.70.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-70-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156122,7 +156122,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.71.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-71-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156141,7 +156141,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.72.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-72-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156160,7 +156160,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.73.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-73-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156179,7 +156179,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.74.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-74-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156198,7 +156198,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.75.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-75-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156217,7 +156217,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.76.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-76-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156236,7 +156236,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.77.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-77-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156255,7 +156255,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.78.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-78-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156274,7 +156274,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.79.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-79-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156293,7 +156293,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.8.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-8-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156312,7 +156312,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.80.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-80-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156331,7 +156331,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.81.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-81-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156350,7 +156350,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.82.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-82-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156369,7 +156369,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.83.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-83-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156388,7 +156388,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.84.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-84-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156407,7 +156407,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.85.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-85-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156426,7 +156426,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.86.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-86-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156445,7 +156445,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.87.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-87-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156464,7 +156464,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.88.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-88-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156483,7 +156483,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.89.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-89-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156502,7 +156502,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.9.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-9-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156521,7 +156521,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.90.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-90-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156540,7 +156540,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.91.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-91-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156559,7 +156559,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.92.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-92-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156578,7 +156578,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.93.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-93-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156597,7 +156597,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.94.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-94-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156616,7 +156616,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.95.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-95-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156635,7 +156635,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.96.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-96-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156654,7 +156654,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.97.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-97-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156673,7 +156673,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.98.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-98-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -156692,7 +156692,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.99.source_refs.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: spells-99-source-refs-0 from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -173323,7 +173323,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: data/catalogs/spells.yaml
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: data/catalogs/spells.yaml from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183338,7 +183338,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.285
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Affaiblissement from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183357,7 +183357,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.286
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Affaiblissement de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183376,7 +183376,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.33
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Agrandissement from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183395,7 +183395,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.159
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Animation des armures from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183414,7 +183414,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.0
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Annihilation from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183433,7 +183433,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.287
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Antipathisme from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183452,7 +183452,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.288
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Apathie from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183471,7 +183471,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.130
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Appel de la foudre from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183490,7 +183490,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.131
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Appel de la pluie from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183509,7 +183509,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.243
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Appel des chats from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183528,7 +183528,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.244
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Appel des chevaux from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183547,7 +183547,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.245
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Appel des colombes from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183566,7 +183566,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.246
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Appel des corbeaux from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183585,7 +183585,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.247
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Appel des insectes from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183604,7 +183604,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.248
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Appel des loups from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183623,7 +183623,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.249
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Appel des mammifères from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183642,7 +183642,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.264
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Appel des morts from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183661,7 +183661,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.265
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Appel des morts de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183680,7 +183680,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.266
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Appel des morts majeur from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183699,7 +183699,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.160
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Arc-en-ciel from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183718,7 +183718,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.267
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Armure d’os from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183737,7 +183737,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.289
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Arrêt du temps from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183756,7 +183756,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.1
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Augmentation énergétique from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183775,7 +183775,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.181
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Auto clonage from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183794,7 +183794,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.290
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Autodestruction from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183813,7 +183813,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.62
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Barrière de Höln from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183832,7 +183832,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.2
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Barrière psychique from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183851,7 +183851,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.3
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Barrière psychique de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183870,7 +183870,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.63
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Bénédiction from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183889,7 +183889,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.64
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Bénédiction de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183908,7 +183908,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.291
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Bêtise from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183927,7 +183927,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.4
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Boomerang from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183946,7 +183946,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.65
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Bouclier from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183965,7 +183965,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.66
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Bouclier anti-feu from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -183984,7 +183984,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.67
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Bouclier anti-foudre from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184003,7 +184003,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.68
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Bouclier anti-froid from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184022,7 +184022,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.69
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Bouclier anti-lave from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184041,7 +184041,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.70
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Bouclier anti-mal from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184060,7 +184060,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.133
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Bouclier d’eau from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184079,7 +184079,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.132
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Bouclier de foudre from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184098,7 +184098,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.134
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Boule de feu from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184117,7 +184117,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.135
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Boule de feu majeure from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184136,7 +184136,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.136
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Boule de foudre from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184155,7 +184155,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.137
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Boule de foudre majeure from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184174,7 +184174,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.34
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Branchie from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184193,7 +184193,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.35
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Branchie de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184212,7 +184212,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.138
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Brasier from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184231,7 +184231,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.268
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Cage d'os from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184250,7 +184250,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.5
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Captage d'énergie from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184269,7 +184269,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.161
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Cauchemard from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184288,7 +184288,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.162
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Cauchemard de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184307,7 +184307,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.182
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Centaure illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184326,7 +184326,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.139
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Cercle de feu from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184345,7 +184345,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.250
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Cercle de fleur from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184364,7 +184364,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.140
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Chaîne d’éclairs from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184383,7 +184383,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.141
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Champs de boue from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184402,7 +184402,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.36
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Changement de sexe from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184421,7 +184421,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.37
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Changement en corbeau from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184440,7 +184440,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.38
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Changement en crapaud from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184459,7 +184459,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.39
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Changement en furet from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184478,7 +184478,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.40
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Changement en humain from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184497,7 +184497,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.41
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Changement en lapin from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184516,7 +184516,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.269
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Changement spectral from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184535,7 +184535,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.42
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Changer l’eau en vin from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184554,7 +184554,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.71
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Charisme from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184573,7 +184573,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.72
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Charisme de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184592,7 +184592,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.183
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Chat illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184611,7 +184611,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.43
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Châtiment de la matière from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184630,7 +184630,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.184
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Cheval illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184649,7 +184649,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.185
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Chigr Illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184668,7 +184668,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.186
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Clonage from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184687,7 +184687,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.163
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Cocon thermique from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184706,7 +184706,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.142
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Colère divine from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184725,7 +184725,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.6
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Complexité magique from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184744,7 +184744,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.108
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Connaître le vice from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184763,7 +184763,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.109
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contact from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184782,7 +184782,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.110
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contact de Morphée from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184801,7 +184801,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.111
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contact divin from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184820,7 +184820,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.112
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contacter l’au-delà from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184839,7 +184839,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.292
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contagion du péché from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184858,7 +184858,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.7
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contre-blanc from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184877,7 +184877,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.8
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contre-bleu from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184896,7 +184896,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.9
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contre-brun from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184915,7 +184915,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.10
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contre-gris from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184934,7 +184934,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.11
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contre-jaune from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184953,7 +184953,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.12
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contre-noir from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184972,7 +184972,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.13
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contre-orange from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -184991,7 +184991,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.14
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contre-rouge from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185010,7 +185010,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.15
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contre-turquoise from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185029,7 +185029,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.16
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contre-vert from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185048,7 +185048,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.17
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contre-violet from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185067,7 +185067,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.293
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Control charnel from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185086,7 +185086,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.294
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Contrôle mental from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185105,7 +185105,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.164
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Corde from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185124,7 +185124,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.44
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Corrosion from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185143,7 +185143,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.45
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Corrosion de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185162,7 +185162,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.270
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Corruption de l'air from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185181,7 +185181,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.271
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Corruption de l'eau from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185200,7 +185200,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.272
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Corruption végétale from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185219,7 +185219,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.73
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Courage from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185238,7 +185238,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.187
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Couteau illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185257,7 +185257,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.273
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Crâne hurlant from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185276,7 +185276,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.46
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Création d'aile from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185295,7 +185295,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.47
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Création d'oeil from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185314,7 +185314,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.48
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Création de bras from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185333,7 +185333,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.49
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Création de dent from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185352,7 +185352,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.50
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Création de jambe from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185371,7 +185371,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.51
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Création de kyste from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185390,7 +185390,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.52
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Création de main from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185409,7 +185409,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.53
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Création de pied from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185428,7 +185428,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.54
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Création de queue from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185447,7 +185447,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.251
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Croissance from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185466,7 +185466,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.274
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Décret de non repos from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185485,7 +185485,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.188
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Demi-elfe illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185504,7 +185504,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.18
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Déplacement magique from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185523,7 +185523,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.19
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Déplacement magique de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185542,7 +185542,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.113
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Détection du danger from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185561,7 +185561,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.20
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Détournement du lien du mort-vivant from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185580,7 +185580,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.74
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Déviation from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185599,7 +185599,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.75
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Déviation de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185618,7 +185618,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.76
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Déviation des projectiles from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185637,7 +185637,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.77
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Déviation majeure from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185656,7 +185656,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.78
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Déviation mineure from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185675,7 +185675,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.79
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Dextérité from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185694,7 +185694,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.80
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Dextérité de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185713,7 +185713,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.21
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Dispersion du familier from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185732,7 +185732,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.22
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Dissipation from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185751,7 +185751,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.81
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Don d’énergie from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185770,7 +185770,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.295
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Douleur from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185789,7 +185789,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.296
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Douleur à distance from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185808,7 +185808,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.297
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Douleur de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185827,7 +185827,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.298
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Douleur majeure from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185846,7 +185846,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.299
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Douleur mineure from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185865,7 +185865,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.300
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Drain de jeunesse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185884,7 +185884,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.301
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Drain de sort from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185903,7 +185903,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.302
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Drain de sort majeur from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185922,7 +185922,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.303
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Drain de sort mineur from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185941,7 +185941,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.304
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Drain de vie from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185960,7 +185960,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.189
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Dryade illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185979,7 +185979,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.252
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Eclosion from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -185998,7 +185998,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.253
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Effacement des traces from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186017,7 +186017,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.254
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Effacement des traces de masses from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186036,7 +186036,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.190
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Elfe illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186055,7 +186055,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.82
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Empathie from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186074,7 +186074,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.83
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Empathie de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186093,7 +186093,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.305
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Emprise corporelle from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186112,7 +186112,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.165
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Enchantement de livre from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186131,7 +186131,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.84
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Endurance from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186150,7 +186150,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.85
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Endurance de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186169,7 +186169,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.86
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Esthétique from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186188,7 +186188,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.87
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Esthétique de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186207,7 +186207,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.55
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Evaporation from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186226,7 +186226,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.166
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Extase from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186245,7 +186245,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.306
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Faiblesse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186264,7 +186264,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.191
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Fantôme illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186283,7 +186283,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.255
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Fertilité from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186302,7 +186302,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.143
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Flash from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186321,7 +186321,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.144
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Flèche de feu from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186340,7 +186340,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.145
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Flèche de foudre from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186359,7 +186359,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.307
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Folie from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186378,7 +186378,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.88
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Force from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186397,7 +186397,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.89
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Force de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186416,7 +186416,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.192
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Fortune illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186435,7 +186435,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.146
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Foudroiement from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186454,7 +186454,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.56
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Gel from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186473,7 +186473,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.193
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Gnome illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186492,7 +186492,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.194
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Gobelin illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186511,7 +186511,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.90
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Guérison absolue from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186530,7 +186530,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.91
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Guérison de la chair from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186549,7 +186549,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.92
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Guérison de la peau from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186568,7 +186568,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.93
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Guérison des muscles from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186587,7 +186587,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.94
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Guérison des muscles mineure from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186606,7 +186606,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.95
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Guérison des organes from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186625,7 +186625,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.96
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Guérison des os from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186644,7 +186644,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.308
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Hibernation from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186663,7 +186663,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.195
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Hobbit illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186682,7 +186682,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.196
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Homme lézard illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186701,7 +186701,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.197
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Homme oiseau illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186720,7 +186720,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.198
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Homme rat illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186739,7 +186739,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.309
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Horreur from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186758,7 +186758,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.199
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Humain illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186777,7 +186777,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.114
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Identification from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186796,7 +186796,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.147
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Immolation from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186815,7 +186815,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.310
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Implosion from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186834,7 +186834,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.256
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Instinct de reproduction from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186853,7 +186853,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.257
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Instinct de survie from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186872,7 +186872,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.97
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Intelligence from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186891,7 +186891,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.98
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Intelligence de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186910,7 +186910,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.23
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Interdiction magique from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186929,7 +186929,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.167
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invisibilité from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186948,7 +186948,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.238
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation d’abeilles from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186967,7 +186967,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.213
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation d'elfe from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -186986,7 +186986,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.214
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation d'homme lézard from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187005,7 +187005,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.215
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation d'homme oiseau from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187024,7 +187024,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.216
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation d'homme rat from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187043,7 +187043,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.217
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation d'humain from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187062,7 +187062,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.239
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation d’ogres from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187081,7 +187081,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.218
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation d'ondine from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187100,7 +187100,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.240
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation d’orc from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187119,7 +187119,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.219
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de centaure from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187138,7 +187138,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.220
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de chat from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187157,7 +187157,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.221
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de cheval from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187176,7 +187176,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.222
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de chigr from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187195,7 +187195,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.223
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de demi elfe from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187214,7 +187214,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.224
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de dryade from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187233,7 +187233,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.225
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de gnome from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187252,7 +187252,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.226
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de gobelin from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187271,7 +187271,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.227
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de guêpe from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187290,7 +187290,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.228
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de hobbit from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187309,7 +187309,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.229
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de khochigr from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187328,7 +187328,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.230
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de khogr from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187347,7 +187347,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.231
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de loup from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187366,7 +187366,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.232
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de loup-garou from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187385,7 +187385,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.233
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de nain from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187404,7 +187404,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.234
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de squelette from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187423,7 +187423,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.235
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de termite from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187442,7 +187442,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.236
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de troll from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187461,7 +187461,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.237
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Invocation de vampire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187480,7 +187480,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.24
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Irréductibilité from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187499,7 +187499,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.25
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Irréductibilité de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187518,7 +187518,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.200
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Khochigr illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187537,7 +187537,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.201
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Khogr illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187556,7 +187556,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.311
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Lâcheté from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187575,7 +187575,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.312
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Laideur from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187594,7 +187594,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.168
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Légèreté from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187613,7 +187613,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.313
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Lenteur from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187632,7 +187632,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.314
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Lenteur de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187651,7 +187651,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.241
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Lien d'invocation from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187670,7 +187670,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.115
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Localisation from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187689,7 +187689,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.203
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Loup-garou illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187708,7 +187708,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.202
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Loup illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187727,7 +187727,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.169
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Lourdeur from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187746,7 +187746,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.99
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Lumière from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187765,7 +187765,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.315
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Malédiction from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187784,7 +187784,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.170
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Marche sur l'eau from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187803,7 +187803,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.258
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Marécage from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187822,7 +187822,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.57
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Membre téléscopique from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187841,7 +187841,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.58
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Miniaturisation from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187860,7 +187860,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.275
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Mort temporaire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187879,7 +187879,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.148
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Multi-flamme from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187898,7 +187898,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.171
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Multilinguisme from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187917,7 +187917,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.149
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Mur de flammes from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187936,7 +187936,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.204
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Mur illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187955,7 +187955,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.259
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Mûrissement from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187974,7 +187974,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.205
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Nain illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -187993,7 +187993,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.172
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Nettoyage magique from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188012,7 +188012,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.116
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Nouvelle du monde from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188031,7 +188031,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.117
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Nouvelle nationale from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188050,7 +188050,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.118
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Nouvelle régionale from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188069,7 +188069,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.260
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Obstacles végétaux from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188088,7 +188088,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.206
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Ogre illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188107,7 +188107,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.207
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Ondine illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188126,7 +188126,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.208
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Orc illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188145,7 +188145,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.316
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Oubli from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188164,7 +188164,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.317
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Paralysie from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188183,7 +188183,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.173
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Parler aux oiseaux from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188202,7 +188202,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.174
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Passe-partout from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188221,7 +188221,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.318
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Pénombre from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188240,7 +188240,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.26
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Perturbation from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188259,7 +188259,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.59
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Pétrification from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188278,7 +188278,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.319
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Peur from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188297,7 +188297,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.276
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Piège d'os from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188316,7 +188316,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.27
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Piégeage magique from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188335,7 +188335,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.150
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Pilier de feu from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188354,7 +188354,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.320
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Pluie de sang from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188373,7 +188373,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.175
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Porte de secours from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188392,7 +188392,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.119
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Prémonition from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188411,7 +188411,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.100
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Purification de l'air from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188430,7 +188430,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.101
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Purification de l'eau from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188449,7 +188449,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.277
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Putréfaction from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188468,7 +188468,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.151
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Pyramide de feu from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188487,7 +188487,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.278
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Raideur cadavérique from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188506,7 +188506,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.28
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Ralentissement magique from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188525,7 +188525,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.102
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Rapidité from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188544,7 +188544,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.103
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Rapidité de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188563,7 +188563,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.152
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Rayon d’eau from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188582,7 +188582,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.153
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Raz de marée from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188601,7 +188601,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.279
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Réanimation des membres from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188620,7 +188620,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.120
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Regard de puissance from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188639,7 +188639,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.60
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Rendre forme from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188658,7 +188658,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.280
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Renvoi from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188677,7 +188677,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.104
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Renvoi du démon from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188696,7 +188696,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.281
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Renvoie de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188715,7 +188715,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.105
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Respiration from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188734,7 +188734,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.106
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Respiration de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188753,7 +188753,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.321
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Resserrement des murs from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188772,7 +188772,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.107
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Résurrection from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188791,7 +188791,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.29
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Rets des âmes from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188810,7 +188810,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.30
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Rets des cadavres from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188829,7 +188829,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.261
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Réveil de la bête from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188848,7 +188848,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.242
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Révocation from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188867,7 +188867,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.176
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Rire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188886,7 +188886,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.177
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Rire de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188905,7 +188905,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.31
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Rupture de lien d'invocation from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188924,7 +188924,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.154
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Sables mouvants from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188943,7 +188943,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.121
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Savoir l'aptitude from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188962,7 +188962,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.122
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Savoir l'énergie from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -188981,7 +188981,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.123
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Savoir la vitalité from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189000,7 +189000,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.124
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Savoir la vitesse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189019,7 +189019,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.125
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Savoir la volonté from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189038,7 +189038,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.126
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Savoir le nom from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189057,7 +189057,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.127
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Savoir les compétences from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189076,7 +189076,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.262
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Sol fertile from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189095,7 +189095,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.178
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Sommeil from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189114,7 +189114,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.61
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Soudure from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189133,7 +189133,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.209
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Squelette illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189152,7 +189152,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.32
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Substitution de sort from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189171,7 +189171,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.282
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Terre stérile from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189190,7 +189190,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.155
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Tornade from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189209,7 +189209,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.156
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Tornade de feu from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189228,7 +189228,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.263
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Torsion du bois from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189247,7 +189247,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.157
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Touché ardant from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189266,7 +189266,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.283
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Touché mortel from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189285,7 +189285,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.210
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Troll illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189304,7 +189304,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.158
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Vague de feu from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189323,7 +189323,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.211
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Vampire illusoire from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189342,7 +189342,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.322
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Vengeance from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189361,7 +189361,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.323
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Vengeance en masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189380,7 +189380,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.212
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Vide sidéral from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189399,7 +189399,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.284
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Vieillissement from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189418,7 +189418,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.128
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Vision ante mortem from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189437,7 +189437,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.129
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Vision de rêve from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189456,7 +189456,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.179
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Vol de masse from data/catalogs/spells.yaml.
     status: partial
     gaps:
@@ -189475,7 +189475,7 @@ units:
     source_refs:
       - source_id: DATA-CATALOGS-SPELLS
         locator: spells.180
-        hash: sha256:4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+        hash: sha256:2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     business_rule: Vol magique from data/catalogs/spells.yaml.
     status: partial
     gaps:

--- a/docs/canonical/nomos/source-manifest.yaml
+++ b/docs/canonical/nomos/source-manifest.yaml
@@ -12756,7 +12756,7 @@ sources:
     domain: catalogs
     priority: secondary
     status: active
-    hash: 4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486
+    hash: 2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37
     owner: decarvalhoe
     license: proprietary
     confidentiality: internal

--- a/docs/canonical/source-manifest.yaml
+++ b/docs/canonical/source-manifest.yaml
@@ -8122,7 +8122,7 @@ sources:
     notes: "Product YAML catalog."
   - id: "data-catalogs-spells"
     path: "data/catalogs/spells.yaml"
-    sha256: "4addad5345d4d3867416d6dcdb5a0648a97a9b728c5368fa5d2f0b89ec65d486"
+    sha256: "2ce0920c9985c592e4cd6f558fbc76468471339a7a6ad4e0d36897abb6939c37"
     source_type: catalog_yaml
     priority: 90
     status: active


### PR DESCRIPTION
## Résumé

**E2k** — structure l'école **nécromancie** (12 sorts). **157 effect_model** (42 `covered`, 115
`pending`) sur 8 écoles.

- **summon** (morts/membres relevés) : `appel-des-morts`, `-majeur`, `-de-masse`
  (`level + (successes - 1)`), `reanimation-des-membres` ; `until_dispel`.
- **status** : `changement-spectral` (spectral), `raideur-cadaverique` (paralyzed, 50 DT/R),
  `piege-d-os` (immobilized).
- **damage** : `corruption-vegetale`/`-air`/`-eau` (`2 * successes`), `crane-hurlant`
  (`2 * successes` feu, + peur notée), `putrefaction` (DoT : `successes`/jour pendant `level` jours).

Jets de résistance (endurance) + contraintes (catégorie max, portée, aire) en prose ; enforcement
différé. Non inclus : bannissements (`renvoi*`), mort/résurrection, objets, narratif. Tout `pending`.

## Test plan

- [x] `catalogs:link:spell-effects` — 157 attachés, validés via `parseEffectModel`
- [x] `canonical:check` vert (additif, 0 churn `imported_at`)
- [x] prettier
- [ ] CI : Validate + 3 gates verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
