### PR TITLE
feat(rules-core): E3a - runtime temps-double (horloge narrative + sorts actifs)

### DIFF
--- a/packages/rules-core/src/index.ts
+++ b/packages/rules-core/src/index.ts
@@ -10,6 +10,7 @@ export * from './hit-table.js';
 export * from './inventory.js';
 export * from './magic.js';
 export * from './money.js';
+export * from './narrative-time.js';
 export * from './npc-control.js';
 export * from './predilection.js';
 export * from './progression.js';

--- a/packages/rules-core/src/narrative-time.test.ts
+++ b/packages/rules-core/src/narrative-time.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ActiveSpell,
+  DT_SECONDS,
+  NARRATIVE_UNIT_SECONDS,
+  advanceNarrative,
+  dtToNarrativeSeconds,
+  durationToSeconds,
+  endCombat,
+  expireActiveSpells,
+  isActiveSpellExpired,
+  spellExpiresAt
+} from './narrative-time.js';
+
+function spell(overrides: Partial<ActiveSpell> = {}): ActiveSpell {
+  return {
+    id: overrides.id ?? 'spell-1',
+    castAtSeconds: overrides.castAtSeconds ?? 0,
+    durationAmount: overrides.durationAmount ?? 1,
+    durationUnit: overrides.durationUnit ?? 'minute',
+    ...overrides
+  };
+}
+
+describe('constants (R-8.20)', () => {
+  it('uses 0,2 s per DT', () => {
+    expect(DT_SECONDS).toBe(0.2);
+  });
+
+  it('maps narrative units to seconds', () => {
+    expect(NARRATIVE_UNIT_SECONDS).toEqual({ minute: 60, hour: 3_600, day: 86_400 });
+  });
+});
+
+describe('dtToNarrativeSeconds (R-8.20 — 1 DT = 0,2 s)', () => {
+  it('converts combat time to narrative seconds', () => {
+    expect(dtToNarrativeSeconds(0)).toBe(0);
+    expect(dtToNarrativeSeconds(1)).toBeCloseTo(0.2);
+    expect(dtToNarrativeSeconds(50)).toBeCloseTo(10);
+  });
+
+  it('rejects negative or non-finite input', () => {
+    expect(() => dtToNarrativeSeconds(-1)).toThrow(/non-negative finite/);
+    expect(() => dtToNarrativeSeconds(Number.NaN)).toThrow(/non-negative finite/);
+    expect(() => dtToNarrativeSeconds(Number.POSITIVE_INFINITY)).toThrow(/non-negative finite/);
+  });
+});
+
+describe('durationToSeconds', () => {
+  it('returns null for a permanent spell (dispel-only)', () => {
+    expect(durationToSeconds(0, 'permanent')).toBeNull();
+    expect(durationToSeconds(99, 'permanent')).toBeNull();
+  });
+
+  it('scales DT durations by 0,2 s', () => {
+    expect(durationToSeconds(10, 'DT')).toBeCloseTo(2);
+  });
+
+  it('scales narrative durations by their unit', () => {
+    expect(durationToSeconds(2, 'minute')).toBe(120);
+    expect(durationToSeconds(3, 'hour')).toBe(10_800);
+    expect(durationToSeconds(1, 'day')).toBe(86_400);
+  });
+
+  it('rejects negative or non-finite amounts (non-permanent)', () => {
+    expect(() => durationToSeconds(-1, 'minute')).toThrow(/non-negative finite/);
+    expect(() => durationToSeconds(Number.NaN, 'DT')).toThrow(/non-negative finite/);
+  });
+});
+
+describe('spellExpiresAt', () => {
+  it('adds the resolved duration to the cast instant', () => {
+    expect(
+      spellExpiresAt(spell({ castAtSeconds: 100, durationAmount: 2, durationUnit: 'minute' }))
+    ).toBe(220);
+  });
+
+  it('returns null for a permanent spell', () => {
+    expect(spellExpiresAt(spell({ durationUnit: 'permanent' }))).toBeNull();
+  });
+
+  it('places a combat-scale (DT) spell on the same narrative clock', () => {
+    // 10 DT = 2 s, cast at 60 s narrative → expires at 62 s.
+    expect(
+      spellExpiresAt(spell({ castAtSeconds: 60, durationAmount: 10, durationUnit: 'DT' }))
+    ).toBeCloseTo(62);
+  });
+});
+
+describe('isActiveSpellExpired', () => {
+  const s = spell({ castAtSeconds: 0, durationAmount: 1, durationUnit: 'minute' }); // expires at 60
+
+  it('is not expired before the expiry instant', () => {
+    expect(isActiveSpellExpired(s, 59.9)).toBe(false);
+  });
+
+  it('expires exactly at the expiry instant (>=)', () => {
+    expect(isActiveSpellExpired(s, 60)).toBe(true);
+  });
+
+  it('is expired after the expiry instant', () => {
+    expect(isActiveSpellExpired(s, 61)).toBe(true);
+  });
+
+  it('never expires a permanent spell', () => {
+    expect(isActiveSpellExpired(spell({ durationUnit: 'permanent' }), 1_000_000)).toBe(false);
+  });
+});
+
+describe('expireActiveSpells', () => {
+  it('partitions spells into active and expired at the narrative instant', () => {
+    const dtCombat = spell({ id: 'dt', castAtSeconds: 0, durationAmount: 10, durationUnit: 'DT' }); // 2 s
+    const shortBuff = spell({
+      id: 'min',
+      castAtSeconds: 0,
+      durationAmount: 1,
+      durationUnit: 'minute'
+    }); // 60 s
+    const ward = spell({ id: 'perm', durationUnit: 'permanent' });
+
+    // 5 s after start: combat spell gone, the minute buff still up, permanent always up.
+    const { active, expired } = expireActiveSpells([dtCombat, shortBuff, ward], 5);
+
+    expect(expired.map((x) => x.id)).toEqual(['dt']);
+    expect(active.map((x) => x.id)).toEqual(['min', 'perm']);
+  });
+
+  it('preserves input order within each bucket', () => {
+    const a = spell({ id: 'a', castAtSeconds: 0, durationAmount: 1, durationUnit: 'minute' });
+    const b = spell({ id: 'b', castAtSeconds: 0, durationAmount: 2, durationUnit: 'minute' });
+    const c = spell({ id: 'c', castAtSeconds: 0, durationAmount: 3, durationUnit: 'minute' });
+    const { active, expired } = expireActiveSpells([a, b, c], 120); // a & b expired at/after 120
+    expect(expired.map((x) => x.id)).toEqual(['a', 'b']);
+    expect(active.map((x) => x.id)).toEqual(['c']);
+  });
+
+  it('returns empty buckets for an empty input', () => {
+    expect(expireActiveSpells([], 10)).toEqual({ active: [], expired: [] });
+  });
+});
+
+describe('advanceNarrative (MJ « passer la journée / N heures »)', () => {
+  it('advances by a full day', () => {
+    expect(advanceNarrative(0, { days: 1 })).toBe(86_400);
+  });
+
+  it('combines days, hours, minutes and seconds', () => {
+    expect(advanceNarrative(100, { days: 1, hours: 2, minutes: 3, seconds: 4 })).toBe(
+      100 + 86_400 + 7_200 + 180 + 4
+    );
+  });
+
+  it('treats omitted fields as zero', () => {
+    expect(advanceNarrative(50, {})).toBe(50);
+  });
+
+  it('rejects a negative starting instant', () => {
+    expect(() => advanceNarrative(-1, { hours: 1 })).toThrow(/non-negative finite/);
+  });
+
+  it('rejects a negative advance delta', () => {
+    expect(() => advanceNarrative(0, { hours: -1 })).toThrow(/non-negative finite/);
+  });
+
+  it('expires a DT-scale combat buff once the MJ skips a day (combat nests in narrative)', () => {
+    const combatBuff = spell({ castAtSeconds: 0, durationAmount: 10, durationUnit: 'DT' });
+    const later = advanceNarrative(0, { days: 1 });
+    expect(isActiveSpellExpired(combatBuff, later)).toBe(true);
+  });
+});
+
+describe('endCombat (R-8.20 — scene DT folds back into the narrative clock)', () => {
+  it('advances the narrative clock by the cumulated combat time', () => {
+    // 50 DT of combat = 10 s narrative.
+    expect(endCombat(1_000, 50)).toBeCloseTo(1_010);
+  });
+
+  it('is a no-op for a zero-length combat', () => {
+    expect(endCombat(1_000, 0)).toBe(1_000);
+  });
+
+  it('rejects a negative starting instant', () => {
+    expect(() => endCombat(-1, 10)).toThrow(/non-negative finite/);
+  });
+});

