### PR TITLE
feat(game): S1 Fiche - boucle equipement vers encombrement (R-2.18)

### DIFF
--- a/apps/game/src/features/character-sheet/CharacterSheet.tsx
+++ b/apps/game/src/features/character-sheet/CharacterSheet.tsx
@@ -344,7 +344,26 @@ export function CharacterSheet({
           }
           title="Inventaire"
         >
-          <p className="kw-sheet__muted">Charge {view.carriedWeightKg} kg</p>
+          <div className="kw-sheet__encumbrance" data-testid="encumbrance-summary">
+            <p className="kw-sheet__muted">
+              Charge {view.encumbrance.carriedKg} / {view.encumbrance.capacityKg} kg{' '}
+              {view.encumbrance.overloaded ? (
+                <Badge tone="danger">Surcharge +{view.encumbrance.penaltyDT} DT</Badge>
+              ) : (
+                <Badge tone="success">Dans la capacité</Badge>
+              )}
+            </p>
+            <StatBlock
+              items={[
+                { label: 'Capacité (Force×5)', value: `${view.encumbrance.capacityKg} kg` },
+                { label: 'Pénalité charge', value: `+${view.encumbrance.penaltyDT} DT` },
+                {
+                  label: 'Facteur vitesse effectif',
+                  value: view.encumbrance.effectiveSpeedFactor
+                }
+              ]}
+            />
+          </div>
           <div className="kw-sheet__row-list">
             {inventory.map((item) => (
               <InventoryRow

--- a/apps/game/src/features/character-sheet/model.test.ts
+++ b/apps/game/src/features/character-sheet/model.test.ts
@@ -291,6 +291,48 @@ describe('character sheet model', () => {
     expect(summary.pointsCommitted).toBe(3);
     expect(summary.energyAvailable).toBe(60);
   });
+
+  it('surfaces the equipment→encumbrance loop within carrying capacity (R-2.18)', () => {
+    // sampleCharacter has effective Force 5 (base 3 + training +2) -> capacity 25 kg.
+    const view = buildCharacterSheetView({
+      character: sampleCharacter(),
+      inventory: sampleInventory(), // 1.4 + 0.5 = 1.9 kg
+      mode: 'complete',
+      spells: sampleSpells()
+    });
+
+    expect(view.encumbrance).toEqual({
+      baseSpeedFactor: 8,
+      capacityKg: 25,
+      carriedKg: 1.9,
+      effectiveSpeedFactor: 8,
+      excessKg: 0,
+      overloaded: false,
+      penaltyDT: 0
+    });
+  });
+
+  it('adds the load penalty to the effective speed factor when overloaded (R-2.18)', () => {
+    const heavy: InventoryItem[] = [
+      { category: 'gear', id: 'anvil', name: 'Enclume', quantity: 1, weightKg: 30 }
+    ];
+    const view = buildCharacterSheetView({
+      character: sampleCharacter(),
+      inventory: heavy,
+      mode: 'complete',
+      spells: sampleSpells()
+    });
+
+    expect(view.encumbrance).toEqual({
+      baseSpeedFactor: 8,
+      capacityKg: 25,
+      carriedKg: 30,
+      effectiveSpeedFactor: 9,
+      excessKg: 5,
+      overloaded: true,
+      penaltyDT: 1
+    });
+  });
 });
 
 function sampleCharacter(): Character {

--- a/apps/game/src/features/character-sheet/model.ts
+++ b/apps/game/src/features/character-sheet/model.ts
@@ -3,6 +3,7 @@ import {
   calculateLevelProgression,
   calculateEffectiveAttributes,
   rollDice,
+  summarizeEncumbrance,
   type AttributeKey,
   type Character,
   type CharacterAttributes,
@@ -221,10 +222,25 @@ export interface CreationBudgetSummary {
   spellPoints: number;
 }
 
+export interface CharacterEncumbranceView {
+  /** Base (racial) speed factor before the load penalty. */
+  baseSpeedFactor: number;
+  /** Carrying capacity without penalty (kg) = Force × 5 (R-2.18). */
+  capacityKg: number;
+  carriedKg: number;
+  /** Speed factor once the encumbrance penalty is added. */
+  effectiveSpeedFactor: number;
+  excessKg: number;
+  overloaded: boolean;
+  /** Extra DT added to the speed factor by the load (R-2.18). */
+  penaltyDT: number;
+}
+
 export interface CharacterSheetView {
   attributes: CharacterAttributes;
   carriedWeightKg: number;
   creationBudget: CreationBudgetSummary;
+  encumbrance: CharacterEncumbranceView;
   equippedWeapons: InventoryItem[];
   levelProgression: LevelProgression;
   mode: CharacterSheetMode;
@@ -298,15 +314,42 @@ export function buildCharacterSheetView(input: {
   mode: CharacterSheetMode;
   spells: SpellEntry[];
 }): CharacterSheetView {
+  const attributes = calculateEffectiveAttributes(input.character);
+  const carriedWeightKg = totalInventoryWeight(input.inventory);
+
   return {
-    attributes: calculateEffectiveAttributes(input.character),
-    carriedWeightKg: totalInventoryWeight(input.inventory),
+    attributes,
+    carriedWeightKg,
     creationBudget: summarizeCreationBudget(input.character),
+    encumbrance: buildEncumbranceView(input.character, attributes, carriedWeightKg),
     equippedWeapons: input.inventory.filter((item) => item.category === 'weapon' && item.equipped),
     levelProgression: calculateLevelProgression(input.character),
     mode: input.mode,
     sections: sectionsByMode[input.mode].map((id) => ({ id, label: sectionLabels[id] })),
     spellSummary: summarizeSpellSlots(input.character, input.spells)
+  };
+}
+
+/**
+ * R-2.18 — Surfaces the equipment→encumbrance loop on the sheet: carried weight
+ * vs capacity (Force × 5 kg), the resulting speed-factor penalty and the effective
+ * speed factor. Uses the canonical rules-core helper so it never drifts from combat.
+ */
+function buildEncumbranceView(
+  character: Character,
+  attributes: CharacterAttributes,
+  carriedWeightKg: number
+): CharacterEncumbranceView {
+  const summary = summarizeEncumbrance({ carriedWeightKg, strength: attributes.strength });
+
+  return {
+    baseSpeedFactor: character.speedFactor,
+    capacityKg: summary.capacityKg,
+    carriedKg: summary.carriedKg,
+    effectiveSpeedFactor: character.speedFactor + summary.penaltyDT,
+    excessKg: summary.excessKg,
+    overloaded: summary.overloaded,
+    penaltyDT: summary.penaltyDT
   };
 }
 

--- a/docs/canonical/canonical-matrix.yaml
+++ b/docs/canonical/canonical-matrix.yaml
@@ -348503,7 +348503,7 @@ units:
     sources:
       - path: "docs/plan/MAGIC-IMPLEMENTATION.md"
         ref: "docs/plan/MAGIC-IMPLEMENTATION.md"
-        sha256: "41b8df5b5664e95ea9c4e39be924265be96660f61cb2eb723ec31b2a6eb4ae2d"
+        sha256: "894983464a6c53dc7dcb6d23cb4dfcde40a2862a7e9e3b09c4692bcb27c4bcae"
     business_rule:
       summary: "docs/plan/MAGIC-IMPLEMENTATION.md from docs/plan/MAGIC-IMPLEMENTATION.md."
       ambiguity_ref: null

--- a/docs/canonical/nomos/canonical-matrix.yaml
+++ b/docs/canonical/nomos/canonical-matrix.yaml
@@ -182783,7 +182783,7 @@ units:
     source_refs:
       - source_id: DOCS-PLAN-MAGIC-IMPLEMENTATION
         locator: docs/plan/MAGIC-IMPLEMENTATION.md
-        hash: sha256:41b8df5b5664e95ea9c4e39be924265be96660f61cb2eb723ec31b2a6eb4ae2d
+        hash: sha256:894983464a6c53dc7dcb6d23cb4dfcde40a2862a7e9e3b09c4692bcb27c4bcae
     business_rule: docs/plan/MAGIC-IMPLEMENTATION.md from docs/plan/MAGIC-IMPLEMENTATION.md.
     status: partial
     gaps:

--- a/docs/canonical/nomos/source-manifest.yaml
+++ b/docs/canonical/nomos/source-manifest.yaml
@@ -20682,7 +20682,7 @@ sources:
     domain: project-governance
     priority: derived
     status: active
-    hash: 41b8df5b5664e95ea9c4e39be924265be96660f61cb2eb723ec31b2a6eb4ae2d
+    hash: 894983464a6c53dc7dcb6d23cb4dfcde40a2862a7e9e3b09c4692bcb27c4bcae
     owner: decarvalhoe
     license: proprietary
     confidentiality: internal

--- a/docs/canonical/source-manifest.yaml
+++ b/docs/canonical/source-manifest.yaml
@@ -13216,7 +13216,7 @@ sources:
     notes: "Project documentation source."
   - id: "docs-plan-magic-implementation"
     path: "docs/plan/MAGIC-IMPLEMENTATION.md"
-    sha256: "41b8df5b5664e95ea9c4e39be924265be96660f61cb2eb723ec31b2a6eb4ae2d"
+    sha256: "894983464a6c53dc7dcb6d23cb4dfcde40a2862a7e9e3b09c4692bcb27c4bcae"
     source_type: generated_doc
     priority: 40
     status: active

--- a/packages/rules-core/src/combat.test.ts
+++ b/packages/rules-core/src/combat.test.ts
@@ -11,6 +11,7 @@ import {
   interruptCombatant,
   resolveNextAction,
   resolveStaminaDamage,
+  summarizeEncumbrance,
   type AttackAction,
   type Combatant,
   type SpellAction
@@ -596,6 +597,45 @@ describe('effective speed factor (R-2.18 encumbrance / R-1.38 effects)', () => {
     );
 
     expect(state.timeline[0].nextActionAt).toBe(8);
+  });
+});
+
+describe('summarizeEncumbrance (R-2.18)', () => {
+  it('reports no overload at or below capacity (Force x 5 kg)', () => {
+    expect(summarizeEncumbrance({ carriedWeightKg: 15, strength: 3 })).toEqual({
+      capacityKg: 15,
+      carriedKg: 15,
+      excessKg: 0,
+      overloaded: false,
+      penaltyDT: 0
+    });
+  });
+
+  it('adds +1 DT per full 5 kg above capacity and flags overload', () => {
+    expect(summarizeEncumbrance({ carriedWeightKg: 20.1, strength: 3 })).toEqual({
+      capacityKg: 15,
+      carriedKg: 20.1,
+      excessKg: 5.1,
+      overloaded: true,
+      penaltyDT: 2
+    });
+  });
+
+  it('clamps negative carried weight to zero (no negative penalty)', () => {
+    expect(summarizeEncumbrance({ carriedWeightKg: -4, strength: 2 })).toMatchObject({
+      carriedKg: 0,
+      excessKg: 0,
+      penaltyDT: 0
+    });
+  });
+
+  it('shares its definition with effectiveSpeedFactor (penalty matches)', () => {
+    const penalty = summarizeEncumbrance({ carriedWeightKg: 22, strength: 3 }).penaltyDT;
+    const base = 5;
+
+    expect(
+      effectiveSpeedFactor(loaded({ speedFactor: base, strength: 3, carriedWeightKg: 22 }))
+    ).toBe(base + penalty);
   });
 });
 

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -884,6 +884,49 @@ function actionCostDT(
 }
 
 /**
+ * R-2.18 — Encumbrance summary for a carried load against a Force score.
+ *
+ * Carrying capacity is `strength * encumbranceKgPerStrength` kg; every full
+ * `encumbranceKgPerStep` kg above it adds +1 to the speed factor (a heavier load
+ * makes actions slower). Pure and config-driven so both the combat scheduler and
+ * the character sheet share one definition of the rule.
+ */
+export interface EncumbranceSummary {
+  /** Carrying capacity without penalty (kg) = Force × `encumbranceKgPerStrength`. */
+  capacityKg: number;
+  /** Total carried weight considered (kg, clamped to ≥ 0). */
+  carriedKg: number;
+  /** Weight above capacity (kg); 0 when within capacity. */
+  excessKg: number;
+  /** True when the carried weight exceeds the capacity. */
+  overloaded: boolean;
+  /** Speed-factor penalty in DT (+1 per full `encumbranceKgPerStep` above capacity). */
+  penaltyDT: number;
+}
+
+export function summarizeEncumbrance(
+  input: { carriedWeightKg: number; strength: number },
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): EncumbranceSummary {
+  const carriedKg = roundToTenthKg(Math.max(0, input.carriedWeightKg));
+  const capacityKg = Math.max(0, input.strength) * config.combat.encumbranceKgPerStrength;
+  const excessKg = roundToTenthKg(Math.max(0, carriedKg - capacityKg));
+  const penaltyDT = Math.ceil(excessKg / config.combat.encumbranceKgPerStep);
+
+  return {
+    capacityKg,
+    carriedKg,
+    excessKg,
+    overloaded: excessKg > 0,
+    penaltyDT
+  };
+}
+
+function roundToTenthKg(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/**
  * R-2.18 / R-1.38 — Effective speed factor used to schedule a combatant's actions.
  *
  * Starts from the base (racial) speed factor, adds the encumbrance penalty (R-2.18:
@@ -915,10 +958,10 @@ function encumbrancePenalty(actor: Combatant, config: RulesConfig): number {
     return 0;
   }
 
-  const capacity = actor.attributes.strength * config.combat.encumbranceKgPerStrength;
-  const excess = Math.max(0, carried - capacity);
-
-  return Math.ceil(excess / config.combat.encumbranceKgPerStep);
+  return summarizeEncumbrance(
+    { carriedWeightKg: carried, strength: actor.attributes.strength },
+    config
+  ).penaltyDT;
 }
 
 const DAMAGE_TYPES: DamageType[] = ['P', 'E', 'C', 'T'];


### PR DESCRIPTION
Surface la boucle equipement->encombrement sur la Fiche (S1, direction 3). rules-core expose summarizeEncumbrance (capacite=Force x5 kg, penalite +1 DT/5 kg, arrondi dixieme) et encumbrancePenalty interne delegue a ce helper (source unique R-2.18). La Fiche affiche poids/capacite, badge surcharge, penalite +N DT et facteur de vitesse effectif. Tests : +4 rules-core (dont parite avec effectiveSpeedFactor) + 2 character-sheet ; typecheck + build:game OK ; aucune nouvelle table ni source canonique touchee.