### PR TITLE
feat(game): E3c - panneau Horloge narrative (surface session)

### DIFF
--- a/apps/game/src/features/session-manager/SessionManager.tsx
+++ b/apps/game/src/features/session-manager/SessionManager.tsx
@@ -2,6 +2,7 @@
 
 import {
   CheckCircle2,
+  Clock,
   Dice5,
   History,
   ListChecks,
@@ -10,15 +11,19 @@ import {
   RotateCcw,
   ScrollText,
   ShieldAlert,
+  Sparkles,
   Users,
+  Wand2,
   XCircle
 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { trpc } from '@/lib/trpc';
 import { applyLiveSessionEvent, buildSessionManagerView, type SessionManagerState } from './model';
 import {
+  advancePersistedNarrative,
   appendDiceRollToSession,
   appendPersistedSessionEvent,
+  dispelPersistedSpell,
   fetchPersistedSessionState,
   queuePersistedGmDecision,
   requestPersistedRollback,
@@ -107,6 +112,12 @@ export function SessionManager({ initialState }: Readonly<SessionManagerProps>) 
     } finally {
       setPendingAction(null);
     }
+  }
+
+  function skipNarrativeTime(by: { days?: number; hours?: number; minutes?: number }) {
+    void runPersistedAction('narrative-advance', async (slug) => {
+      await advancePersistedNarrative(slug, { actorId: 'gm', by });
+    });
   }
 
   return (
@@ -261,6 +272,81 @@ export function SessionManager({ initialState }: Readonly<SessionManagerProps>) 
               {mutationError}
             </p>
           ) : null}
