### PR TITLE
feat(rules-core): E3b - horloge narrative event-sourced dans la session

### DIFF
--- a/apps/game/src/features/session-manager/model.ts
+++ b/apps/game/src/features/session-manager/model.ts
@@ -79,14 +79,18 @@ export interface SessionManagerView {
 
 const eventLabels: Record<SessionEventType, string> = {
   combat: 'Combat',
+  combat_ended: 'Fin de combat',
   dice_roll: 'Jet de des',
   gm_decision_requested: 'Decision MJ demandee',
   gm_decision_resolved: 'Decision MJ resolue',
   gm_ruling: 'Arbitrage MJ',
   narration: 'Narration',
+  narrative_time_advanced: 'Temps narratif avance',
   player_action: 'Action joueur',
   rollback_requested: 'Rollback demande',
-  scene_opened: 'Scene ouverte'
+  scene_opened: 'Scene ouverte',
+  spell_cast: 'Sort lance',
+  spell_dispelled: 'Sort dissipe'
 };
 
 export function createSessionManagerState(

--- a/apps/server/src/routes/sessions.test.ts
+++ b/apps/server/src/routes/sessions.test.ts
@@ -346,6 +346,58 @@ describe('session routes', () => {
     expect(auditRows.map((row) => row.payload.links)).toEqual([links, links, links, links]);
   });
 
+  it('projects the narrative clock and active spells from the event journal (R-8.20)', async () => {
+    const slug = `clock-session-${randomUUID()}`;
+
+    await app.inject({
+      method: 'POST',
+      payload: { mode: 'digital_human_gm', slug, title: 'Clock API' },
+      url: '/sessions'
+    });
+    // Advance one hour of narrative time, then cast a 10-minute buff.
+    await app.inject({
+      method: 'POST',
+      payload: { actorId: 'gm', eventType: 'narrative_time_advanced', payload: { hours: 1 } },
+      url: `/sessions/${slug}/events`
+    });
+    await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        eventType: 'spell_cast',
+        payload: {
+          activeSpellId: 'spell-aura',
+          durationAmount: 10,
+          durationUnit: 'minute',
+          spellId: 'aura-de-courage',
+          targetId: 'aveline'
+        }
+      },
+      url: `/sessions/${slug}/events`
+    });
+
+    const whileActive = await app.inject({ method: 'GET', url: `/sessions/${slug}` });
+    const activeState = whileActive.json().state;
+
+    expect(activeState.narrativeSeconds).toBe(3_600);
+    expect(activeState.activeSpells).toMatchObject([
+      { id: 'spell-aura', castAtSeconds: 3_600, durationUnit: 'minute' }
+    ]);
+
+    // Skip past the buff's lifetime — it must lapse on the shared narrative clock.
+    await app.inject({
+      method: 'POST',
+      payload: { actorId: 'gm', eventType: 'narrative_time_advanced', payload: { minutes: 10 } },
+      url: `/sessions/${slug}/events`
+    });
+
+    const afterExpiry = await app.inject({ method: 'GET', url: `/sessions/${slug}` });
+    const expiredState = afterExpiry.json().state;
+
+    expect(expiredState.narrativeSeconds).toBe(4_200);
+    expect(expiredState.activeSpells).toEqual([]);
+  });
+
   it('rejects invalid session payloads', async () => {
     const response = await app.inject({
       method: 'POST',

--- a/packages/rules-core/src/session.test.ts
+++ b/packages/rules-core/src/session.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  advanceSessionNarrative,
   appendSessionEvent,
+  castSessionSpell,
   createSessionState,
+  dispelSessionSpell,
+  endSessionCombat,
+  getActiveSpells,
   getPendingDecisions,
   queueGmDecision,
   rebuildSessionStateFromEvents,
@@ -275,5 +280,135 @@ describe('session state reconstruction', () => {
     expect(twice.events).toEqual(once.events);
     // The decision derived from events matches the one the queue helper recorded.
     expect(once.decisions).toEqual(journal.decisions);
+  });
+});
+
+describe('session narrative clock (R-8.20 — temps double)', () => {
+  function newSession() {
+    return createSessionState({
+      id: 'session-brumeval',
+      mode: 'digital_human_gm',
+      slug: 'brumeval',
+      title: 'Brumeval'
+    });
+  }
+
+  it('starts at instant zero with no active spells', () => {
+    const session = newSession();
+
+    expect(session.narrativeSeconds).toBe(0);
+    expect(session.activeSpells).toEqual([]);
+  });
+
+  it('advances the clock when the MJ skips time (« passer la journée »)', () => {
+    const session = newSession();
+    const later = advanceSessionNarrative(
+      session,
+      { actorId: 'gm', by: { days: 1, hours: 2 } },
+      { eventId: 'event-1', now: '2026-04-30T10:00:00.000Z' }
+    );
+
+    expect(later.narrativeSeconds).toBe(86_400 + 7_200);
+    expect(later.events.map((event) => event.type)).toEqual(['narrative_time_advanced']);
+  });
+
+  it('folds the elapsed combat DT back into the narrative clock at end of combat', () => {
+    const session = newSession();
+    // 50 DT of combat = 10 narrative seconds (1 DT = 0,2 s).
+    const after = endSessionCombat(session, { actorId: 'gm', elapsedDT: 50 });
+
+    expect(after.narrativeSeconds).toBeCloseTo(10);
+  });
+
+  it('records a cast spell at the current instant and keeps it active until it expires', () => {
+    const session = newSession();
+    const withTime = advanceSessionNarrative(session, { by: { hours: 1 } }); // 3600 s
+    const cast = castSessionSpell(withTime, {
+      activeSpellId: 'spell-aura',
+      durationAmount: 10,
+      durationUnit: 'minute',
+      spellId: 'aura-de-courage',
+      targetId: 'aveline'
+    });
+
+    expect(cast.activeSpells).toMatchObject([
+      { id: 'spell-aura', castAtSeconds: 3_600, durationAmount: 10, durationUnit: 'minute' }
+    ]);
+    expect(getActiveSpells(cast)).toHaveLength(1);
+
+    // 10 minutes later the buff has lapsed.
+    const muchLater = advanceSessionNarrative(cast, { by: { minutes: 10 } });
+    expect(muchLater.narrativeSeconds).toBe(3_600 + 600);
+    expect(muchLater.activeSpells).toEqual([]);
+  });
+
+  it('expires a combat-scale (DT) spell once the MJ skips a day (combat nests in narrative)', () => {
+    const session = newSession();
+    const cast = castSessionSpell(session, {
+      activeSpellId: 'spell-haste',
+      durationAmount: 10,
+      durationUnit: 'DT' // 2 s
+    });
+
+    expect(cast.activeSpells).toHaveLength(1);
+
+    const nextDay = advanceSessionNarrative(cast, { by: { days: 1 } });
+    expect(nextDay.activeSpells).toEqual([]);
+  });
+
+  it('keeps a permanent spell active until it is explicitly dispelled', () => {
+    const session = newSession();
+    const cast = castSessionSpell(session, {
+      activeSpellId: 'spell-ward',
+      durationAmount: 0,
+      durationUnit: 'permanent'
+    });
+    const farFuture = advanceSessionNarrative(cast, { by: { days: 365 } });
+
+    expect(farFuture.activeSpells.map((spell) => spell.id)).toEqual(['spell-ward']);
+
+    const dispelled = dispelSessionSpell(farFuture, { actorId: 'gm', activeSpellId: 'spell-ward' });
+    expect(dispelled.activeSpells).toEqual([]);
+  });
+
+  it('rewinds the clock and resurrects a lapsed spell when reverting (rollback rewinds time)', () => {
+    const session = newSession();
+    const cast = castSessionSpell(
+      session,
+      { activeSpellId: 'spell-aura', durationAmount: 10, durationUnit: 'minute' },
+      { eventId: 'event-1', now: '2026-04-30T10:00:00.000Z' }
+    );
+    const later = advanceSessionNarrative(
+      cast,
+      { by: { hours: 1 } },
+      { eventId: 'event-2', now: '2026-04-30T11:00:00.000Z' }
+    );
+
+    // After an hour the 10-minute buff is gone.
+    expect(later.narrativeSeconds).toBe(3_600);
+    expect(later.activeSpells).toEqual([]);
+
+    // Revert to just after the cast (sequence 1): the clock is back to 0 and the spell is active again.
+    const reverted = revertSessionToSequence(later, 1);
+    expect(reverted.narrativeSeconds).toBe(0);
+    expect(reverted.activeSpells.map((spell) => spell.id)).toEqual(['spell-aura']);
+  });
+
+  it('derives the clock purely from the journal (createSessionState folds events)', () => {
+    const session = newSession();
+    const built = advanceSessionNarrative(
+      session,
+      { by: { minutes: 30 } },
+      { eventId: 'event-1', now: '2026-04-30T10:00:00.000Z' }
+    );
+    // Rebuild a fresh state from the raw events alone — the clock must match.
+    const rehydrated = createSessionState({
+      events: built.events,
+      id: built.id,
+      slug: built.slug,
+      title: built.title
+    });
+
+    expect(rehydrated.narrativeSeconds).toBe(1_800);
   });
 });

--- a/packages/rules-core/src/session.ts
+++ b/packages/rules-core/src/session.ts
@@ -1,3 +1,13 @@
+import {
+  type ActiveSpell,
+  type NarrativeAdvance,
+  type SpellDurationUnit,
+  SPELL_DURATION_UNITS,
+  advanceNarrative,
+  endCombat,
+  expireActiveSpells
+} from './narrative-time.js';
+
 export const SESSION_MODES = [
   'classic_table',
   'digital_human_gm',
@@ -19,7 +29,11 @@ export const SESSION_EVENT_TYPES = [
   'gm_ruling',
   'gm_decision_requested',
   'gm_decision_resolved',
-  'rollback_requested'
+  'rollback_requested',
+  'narrative_time_advanced',
+  'combat_ended',
+  'spell_cast',
+  'spell_dispelled'
 ] as const;
 
 export const SESSION_DECISION_PRIORITIES = ['low', 'normal', 'high', 'urgent'] as const;
@@ -85,6 +99,8 @@ export interface SessionAuditEntry {
 }
 
 export interface SessionState {
+  /** Sorts encore actifs à l'instant narratif courant (R-8.20), dérivés du journal. */
+  activeSpells: ActiveSpell[];
   audit: SessionAuditEntry[];
   createdAt: string;
   decisions: SessionDecision[];
@@ -92,6 +108,8 @@ export interface SessionState {
   id: string;
   metadata: Record<string, unknown>;
   mode: SessionMode;
+  /** Horloge narrative en secondes (R-8.20), dérivée du journal d'événements. */
+  narrativeSeconds: number;
   players: SessionPlayer[];
   scenes: SessionScene[];
   slug: string;
@@ -158,15 +176,19 @@ const priorityRank: Record<SessionDecisionPriority, number> = {
 
 export function createSessionState(input: CreateSessionStateInput): SessionState {
   const now = input.createdAt ?? new Date().toISOString();
+  const events = sortEvents(input.events ?? []);
+  const clock = foldNarrativeClock(events);
 
   return {
+    activeSpells: activeSpellsAt(clock),
     audit: input.audit ? [...input.audit] : [],
     createdAt: now,
     decisions: input.decisions ? [...input.decisions] : [],
-    events: sortEvents(input.events ?? []),
+    events,
     id: input.id,
     metadata: normalizePayload(input.metadata),
     mode: input.mode ?? 'classic_table',
+    narrativeSeconds: clock.narrativeSeconds,
     players: input.players ? [...input.players] : [],
     scenes: input.scenes ? [...input.scenes] : [],
     slug: input.slug,
@@ -192,7 +214,7 @@ export function appendSessionEvent(
     type: input.type
   };
 
-  return {
+  return withNarrativeClock({
     ...state,
     audit: [
       ...state.audit,
@@ -212,7 +234,7 @@ export function appendSessionEvent(
     ],
     events: [...state.events, event],
     updatedAt: now
-  };
+  });
 }
 
 export function queueGmDecision(
@@ -449,12 +471,15 @@ export function rebuildSessionStateFromEvents(
     decisions: [],
     scenes: []
   });
+  const clock = foldNarrativeClock(retained);
   const lastEvent = retained.at(-1);
 
   return {
     ...state,
+    activeSpells: activeSpellsAt(clock),
     decisions: projection.decisions,
     events: retained,
+    narrativeSeconds: clock.narrativeSeconds,
     scenes: projection.scenes,
     updatedAt: options.now ?? lastEvent?.createdAt ?? state.createdAt
   };
@@ -538,6 +563,210 @@ function applyDecisionResolution(
         }
       : decision
   );
+}
+
+// --- Horloge narrative « temps double » (R-8.20) -----------------------------
+// La narrativeSeconds et les sorts actifs sont une projection pure du journal :
+// un rollback rembobine donc automatiquement le temps et l'état des sorts.
+
+export interface AdvanceSessionNarrativeInput {
+  actorId?: string;
+  by: NarrativeAdvance;
+}
+
+export interface EndSessionCombatInput {
+  actorId?: string;
+  /** DT cumulés de la scène de combat (R-8.20 : 1 DT = 0,2 s). */
+  elapsedDT: number;
+}
+
+export interface CastSessionSpellInput {
+  actorId?: string;
+  /** Identifiant stable de l'instance de sort (défaut : dérivé de la séquence). */
+  activeSpellId?: string;
+  /** Quantité de durée déjà résolue (mise à l'échelle par réussites le cas échéant). */
+  durationAmount: number;
+  durationUnit: SpellDurationUnit;
+  spellId?: string;
+  targetId?: string;
+}
+
+export interface DispelSessionSpellInput {
+  actorId?: string;
+  activeSpellId: string;
+}
+
+interface NarrativeClock {
+  /** Instant narratif courant en secondes (R-8.20). */
+  narrativeSeconds: number;
+  /** Tous les sorts lancés (chacun avec son castAtSeconds), moins ceux dissipés. */
+  spells: ActiveSpell[];
+}
+
+/** Avance l'horloge narrative (contrôle MJ « passer la journée / N heures », R-8.20). */
+export function advanceSessionNarrative(
+  state: SessionState,
+  input: AdvanceSessionNarrativeInput,
+  options: SessionMutationOptions = {}
+): SessionState {
+  return appendSessionEvent(
+    state,
+    { actorId: input.actorId, payload: { ...input.by }, type: 'narrative_time_advanced' },
+    options
+  );
+}
+
+/** Fin de combat (R-8.20) : replie les DT écoulés de la scène sur l'horloge narrative. */
+export function endSessionCombat(
+  state: SessionState,
+  input: EndSessionCombatInput,
+  options: SessionMutationOptions = {}
+): SessionState {
+  return appendSessionEvent(
+    state,
+    { actorId: input.actorId, payload: { elapsedDT: input.elapsedDT }, type: 'combat_ended' },
+    options
+  );
+}
+
+/** Inscrit un sort actif sur l'horloge narrative ; son castAtSeconds est l'instant courant. */
+export function castSessionSpell(
+  state: SessionState,
+  input: CastSessionSpellInput,
+  options: SessionMutationOptions = {}
+): SessionState {
+  return appendSessionEvent(
+    state,
+    {
+      actorId: input.actorId,
+      payload: {
+        activeSpellId: input.activeSpellId,
+        durationAmount: input.durationAmount,
+        durationUnit: input.durationUnit,
+        spellId: input.spellId,
+        targetId: input.targetId
+      },
+      type: 'spell_cast'
+    },
+    options
+  );
+}
+
+/** Dissipe un sort actif (seul moyen de terminer un sort `permanent`). */
+export function dispelSessionSpell(
+  state: SessionState,
+  input: DispelSessionSpellInput,
+  options: SessionMutationOptions = {}
+): SessionState {
+  return appendSessionEvent(
+    state,
+    {
+      actorId: input.actorId,
+      payload: { activeSpellId: input.activeSpellId },
+      type: 'spell_dispelled'
+    },
+    options
+  );
+}
+
+/** Sorts encore actifs à l'instant narratif courant de la session. */
+export function getActiveSpells(state: SessionState): ActiveSpell[] {
+  return state.activeSpells;
+}
+
+/** Recalcule les champs dérivés de l'horloge narrative à partir du journal. */
+function withNarrativeClock(state: SessionState): SessionState {
+  const clock = foldNarrativeClock(state.events);
+
+  return {
+    ...state,
+    activeSpells: activeSpellsAt(clock),
+    narrativeSeconds: clock.narrativeSeconds
+  };
+}
+
+function activeSpellsAt(clock: NarrativeClock): ActiveSpell[] {
+  return expireActiveSpells(clock.spells, clock.narrativeSeconds).active;
+}
+
+function foldNarrativeClock(events: SessionEvent[]): NarrativeClock {
+  return sortEvents(events).reduce<NarrativeClock>(reduceNarrativeEvent, {
+    narrativeSeconds: 0,
+    spells: []
+  });
+}
+
+function reduceNarrativeEvent(clock: NarrativeClock, event: SessionEvent): NarrativeClock {
+  switch (event.type) {
+    case 'narrative_time_advanced':
+      return {
+        ...clock,
+        narrativeSeconds: advanceNarrative(
+          clock.narrativeSeconds,
+          narrativeAdvanceFromPayload(event.payload)
+        )
+      };
+    case 'combat_ended':
+      return {
+        ...clock,
+        narrativeSeconds: endCombat(
+          clock.narrativeSeconds,
+          nonNegativeNumber(event.payload.elapsedDT)
+        )
+      };
+    case 'spell_cast': {
+      const spell = activeSpellFromEvent(event, clock.narrativeSeconds);
+
+      return spell === undefined ? clock : { ...clock, spells: [...clock.spells, spell] };
+    }
+    case 'spell_dispelled': {
+      const id = optionalString(event.payload.activeSpellId) ?? optionalString(event.payload.id);
+
+      return id === undefined
+        ? clock
+        : { ...clock, spells: clock.spells.filter((spell) => spell.id !== id) };
+    }
+    default:
+      return clock;
+  }
+}
+
+function narrativeAdvanceFromPayload(payload: Record<string, unknown>): NarrativeAdvance {
+  return {
+    days: nonNegativeNumber(payload.days),
+    hours: nonNegativeNumber(payload.hours),
+    minutes: nonNegativeNumber(payload.minutes),
+    seconds: nonNegativeNumber(payload.seconds)
+  };
+}
+
+function activeSpellFromEvent(event: SessionEvent, castAtSeconds: number): ActiveSpell | undefined {
+  const payload = event.payload;
+  const durationUnit = optionalString(payload.durationUnit);
+
+  if (!isSpellDurationUnit(durationUnit)) {
+    return undefined;
+  }
+
+  return {
+    castAtSeconds,
+    durationAmount: nonNegativeNumber(payload.durationAmount),
+    durationUnit,
+    id:
+      optionalString(payload.activeSpellId) ??
+      optionalString(payload.id) ??
+      `spell-${event.sequence}`,
+    spellId: optionalString(payload.spellId),
+    targetId: optionalString(payload.targetId)
+  };
+}
+
+function isSpellDurationUnit(value: string | undefined): value is SpellDurationUnit {
+  return value !== undefined && (SPELL_DURATION_UNITS as readonly string[]).includes(value);
+}
+
+function nonNegativeNumber(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : 0;
 }
 
 function optionalString(value: unknown): string | undefined {


### PR DESCRIPTION
## E3b — Horloge narrative « event-sourced » dans le modèle de session (R-8.20)

Deuxième brique de l'épopée **E3 (#188)**, posée sur les primitives pures d'E3a (#236). La session devient porteuse de l'**horloge narrative** et des **sorts actifs**, **dérivés du journal d'événements immuable** — donc un **rollback rembobine automatiquement le temps et l'état des sorts**.

### Principe

`narrativeSeconds` et `activeSpells` ne sont **pas** des colonnes mutables : ce sont une **projection pure** du log (comme `scenes` / `decisions`). Quatre nouveaux types d'événements canoniques :

| Événement | Effet sur l'horloge |
| --- | --- |
| `narrative_time_advanced` | `advanceNarrative` (MJ « passer la journée / N heures ») |
| `combat_ended` | `endCombat` — replie les DT de la scène (1 DT = 0,2 s) |
| `spell_cast` | inscrit un `ActiveSpell` avec `castAtSeconds` = instant courant |
| `spell_dispelled` | retire le sort (seul moyen de terminer un `permanent`) |

Les sorts expirent sur l'**horloge partagée** combat ↔ narratif : un buff de durée `DT` lancé en combat disparaît dès que le MJ « passe la journée ».

### Modifié

- `packages/rules-core/src/session.ts` :
  - `SessionState.narrativeSeconds` + `SessionState.activeSpells` (champs dérivés).
  - fold de l'horloge dans `createSessionState`, `rebuildSessionStateFromEvents` (rollback) et `appendSessionEvent` (cohérence sur tous les chemins).
  - helpers mutateurs : `advanceSessionNarrative`, `endSessionCombat`, `castSessionSpell`, `dispelSessionSpell`, lecteur `getActiveSpells`.
- `apps/game/.../session-manager/model.ts` : libellés des 4 nouveaux types (map exhaustive).
- L'API `/sessions/:slug` **expose déjà** `state.narrativeSeconds` + `state.activeSpells` (la projection passe par `state`, aucune colonne DB, compatible rollback).

### Tests

- **rules-core** (+8) : départ à zéro, « passer la journée », fin de combat, expiration d'un buff minute, expiration d'un buff DT au saut de jour, `permanent` → dispel, **rollback qui rembobine le temps et ressuscite un sort expiré**, fold pur depuis le journal.
- **serveur** (+1) : vertical complet via HTTP (advance → cast → GET montre le sort actif → advance → GET montre l'expiration), exécuté contre le devlab Postgres.

### Gates

- ✅ `vitest run packages/rules-core/src` (290) + `apps/server/.../sessions.test.ts` (7, devlab)
- ✅ `turbo run typecheck` (rules-core, server, game, cms, tokens)
- ✅ eslint + prettier
- Pas de régénération canon : modèle pur + test, aucune source canonique touchée.

### Suite (E3c)

Surface MJ de l'horloge (panneaux « scénario/scène » + « combat-commande » du Cockpit S4 #168) : contrôles « passer la journée », liste des sorts actifs avec compte à rebours, dispel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
