### PR TITLE
feat(game): S1 Fiche - panneau predilections (#140)

### DIFF
--- a/apps/game/src/features/character-sheet/CharacterSheet.tsx
+++ b/apps/game/src/features/character-sheet/CharacterSheet.tsx
@@ -408,6 +408,21 @@ export function CharacterSheet({
             ))}
           </div>
         </SectionCard>
+
+        <SectionCard title="Prédilections">
+          {view.predilections.length === 0 ? (
+            <p className="kw-sheet__muted">Aucune prédilection définie.</p>
+          ) : (
+            <div className="kw-sheet__row-list">
+              {view.predilections.map((predilection) => (
+                <div className="kw-sheet__info-line" key={predilection.kind}>
+                  <Badge tone="neutral">{predilection.label}</Badge>
+                  <p>{predilection.values.join(' · ')}</p>
+                </div>
+              ))}
+            </div>
+          )}
+        </SectionCard>
       </div>
     </div>
   );

--- a/apps/game/src/features/character-sheet/model.test.ts
+++ b/apps/game/src/features/character-sheet/model.test.ts
@@ -366,6 +366,35 @@ describe('character sheet model', () => {
       weakened: true
     });
   });
+
+  it('lists no predilections when the character has none', () => {
+    const view = buildCharacterSheetView({
+      character: sampleCharacter(),
+      inventory: sampleInventory(),
+      mode: 'complete',
+      spells: sampleSpells()
+    });
+
+    expect(view.predilections).toEqual([]);
+  });
+
+  it('surfaces chosen predilection slots in canonical kind order (#140)', () => {
+    const character: Character = {
+      ...sampleCharacter(),
+      predilection: { domaine: ['nature'], arme: ['epee_batarde', 'dague'] }
+    };
+    const view = buildCharacterSheetView({
+      character,
+      inventory: sampleInventory(),
+      mode: 'complete',
+      spells: sampleSpells()
+    });
+
+    expect(view.predilections).toEqual([
+      { kind: 'arme', label: 'Arme de prédilection', values: ['epee_batarde', 'dague'] },
+      { kind: 'domaine', label: 'Domaine de prédilection', values: ['nature'] }
+    ]);
+  });
 });
 
 function sampleCharacter(): Character {

--- a/apps/game/src/features/character-sheet/model.ts
+++ b/apps/game/src/features/character-sheet/model.ts
@@ -5,6 +5,7 @@ import {
   rollDice,
   summarizeEncumbrance,
   summarizeVitalityState,
+  PREDILECTION_KINDS,
   type AttributeKey,
   type Character,
   type CharacterAttributes,
@@ -12,6 +13,7 @@ import {
   type CharacterSkill,
   type DiceRollResult,
   type LevelProgression,
+  type PredilectionKind,
   type RandomInteger,
   type VitalityState
 } from '@knightandwizard/rules-core';
@@ -238,6 +240,12 @@ export interface CharacterEncumbranceView {
   penaltyDT: number;
 }
 
+export interface PredilectionRow {
+  kind: PredilectionKind;
+  label: string;
+  values: string[];
+}
+
 export interface CharacterSheetView {
   attributes: CharacterAttributes;
   carriedWeightKg: number;
@@ -246,10 +254,19 @@ export interface CharacterSheetView {
   equippedWeapons: InventoryItem[];
   levelProgression: LevelProgression;
   mode: CharacterSheetMode;
+  predilections: PredilectionRow[];
   sections: CharacterSheetSection[];
   spellSummary: SpellSlotSummary;
   vitalityState: VitalityState;
 }
+
+const predilectionLabels: Record<PredilectionKind, string> = {
+  animaux: 'Animaux de prédilection',
+  arme: 'Arme de prédilection',
+  domaine: 'Domaine de prédilection',
+  instrument: 'Instrument de prédilection',
+  monture: 'Monture de prédilection'
+};
 
 export interface SpellSlotSummary {
   energyAvailable: number;
@@ -328,10 +345,34 @@ export function buildCharacterSheetView(input: {
     equippedWeapons: input.inventory.filter((item) => item.category === 'weapon' && item.equipped),
     levelProgression: calculateLevelProgression(input.character),
     mode: input.mode,
+    predilections: buildPredilectionRows(input.character),
     sections: sectionsByMode[input.mode].map((id) => ({ id, label: sectionLabels[id] })),
     spellSummary: summarizeSpellSlots(input.character, input.spells),
     vitalityState: summarizeVitalityState(input.character.vitality)
   };
+}
+
+/**
+ * Lists the character's predilection slots (R-6 / #140) for read-only display.
+ * Only kinds with at least one chosen value are surfaced; changing them is an
+ * MJ-validated action routed through the governance pipeline, not edited here.
+ */
+function buildPredilectionRows(character: Character): PredilectionRow[] {
+  const slots = character.predilection;
+
+  if (slots === undefined) {
+    return [];
+  }
+
+  return PREDILECTION_KINDS.flatMap((kind) => {
+    const values = slots[kind];
+
+    if (values === undefined || values.length === 0) {
+      return [];
+    }
+
+    return [{ kind, label: predilectionLabels[kind], values: [...values] }];
+  });
 }
 
 /**


### PR DESCRIPTION
Surface les predilections du personnage (arme/instrument/monture/animaux/domaine) sur la Fiche, en lecture seule, via le module predilection rules-core existant. Affiche uniquement les slots renseignes, en ordre canonique (PREDILECTION_KINDS) ; modifier une predilection reste une action MJ-validee routee par la gouvernance (pipeline A), pas editable ici. Tests : +2 character-sheet (aucune / slots ordonnes) ; typecheck + build:game OK ; pur frontend, aucune source canonique touchee.