### PR TITLE
feat(game): S1 Fiche - etat auto vitalite (malus physique R-9)

### DIFF
--- a/apps/game/src/features/character-sheet/CharacterSheet.tsx
+++ b/apps/game/src/features/character-sheet/CharacterSheet.tsx
@@ -294,6 +294,13 @@ export function CharacterSheet({
             tone="danger"
             value={character.vitality.current}
           />
+          {view.vitalityState.weakened ? (
+            <Badge tone="danger">
+              {view.vitalityState.incapacitated
+                ? 'Hors de combat · 0 vitalité'
+                : `Affaibli · −${view.vitalityState.physicalMalus} Force / Dextérité / Endurance`}
+            </Badge>
+          ) : null}
           <ProgressBar
             label="Énergie"
             max={character.energy.max}

--- a/apps/game/src/features/character-sheet/model.test.ts
+++ b/apps/game/src/features/character-sheet/model.test.ts
@@ -333,6 +333,39 @@ describe('character sheet model', () => {
       penaltyDT: 1
     });
   });
+
+  it('derives a healthy vitality state at full vitality (R-9)', () => {
+    const view = buildCharacterSheetView({
+      character: sampleCharacter(), // vitality 24/24 -> threshold 12
+      inventory: sampleInventory(),
+      mode: 'complete',
+      spells: sampleSpells()
+    });
+
+    expect(view.vitalityState).toEqual({
+      incapacitated: false,
+      malusThreshold: 12,
+      physicalMalus: 0,
+      weakened: false
+    });
+  });
+
+  it('surfaces the wounded physical-attribute malus below half vitality (R-9)', () => {
+    const wounded: Character = { ...sampleCharacter(), vitality: { current: 5, max: 24 } };
+    const view = buildCharacterSheetView({
+      character: wounded,
+      inventory: sampleInventory(),
+      mode: 'complete',
+      spells: sampleSpells()
+    });
+
+    expect(view.vitalityState).toEqual({
+      incapacitated: false,
+      malusThreshold: 12,
+      physicalMalus: 7,
+      weakened: true
+    });
+  });
 });
 
 function sampleCharacter(): Character {

--- a/apps/game/src/features/character-sheet/model.ts
+++ b/apps/game/src/features/character-sheet/model.ts
@@ -4,6 +4,7 @@ import {
   calculateEffectiveAttributes,
   rollDice,
   summarizeEncumbrance,
+  summarizeVitalityState,
   type AttributeKey,
   type Character,
   type CharacterAttributes,
@@ -11,7 +12,8 @@ import {
   type CharacterSkill,
   type DiceRollResult,
   type LevelProgression,
-  type RandomInteger
+  type RandomInteger,
+  type VitalityState
 } from '@knightandwizard/rules-core';
 
 export type CharacterSheetMode = 'combat' | 'complete' | 'gm' | 'social';
@@ -246,6 +248,7 @@ export interface CharacterSheetView {
   mode: CharacterSheetMode;
   sections: CharacterSheetSection[];
   spellSummary: SpellSlotSummary;
+  vitalityState: VitalityState;
 }
 
 export interface SpellSlotSummary {
@@ -326,7 +329,8 @@ export function buildCharacterSheetView(input: {
     levelProgression: calculateLevelProgression(input.character),
     mode: input.mode,
     sections: sectionsByMode[input.mode].map((id) => ({ id, label: sectionLabels[id] })),
-    spellSummary: summarizeSpellSlots(input.character, input.spells)
+    spellSummary: summarizeSpellSlots(input.character, input.spells),
+    vitalityState: summarizeVitalityState(input.character.vitality)
   };
 }
 

--- a/packages/rules-core/src/combat.test.ts
+++ b/packages/rules-core/src/combat.test.ts
@@ -12,6 +12,7 @@ import {
   resolveNextAction,
   resolveStaminaDamage,
   summarizeEncumbrance,
+  summarizeVitalityState,
   type AttackAction,
   type Combatant,
   type SpellAction
@@ -636,6 +637,49 @@ describe('summarizeEncumbrance (R-2.18)', () => {
     expect(
       effectiveSpeedFactor(loaded({ speedFactor: base, strength: 3, carriedWeightKg: 22 }))
     ).toBe(base + penalty);
+  });
+});
+
+describe('summarizeVitalityState (R-9 — vitality malus)', () => {
+  it('reports no malus at or above the half-vitality threshold', () => {
+    expect(summarizeVitalityState({ current: 24, max: 24 })).toEqual({
+      incapacitated: false,
+      malusThreshold: 12,
+      physicalMalus: 0,
+      weakened: false
+    });
+    // Exactly at the threshold is not yet weakened (malus = max(0, 12 - 12) = 0).
+    expect(summarizeVitalityState({ current: 12, max: 24 })).toMatchObject({
+      physicalMalus: 0,
+      weakened: false
+    });
+  });
+
+  it('applies a progressive malus below the threshold', () => {
+    expect(summarizeVitalityState({ current: 5, max: 24 })).toEqual({
+      incapacitated: false,
+      malusThreshold: 12,
+      physicalMalus: 7,
+      weakened: true
+    });
+  });
+
+  it('flags incapacitation at zero vitality', () => {
+    expect(summarizeVitalityState({ current: 0, max: 10 })).toEqual({
+      incapacitated: true,
+      malusThreshold: 5,
+      physicalMalus: 5,
+      weakened: true
+    });
+  });
+
+  it('matches the malus that applyDamage bakes into physical attributes', () => {
+    // Default combatant: vitality 10/10, strength 5. Drop to 3 -> threshold 5, malus 2.
+    const state = addCombatant(createCombatState(1), combatant({ id: 'hurt' }));
+    const hurt = applyDamage(state, 'hurt', 7).timeline[0]!;
+    const expectedMalus = summarizeVitalityState(hurt.vitality).physicalMalus;
+
+    expect(hurt.attributes.strength).toBe(5 - expectedMalus);
   });
 });
 

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -1010,6 +1010,38 @@ function normalizeCombatant(
   );
 }
 
+/**
+ * R-9 — Derived vitality state: below the half-vitality threshold a character's
+ * physical attributes (Force / Dextérité / Endurance) take a progressive malus.
+ * Pure and config-driven so the combat malus recomputation and the character sheet
+ * share a single definition of the rule.
+ */
+export interface VitalityState {
+  /** True at 0 vitality (incapacitated / dead per combat). */
+  incapacitated: boolean;
+  /** Half-vitality threshold = round(max × `vitalityMalusRatio`). */
+  malusThreshold: number;
+  /** Malus applied to Force / Dextérité / Endurance (0 at or above the threshold). */
+  physicalMalus: number;
+  /** True once current vitality is below the malus threshold. */
+  weakened: boolean;
+}
+
+export function summarizeVitalityState(
+  vitality: { current: number; max: number },
+  config: RulesConfig = DEFAULT_RULES_CONFIG
+): VitalityState {
+  const malusThreshold = Math.round(vitality.max * config.combat.vitalityMalusRatio);
+  const physicalMalus = Math.max(0, malusThreshold - vitality.current);
+
+  return {
+    incapacitated: vitality.current <= 0,
+    malusThreshold,
+    physicalMalus,
+    weakened: physicalMalus > 0
+  };
+}
+
 function recomputeVitalityMalus(
   combatant: Combatant,
   config: RulesConfig = DEFAULT_RULES_CONFIG
@@ -1017,11 +1049,7 @@ function recomputeVitalityMalus(
   const baseAttributes = combatant.baseAttributes ?? combatant.attributes;
   const malus = combatant.ignoresVitalityMalus
     ? 0
-    : Math.max(
-        0,
-        Math.round(combatant.vitality.max * config.combat.vitalityMalusRatio) -
-          combatant.vitality.current
-      );
+    : summarizeVitalityState(combatant.vitality, config).physicalMalus;
 
   return {
     ...combatant,


### PR DESCRIPTION
Surface l etat de vitalite derive sur la Fiche (S1, direction 3). rules-core expose summarizeVitalityState (seuil = round(max x vitalityMalusRatio), malus physique progressif = max(0, seuil - current), weakened, incapacitated) et recomputeVitalityMalus delegue desormais a ce helper (source unique R-9, partagee combat/fiche). La Fiche affiche un badge Affaibli -N Force/Dexterite/Endurance (ou Hors de combat a 0 vitalite) sous la barre de vitalite. Tests : +4 rules-core (dont parite avec applyDamage) + 2 character-sheet ; typecheck + canonical:check + build:game OK ; aucune source canonique touchee.