+        </section>
+
+        <section className="mt-5 rounded-md border border-ink/10 bg-white/72 p-4">
+          <div className="flex items-center gap-2">
+            <Clock aria-hidden="true" className="size-5 text-forest" />
+            <h2 className="text-lg font-semibold text-ink">Horloge narrative</h2>
+          </div>
+          <p
+            className="mt-3 font-mono text-2xl font-semibold text-ink"
+            data-testid="narrative-instant"
+          >
+            {view.narrativeClock.instantLabel}
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <TimeSkipButton
+              disabled={busy}
+              label="+10 min"
+              onClick={() => skipNarrativeTime({ minutes: 10 })}
+            />
+            <TimeSkipButton
+              disabled={busy}
+              label="+1 h"
+              onClick={() => skipNarrativeTime({ hours: 1 })}
+            />
+            <TimeSkipButton
+              disabled={busy}
+              label="Passer la journée"
+              onClick={() => skipNarrativeTime({ days: 1 })}
+            />
+          </div>
+
+          <div className="mt-4">
+            <div className="flex items-center gap-2">
+              <Sparkles aria-hidden="true" className="size-4 text-wine" />
+              <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-ink/62">
+                Sorts actifs
+              </h3>
+            </div>
+            {view.narrativeClock.activeSpells.length === 0 ? (
+              <p className="mt-2 rounded-md border border-ink/10 bg-paper px-3 py-2 text-sm font-semibold text-ink/55">
+                Aucun sort actif
+              </p>
+            ) : (
+              <ul className="mt-2 grid gap-2">
+                {view.narrativeClock.activeSpells.map((spell) => (
+                  <li
+                    className="grid grid-cols-[1fr_auto] items-center gap-3 rounded-md border border-ink/10 bg-paper px-3 py-2"
+                    key={spell.id}
+                  >
+                    <span>
+                      <span className="block text-sm font-semibold text-ink">{spell.label}</span>
+                      <span className="block text-xs font-medium text-ink/55">
+                        {spell.target ? `Cible : ${spell.target} · ` : ''}
+                        {spell.remainingLabel}
+                      </span>
+                    </span>
+                    <IconButton
+                      disabled={busy}
+                      label={`Dissiper ${spell.label}`}
+                      onClick={() => {
+                        void runPersistedAction('spell-dispel', async (slug) => {
+                          await dispelPersistedSpell(slug, {
+                            actorId: 'gm',
+                            activeSpellId: spell.id
+                          });
+                        });
+                      }}
+                    >
+                      <Wand2 aria-hidden="true" className="size-4" />
+                    </IconButton>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         </section>
       </section>
 
@@ -426,6 +512,27 @@ function ActionButton({
       type="button"
     >
       {icon}
+      {label}
+    </button>
+  );
+}
+
+function TimeSkipButton({
+  disabled = false,
+  label,
+  onClick
+}: Readonly<{
+  disabled?: boolean;
+  label: string;
+  onClick: () => void;
+}>) {
+  return (
+    <button
+      className="inline-flex min-h-10 items-center justify-center rounded-md border border-ink/15 bg-vellum/70 px-3 py-2 text-sm font-semibold text-ink transition hover:border-forest hover:text-forest disabled:cursor-not-allowed disabled:opacity-40"
+      disabled={disabled}
+      onClick={onClick}
+      type="button"
+    >
       {label}
     </button>
   );

--- a/apps/game/src/features/session-manager/model.test.ts
+++ b/apps/game/src/features/session-manager/model.test.ts
@@ -4,6 +4,8 @@ import {
   applyLiveSessionEvent,
   buildSessionManagerView,
   createSessionManagerState,
+  formatDuration,
+  formatNarrativeInstant,
   recordSessionEvent,
   requestRollbackFromEvent,
   resolveNextPendingDecision,
@@ -267,5 +269,108 @@ describe('applyLiveSessionEvent', () => {
     });
 
     expect(outcome.kind).toBe('gap');
+  });
+
+  it('recomputes the narrative clock when a live time-advance event is applied', () => {
+    const outcome = applyLiveSessionEvent(base, {
+      actorId: 'gm',
+      createdAt: '2026-04-30T12:00:00.000Z',
+      id: 'event-2',
+      payload: { hours: 2 },
+      sequence: 2,
+      type: 'narrative_time_advanced'
+    });
+
+    expect(outcome.kind).toBe('applied');
+
+    if (outcome.kind === 'applied') {
+      expect(outcome.state.narrativeSeconds).toBe(7_200);
+    }
+  });
+});
+
+describe('narrative clock view (R-8.20)', () => {
+  it('exposes the formatted instant and active spells in the manager view', () => {
+    const state = createSessionManagerState({
+      events: [
+        {
+          actorId: 'gm',
+          createdAt: '2026-04-30T10:00:00.000Z',
+          id: 'event-1',
+          payload: { hours: 1 },
+          sequence: 1,
+          type: 'narrative_time_advanced'
+        },
+        {
+          actorId: 'gm',
+          createdAt: '2026-04-30T10:01:00.000Z',
+          id: 'event-2',
+          payload: {
+            activeSpellId: 'spell-aura',
+            durationAmount: 10,
+            durationUnit: 'minute',
+            spellId: 'aura-de-courage',
+            targetId: 'aveline'
+          },
+          sequence: 2,
+          type: 'spell_cast'
+        }
+      ]
+    });
+    const view = buildSessionManagerView(state);
+
+    expect(view.narrativeClock.narrativeSeconds).toBe(3_600);
+    expect(view.narrativeClock.instantLabel).toBe('Jour 1 · 01:00:00');
+    expect(view.narrativeClock.activeSpells).toEqual([
+      {
+        id: 'spell-aura',
+        label: 'aura-de-courage',
+        permanent: false,
+        remainingLabel: 'Expire dans 10 min',
+        target: 'aveline'
+      }
+    ]);
+  });
+
+  it('marks a permanent spell as requiring an explicit dispel', () => {
+    const state = createSessionManagerState({
+      events: [
+        {
+          actorId: 'gm',
+          createdAt: '2026-04-30T10:00:00.000Z',
+          id: 'event-1',
+          payload: {
+            activeSpellId: 'spell-ward',
+            durationAmount: 0,
+            durationUnit: 'permanent',
+            spellId: 'bouclier'
+          },
+          sequence: 1,
+          type: 'spell_cast'
+        }
+      ]
+    });
+    const view = buildSessionManagerView(state);
+
+    expect(view.narrativeClock.activeSpells).toEqual([
+      {
+        id: 'spell-ward',
+        label: 'bouclier',
+        permanent: true,
+        remainingLabel: 'Permanent (dissipation requise)',
+        target: undefined
+      }
+    ]);
+  });
+
+  it('formats absolute instants across day boundaries', () => {
+    expect(formatNarrativeInstant(0)).toBe('Jour 1 · 00:00:00');
+    expect(formatNarrativeInstant(86_400 + 3_661)).toBe('Jour 2 · 01:01:01');
+  });
+
+  it('formats short relative durations with the two largest units', () => {
+    expect(formatDuration(7_200)).toBe('2 h');
+    expect(formatDuration(90)).toBe('1 min 30 s');
+    expect(formatDuration(86_400 + 3_600)).toBe('1 j 1 h');
   });
 });

--- a/apps/game/src/features/session-manager/model.ts
+++ b/apps/game/src/features/session-manager/model.ts
@@ -2,9 +2,12 @@ import {
   appendSessionEvent,
   createSessionState,
   getPendingDecisions,
+  projectSessionNarrativeClock,
   queueGmDecision,
   requestSessionRollback,
   resolveGmDecision,
+  spellExpiresAt,
+  type ActiveSpell,
   type AppendSessionEventInput,
   type SessionAuditEntry,
   type SessionDecision,
@@ -62,6 +65,21 @@ export interface RollbackTargetRow {
   sequence: number;
 }
 
+export interface ActiveSpellRow {
+  id: string;
+  label: string;
+  permanent: boolean;
+  remainingLabel: string;
+  target?: string;
+}
+
+export interface NarrativeClockView {
+  /** Instant narratif formaté (« Jour N · HH:MM:SS »). */
+  instantLabel: string;
+  narrativeSeconds: number;
+  activeSpells: ActiveSpellRow[];
+}
+
 export interface SessionManagerView {
   activeScene?: SessionScene;
   decisionQueue: SessionDecisionRow[];
@@ -71,6 +89,7 @@ export interface SessionManagerView {
     pendingDecisions: number;
     scenes: number;
   };
+  narrativeClock: NarrativeClockView;
   playerRows: Array<SessionPlayer & { statusLabel: string }>;
   recentEvents: SessionEventRow[];
   rollbackTargets: RollbackTargetRow[];
@@ -134,6 +153,7 @@ export function buildSessionManagerView(state: SessionManagerState): SessionMana
       title: decision.title
     })),
     metrics,
+    narrativeClock: buildNarrativeClockView(state),
     playerRows: state.players.map((player) => ({
       ...player,
       statusLabel: player.connected === false ? 'Hors ligne' : 'Connecte'
@@ -247,10 +267,80 @@ export function applyLiveSessionEvent(
   }
 
   if (event.sequence === maxSequence + 1) {
-    return { kind: 'applied', state: { ...state, events: [...state.events, event] } };
+    // Recompute only the narrative-clock projection so a live `narrative_time_advanced`
+    // (or spell) event keeps the displayed clock/active spells in sync without a refetch.
+    return {
+      kind: 'applied',
+      state: projectSessionNarrativeClock({ ...state, events: [...state.events, event] })
+    };
   }
 
   return { kind: 'gap' };
+}
+
+function buildNarrativeClockView(state: SessionManagerState): NarrativeClockView {
+  return {
+    activeSpells: state.activeSpells.map((spell) =>
+      toActiveSpellRow(spell, state.narrativeSeconds)
+    ),
+    instantLabel: formatNarrativeInstant(state.narrativeSeconds),
+    narrativeSeconds: state.narrativeSeconds
+  };
+}
+
+function toActiveSpellRow(spell: ActiveSpell, nowSeconds: number): ActiveSpellRow {
+  const expiresAt = spellExpiresAt(spell);
+  const permanent = expiresAt === null;
+
+  return {
+    id: spell.id,
+    label: spell.spellId ?? 'Sort actif',
+    permanent,
+    remainingLabel: permanent
+      ? 'Permanent (dissipation requise)'
+      : `Expire dans ${formatDuration(Math.max(0, expiresAt - nowSeconds))}`,
+    target: spell.targetId
+  };
+}
+
+/** Formate un instant narratif absolu en « Jour N · HH:MM:SS » (R-8.20). */
+export function formatNarrativeInstant(totalSeconds: number): string {
+  const dayLength = 86_400;
+  const safe = Number.isFinite(totalSeconds) && totalSeconds > 0 ? totalSeconds : 0;
+  const day = Math.floor(safe / dayLength) + 1;
+  const within = Math.floor(safe % dayLength);
+  const hours = Math.floor(within / 3_600);
+  const minutes = Math.floor((within % 3_600) / 60);
+  const seconds = within % 60;
+
+  return `Jour ${day} · ${pad2(hours)}:${pad2(minutes)}:${pad2(seconds)}`;
+}
+
+/** Formate une durée relative courte (« 2 j 3 h », « 8 min 12 s », « permanent »). */
+export function formatDuration(totalSeconds: number): string {
+  const safe = Number.isFinite(totalSeconds) && totalSeconds > 0 ? Math.round(totalSeconds) : 0;
+
+  if (safe <= 0) {
+    return "moins d'une seconde";
+  }
+
+  const days = Math.floor(safe / 86_400);
+  const hours = Math.floor((safe % 86_400) / 3_600);
+  const minutes = Math.floor((safe % 3_600) / 60);
+  const seconds = safe % 60;
+  const units: Array<[number, string]> = [
+    [days, 'j'],
+    [hours, 'h'],
+    [minutes, 'min'],
+    [seconds, 's']
+  ];
+  const significant = units.filter(([value]) => value > 0).slice(0, 2);
+
+  return significant.map(([value, unit]) => `${value} ${unit}`).join(' ');
+}
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, '0');
 }
 
 function getActiveScene(state: SessionManagerState): SessionScene | undefined {

--- a/apps/game/src/features/session-manager/persistence.ts
+++ b/apps/game/src/features/session-manager/persistence.ts
@@ -97,6 +97,40 @@ export async function resolvePersistedGmDecision(
   );
 }
 
+export interface AdvancePersistedNarrativeInput {
+  actorId: string;
+  by: { days?: number; hours?: number; minutes?: number; seconds?: number };
+}
+
+export interface DispelPersistedSpellInput {
+  activeSpellId: string;
+  actorId: string;
+}
+
+/** Avance l'horloge narrative (MJ « passer la journée / N heures », R-8.20). */
+export async function advancePersistedNarrative(
+  slug: string,
+  input: AdvancePersistedNarrativeInput
+): Promise<void> {
+  await appendPersistedSessionEvent(slug, {
+    actorId: input.actorId,
+    eventType: 'narrative_time_advanced',
+    payload: { ...input.by }
+  });
+}
+
+/** Dissipe un sort actif (seul moyen de terminer un sort permanent). */
+export async function dispelPersistedSpell(
+  slug: string,
+  input: DispelPersistedSpellInput
+): Promise<void> {
+  await appendPersistedSessionEvent(slug, {
+    actorId: input.actorId,
+    eventType: 'spell_dispelled',
+    payload: { activeSpellId: input.activeSpellId }
+  });
+}
+
 export async function requestPersistedRollback(
   slug: string,
   input: RequestPersistedRollbackInput

--- a/packages/rules-core/src/session.ts
+++ b/packages/rules-core/src/session.ts
@@ -674,6 +674,16 @@ export function getActiveSpells(state: SessionState): ActiveSpell[] {
   return state.activeSpells;
 }
 
+/**
+ * Recalcule UNIQUEMENT la projection d'horloge narrative (`narrativeSeconds` +
+ * `activeSpells`) depuis le journal, en préservant les autres facettes (scenes,
+ * decisions…). Utile côté client après application d'un événement live, où les
+ * scènes proviennent des métadonnées et non du fold d'événements.
+ */
+export function projectSessionNarrativeClock(state: SessionState): SessionState {
+  return withNarrativeClock(state);
+}
+
 /** Recalcule les champs dérivés de l'horloge narrative à partir du journal. */
 function withNarrativeClock(state: SessionState): SessionState {
   const clock = foldNarrativeClock(state.events);


### PR DESCRIPTION
## E3c — Panneau « Horloge narrative » sur la surface session (R-8.20)

Première brique **direction 3 (frontend)** de l'épopée **E3 (#188)** : elle **surface** côté MJ l'horloge et les sorts actifs construits en E3a/E3b. Préfigure les panneaux « scénario/scène » et « combat-commande » du **Cockpit MJ (S4, #168)**.

### Ce que voit le MJ

Nouveau panneau dans la surface session (`/session`) :

- **Instant narratif** formaté — `Jour N · HH:MM:SS`.
- **Contrôles temps** : `+10 min`, `+1 h`, `Passer la journée` → postent un événement `narrative_time_advanced` (l'horloge avance, les sorts expirés disparaissent).
- **Sorts actifs** : liste avec **compte à rebours** (`Expire dans 10 min`) ou `Permanent (dissipation requise)`, chacun avec un bouton **Dissiper** → poste `spell_dispelled`.

Tout passe par le journal d'événements existant : les actions sont **auditées** et **rollback-ables** (le rollback rembobine le temps, cf. E3b).

### Modifié

- `apps/game/.../session-manager/model.ts` : `NarrativeClockView` + `ActiveSpellRow` dans `buildSessionManagerView` ; helpers `formatNarrativeInstant` / `formatDuration` ; `applyLiveSessionEvent` recalcule l'horloge à la volée pour les événements live.
- `apps/game/.../session-manager/persistence.ts` : `advancePersistedNarrative`, `dispelPersistedSpell`.
- `apps/game/.../session-manager/SessionManager.tsx` : panneau + contrôles.
- `packages/rules-core/src/session.ts` : expose `projectSessionNarrativeClock` (reprojection de l'horloge **seule** — côté client les scènes viennent des métadonnées, pas du fold d'événements, donc on n'utilise pas `rebuildSessionStateFromEvents`).

### Tests / gates

- **+5** tests model (vue horloge, `permanent` → dispel, formatage instant/durée, recompute live) ; suite game **60/60**.
- ✅ `turbo run typecheck` · eslint · prettier · **`pnpm build:game`** (route `/session` OK).
- Pas de régénération canon (UI + helper pur, aucune source canonique touchée).

### Suite (Cockpit S4)

Regrouper ce panneau temps avec PNJ+contrôle, le fil, combat-commande, assistant LLM, mémoire/lore et fin de session/XP dans la vue unique du MJ (`docs/plan/MJ-COCKPIT.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
