### PR TITLE
feat(cms): G1 - gouvernance, expose l effet structure des sorts (file de validation)

### DIFF
--- a/apps/cms/src/collections/catalogCollections.ts
+++ b/apps/cms/src/collections/catalogCollections.ts
@@ -170,6 +170,9 @@ const magicTypes = [
   'legacy_type'
 ] as const;
 
+// EffectModel fidelity (rules-core EFFECT_FIDELITIES) — pilote la file de validation MJ.
+const effectFidelities = ['covered', 'pending', 'ambiguous'] as const;
+
 export const Weapons = catalogCollection({
   defaultColumns: ['canonicalId', 'name', 'category', 'damageFormula', 'difficulty'],
   fields: [
@@ -257,7 +260,14 @@ export const MagicSchools = catalogCollection({
 });
 
 export const Spells = catalogCollection({
-  defaultColumns: ['canonicalId', 'name', 'magicSchoolCanonicalId', 'energyCost', 'difficulty'],
+  defaultColumns: [
+    'canonicalId',
+    'name',
+    'magicSchoolCanonicalId',
+    'difficulty',
+    'effectModelFidelity',
+    'effectModelPendingValidation'
+  ],
   fields: [
     textField('magicSchoolCanonicalId', true),
     relationshipField('magicSchool', 'magic-schools'),
@@ -268,7 +278,17 @@ export const Spells = catalogCollection({
     numberField('difficulty', true),
     numberField('value'),
     checkboxField('directMagic'),
-    textField('legacyTypeId')
+    textField('legacyTypeId'),
+    // E2/gouvernance — effet structuré (EffectModel rules-core) + champs dénormalisés pour la
+    // FILE DE VALIDATION MJ (règles vivantes). `effectModelFidelity`/`effectModelPendingValidation`
+    // sont peuplés depuis `effect_model` à l'import et rendent la file filtrable dans l'admin.
+    jsonField('effectModel'),
+    selectField('effectModelFidelity', effectFidelities, false, {
+      admin: {
+        description: 'covered = validé (canon) ; pending = à valider ; ambiguous = en conflit.'
+      }
+    }),
+    checkboxField('effectModelPendingValidation')
   ],
   labels: { singular: 'Spell', plural: 'Spells' },
   slug: 'spells'

--- a/packages/catalogs/src/payload-types.ts
+++ b/packages/catalogs/src/payload-types.ts
@@ -892,6 +892,20 @@ export interface Spell {
   value?: number | null;
   directMagic?: boolean | null;
   legacyTypeId?: string | null;
+  effectModel?:
+    | {
+        [k: string]: unknown;
+      }
+    | unknown[]
+    | string
+    | number
+    | boolean
+    | null;
+  /**
+   * covered = validé (canon) ; pending = à valider ; ambiguous = en conflit.
+   */
+  effectModelFidelity?: ('covered' | 'pending' | 'ambiguous') | null;
+  effectModelPendingValidation?: boolean | null;
   /**
    * Source files, legacy tables or rules documents used to create this entry.
    */
@@ -2150,6 +2164,9 @@ export interface SpellsSelect<T extends boolean = true> {
   value?: T;
   directMagic?: T;
   legacyTypeId?: T;
+  effectModel?: T;
+  effectModelFidelity?: T;
+  effectModelPendingValidation?: T;
   sourceRefs?:
     | T
     | {

--- a/tools/import-catalogs.ts
+++ b/tools/import-catalogs.ts
@@ -610,6 +610,12 @@ function magicSchoolEntry(
 }
 
 function spellEntry(spell: Spell, catalogMetadata: Record<string, unknown>): ImportEntry {
+  // `effect_model` (overlays `data/spell-effects/*.yaml`, mergé dans spells.yaml) n'est pas dans le
+  // type Zod (passthrough) : on l'extrait pour alimenter l'effet structuré + la file de validation MJ
+  // (champs dénormalisés `effectModelFidelity` / `effectModelPendingValidation`, filtrables dans l'admin).
+  const effectModel = (
+    spell as { effect_model?: { fidelity?: string; spec?: { requires_mj_validation?: boolean } } }
+  ).effect_model;
   return entry(
     'spells',
     spell,
@@ -621,7 +627,10 @@ function spellEntry(spell: Spell, catalogMetadata: Record<string, unknown>): Imp
       legacyTypeId: spell.school_id,
       magicSchoolCanonicalId: spell.school_id,
       magicType: magicTypeValue(spell.school_id),
-      value: spell.value
+      value: spell.value,
+      effectModel: effectModel ?? null,
+      effectModelFidelity: effectModel?.fidelity,
+      effectModelPendingValidation: effectModel?.spec?.requires_mj_validation === true
     },
     catalogMetadata,
     'spells.yaml'


### PR DESCRIPTION
## Résumé

**G1** — première brique de la **surface de gouvernance « règles vivantes »** : rendre les **162
`effect_model` `pending`** visibles et **filtrables** dans l'admin Payload (la file de validation MJ).

- **`Spells` collection** (`catalogCollections.ts`) : `+effectModel` (json — l'`EffectModel` complet),
  `+effectModelFidelity` (select `covered`/`pending`/`ambiguous`), `+effectModelPendingValidation`
  (checkbox). Champs **dénormalisés** depuis `effect_model` pour filtrer la file ; ajoutés aux
  `defaultColumns`.
- **`import-catalogs.ts`** (`spellEntry`) : mappe `spell.effect_model` → `effectModel` + `fidelity` +
  `requires_mj_validation` (extraction typée car `effect_model` est hors du type Zod `passthrough`).
- **`payload-types.ts`** régénéré (les 3 champs `Spell` ; `CatalogAmbiguity`/`CatalogDecision` déjà présents).

> **Correction** : les collections `catalog-ambiguities` / `catalog-decisions` **existent déjà**
> (`governanceCollections.ts`) — `GOVERNANCE-IMPLEMENTATION.md` (qui les disait « stub ») est **périmé**
> → corrigé en G5. La file de validation devient donc : admin Payload → Spells → filtre
> `effectModelPendingValidation = true` (ou `effectModelFidelity = pending`).

## Suite (épic surface complète)
G2 import des ambiguïtés `.md` → `catalog-ambiguities` · G3 hook de régénération sur décision→applied ·
G4 vue file de validation · G5 dé-périmer le registre.

## Test plan
- [x] `cms:generate:types` régénère `payload-types.ts` (3 champs)
- [x] `pnpm typecheck` (turbo) — 7/7
- [x] eslint + prettier
- [x] `cms:import:catalogs:dry-run` — 324 sorts mappés sans erreur
- [ ] CI : Validate + 3 gates verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