--- a/packages/rules-core/src/narrative-time.ts
+++ b/packages/rules-core/src/narrative-time.ts
@@ -1,0 +1,123 @@
+/**
+ * E3 — Runtime « temps double » (R-8.20). Cœur pur rules-core : l'horloge narrative, la conversion
+ * combat↔narratif et le suivi des sorts actifs (expiration double-échelle). La persistance
+ * (`character_active_spells`, DB) et les surfaces MJ (cockpit) sont des couches au-dessus (E3b+).
+ *
+ * **Deux échelles imbriquées** (R-8.20) : le temps de **combat** (1 DT = 0,2 s) s'inscrit dans le
+ * temps **narratif** (heures/jours). Tout est ramené à une **horloge narrative en secondes** : un
+ * sort de durée DT comme un sort de durée min/heure/jour expire sur la même horloge, ce qui gère
+ * automatiquement la conversion « si le combat se termine avant l'expiration ».
+ *
+ * Le multiplicateur de cadence (× temps réel) agit sur le *rythme d'avancée* en appli/UI, **pas** sur
+ * les durées intrinsèques (R-8.20) ; il n'appartient donc pas à ce modèle pur.
+ */
+
+/** 1 DT = 0,2 seconde narrative (R-8.20). */
+export const DT_SECONDS = 0.2;
+
+/** Secondes par unité de durée narrative. */
+export const NARRATIVE_UNIT_SECONDS = {
+  minute: 60,
+  hour: 3_600,
+  day: 86_400
+} as const;
+
+export const SPELL_DURATION_UNITS = ['DT', 'minute', 'hour', 'day', 'permanent'] as const;
+export type SpellDurationUnit = (typeof SPELL_DURATION_UNITS)[number];
+
+/**
+ * Un sort actif sur l'horloge narrative. `durationAmount` est la quantité **résolue** (déjà mise à
+ * l'échelle par les réussites le cas échéant) ; ignorée si `durationUnit === 'permanent'`.
+ */
+export interface ActiveSpell {
+  id: string;
+  spellId?: string;
+  targetId?: string;
+  /** Instant de lancement, en secondes narratives. */
+  castAtSeconds: number;
+  durationAmount: number;
+  durationUnit: SpellDurationUnit;
+}
+
+export interface NarrativeAdvance {
+  days?: number;
+  hours?: number;
+  minutes?: number;
+  seconds?: number;
+}
+
+function assertNonNegativeFinite(label: string, value: number): void {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative finite number`);
+  }
+}
+
+/** Convertit une durée de combat (DT) en secondes narratives (R-8.20 : 1 DT = 0,2 s). */
+export function dtToNarrativeSeconds(dt: number): number {
+  assertNonNegativeFinite('dt', dt);
+  return dt * DT_SECONDS;
+}
+
+/**
+ * Durée intrinsèque d'un sort en secondes narratives. Renvoie `null` pour `permanent` (pas
+ * d'expiration : dissipation uniquement par dispel actif).
+ */
+export function durationToSeconds(amount: number, unit: SpellDurationUnit): number | null {
+  if (unit === 'permanent') {
+    return null;
+  }
+  assertNonNegativeFinite('duration amount', amount);
+  if (unit === 'DT') {
+    return amount * DT_SECONDS;
+  }
+  return amount * NARRATIVE_UNIT_SECONDS[unit];
+}
+
+/** Instant d'expiration (secondes narratives), ou `null` si le sort est permanent. */
+export function spellExpiresAt(spell: ActiveSpell): number | null {
+  const duration = durationToSeconds(spell.durationAmount, spell.durationUnit);
+  return duration === null ? null : spell.castAtSeconds + duration;
+}
+
+/** Vrai si le sort a expiré à l'instant narratif `nowSeconds` (jamais pour un sort permanent). */
+export function isActiveSpellExpired(spell: ActiveSpell, nowSeconds: number): boolean {
+  const expiresAt = spellExpiresAt(spell);
+  return expiresAt !== null && nowSeconds >= expiresAt;
+}
+
+/** Sépare les sorts actifs en `active` / `expired` à l'instant narratif `nowSeconds`. */
+export function expireActiveSpells(
+  spells: readonly ActiveSpell[],
+  nowSeconds: number
+): { active: ActiveSpell[]; expired: ActiveSpell[] } {
+  const active: ActiveSpell[] = [];
+  const expired: ActiveSpell[] = [];
+  for (const spell of spells) {
+    (isActiveSpellExpired(spell, nowSeconds) ? expired : active).push(spell);
+  }
+  return { active, expired };
+}
+
+/**
+ * Avance l'horloge narrative (contrôle MJ « passer la journée / N heures »). Renvoie le nouvel
+ * instant en secondes narratives.
+ */
+export function advanceNarrative(nowSeconds: number, by: NarrativeAdvance): number {
+  assertNonNegativeFinite('nowSeconds', nowSeconds);
+  const delta =
+    (by.days ?? 0) * NARRATIVE_UNIT_SECONDS.day +
+    (by.hours ?? 0) * NARRATIVE_UNIT_SECONDS.hour +
+    (by.minutes ?? 0) * NARRATIVE_UNIT_SECONDS.minute +
+    (by.seconds ?? 0);
+  assertNonNegativeFinite('advance delta', delta);
+  return nowSeconds + delta;
+}
+
+/**
+ * Fin de combat (R-8.20) : l'horloge narrative avance du temps cumulé de la scène de combat
+ * (`elapsedDT` × 0,2 s). Renvoie le nouvel instant narratif.
+ */
+export function endCombat(nowSeconds: number, elapsedDT: number): number {
+  assertNonNegativeFinite('nowSeconds', nowSeconds);
+  return nowSeconds + dtToNarrativeSeconds(elapsedDT);
+}


### PR DESCRIPTION
## E3a — Runtime « temps double » (R-8.20), cœur pur rules-core

Première brique de l'épopée **E3 (#188)** : l'horloge narrative et le suivi des sorts actifs sur **double échelle**, en TypeScript pur (aucune dépendance DB/UI).

### Modèle (R-8.20)

Deux échelles imbriquées ramenées à **une horloge narrative en secondes** :

- Temps de **combat** : `1 DT = 0,2 s`.
- Temps **narratif** : minute / heure / jour.

Un sort de durée `DT` et un sort de durée `minute/heure/jour` expirent sur la **même** horloge — ce qui gère automatiquement « le combat se termine avant l'expiration ».

### API (`packages/rules-core/src/narrative-time.ts`)

- `DT_SECONDS`, `NARRATIVE_UNIT_SECONDS`, `SPELL_DURATION_UNITS`.
- `dtToNarrativeSeconds(dt)` — conversion combat → narratif.
- `durationToSeconds(amount, unit)` — durée intrinsèque (`null` si `permanent`).
- `spellExpiresAt(spell)` / `isActiveSpellExpired(spell, now)` — expiration double-échelle.
- `expireActiveSpells(spells, now)` — partition `{ active, expired }`.
- `advanceNarrative(now, { days, hours, minutes, seconds })` — contrôle MJ « passer la journée / N heures ».
- `endCombat(now, elapsedDT)` — fin de combat : le temps de scène se replie sur l'horloge narrative.

Le multiplicateur de cadence (× temps réel) agit sur le *rythme d'avancée* en appli/UI, pas sur les durées intrinsèques : il n'appartient donc pas à ce modèle pur.

### Hors périmètre (E3b+)

Persistance `character_active_spells` (apps/server) et surfaces MJ (cockpit). L'application des cibles différées (status/protection/summon/spell) reste agrégée côté combat.

### Tests

`narrative-time.test.ts` — 27 cas : conversions, `permanent → null`, frontière d'expiration `>=`, imbrication combat/narratif (un buff DT expire quand le MJ passe la journée), repli de fin de combat, et garde-fous (rejets négatif/non-fini).

### Gates

- ✅ `vitest run packages/rules-core/src` (282 tests)
- ✅ `rules-core typecheck` (tsc -b)
- ✅ eslint + prettier
- Pas de régénération canon : pur rules-core, aucune source canonique touchée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
