### PR TITLE
feat: add session identity join flow

### DIFF
--- a/apps/game/src/app/character/page.tsx
+++ b/apps/game/src/app/character/page.tsx
@@ -9,13 +9,14 @@ import { getCharacterSheetReadModel } from '@/features/character-sheet/read-mode
 export const dynamic = 'force-dynamic';
 
 interface CharacterPageProps {
-  searchParams?: Promise<{ draftId?: string | string[] }>;
+  searchParams?: Promise<{ characterId?: string | string[]; draftId?: string | string[] }>;
 }
 
 export default async function CharacterPage({ searchParams }: Readonly<CharacterPageProps>) {
   const params = await searchParams;
+  const characterId = normalizeSearchParam(params?.characterId);
   const draftId = normalizeSearchParam(params?.draftId);
-  const sheet = await getCharacterSheetReadModel({ draftId });
+  const sheet = await getCharacterSheetReadModel({ characterId, draftId });
 
   return (
     <div className="kw-character-page">

--- a/apps/game/src/app/session/page.tsx
+++ b/apps/game/src/app/session/page.tsx
@@ -1,5 +1,8 @@
 import { SessionManager } from '@/features/session-manager/SessionManager';
-import { getSessionManagerReadModel } from '@/features/session-manager/read-models';
+import {
+  getSessionManagerReadModel,
+  type SessionJoinIdentity
+} from '@/features/session-manager/read-models';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,7 +14,46 @@ export default async function SessionPage({
   const params = await searchParams;
   const rawSlug = params.slug;
   const slug = typeof rawSlug === 'string' && SLUG_PATTERN.test(rawSlug) ? rawSlug : undefined;
-  const readModel = await getSessionManagerReadModel(slug);
+  const readModel = await getSessionManagerReadModel(slug, toSessionJoinIdentity(params));
 
-  return <SessionManager initialState={readModel.initialState} />;
+  return (
+    <SessionManager
+      currentPlayerId={readModel.currentPlayerId}
+      initialState={readModel.initialState}
+    />
+  );
+}
+
+function toSessionJoinIdentity(
+  params: Record<string, string | string[] | undefined>
+): SessionJoinIdentity {
+  const playerId = normalizeSearchParam(params.player);
+  const name = normalizeSearchParam(params.name);
+  const role = normalizeRole(normalizeSearchParam(params.role));
+  const characterId = normalizeSearchParam(params.characterId);
+  const capability = normalizeSearchParam(params.capability);
+
+  return {
+    ...(capability ? { capability } : {}),
+    ...(characterId ? { characterId } : {}),
+    ...(name ? { name } : {}),
+    ...(playerId ? { playerId } : {}),
+    ...(role ? { role } : {})
+  };
+}
+
+function normalizeRole(value: string | undefined): SessionJoinIdentity['role'] | undefined {
+  if (value === 'auto' || value === 'human_gm' || value === 'llm' || value === 'player') {
+    return value;
+  }
+
+  return undefined;
+}
+
+function normalizeSearchParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
 }

--- a/apps/game/src/features/character-sheet/read-models.test.ts
+++ b/apps/game/src/features/character-sheet/read-models.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createPlayerCharacter, type CharacterAttributes } from '@knightandwizard/rules-core';
+
+vi.mock('@/lib/catalogs', () => ({
+  getApiBaseUrl: vi.fn(),
+  getCatalogDocument: vi.fn()
+}));
+
+import { getApiBaseUrl, getCatalogDocument } from '@/lib/catalogs';
 
 import {
   buildEquipmentCatalog,
@@ -7,6 +15,12 @@ import {
   type ProtectionsEquipmentDocument,
   type WeaponsEquipmentDocument
 } from './model.js';
+import { getCharacterSheetReadModel } from './read-models.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 const weapons: WeaponsEquipmentDocument = {
   weapons: [
@@ -97,4 +111,122 @@ describe('character sheet equipment read-model', () => {
 
     expect(inventory.map((item) => item.id)).toEqual(['epee_batarde', 'bouclier_bois']);
   });
+
+  it('loads the current character from the persisted API when characterId is provided', async () => {
+    const character = createPlayerCharacter({
+      attributes: sampleAttributes,
+      classProfile: { id: 'garde', name: 'Garde', orientationId: 'guerrier' },
+      equipment: [{ id: 'epee_batarde', name: 'Epee batarde', quantity: 1 }],
+      id: 'pc-aveline',
+      metadata: { deity: 'Les Trois Flammes', quote: 'La lame engage.' },
+      name: 'Aveline API',
+      orientation: { id: 'guerrier', isMagical: false, name: 'Guerrier' },
+      race: {
+        attributeMax: maxAttributes,
+        category: 20,
+        id: 'humain',
+        name: 'Humain',
+        speedFactor: 2,
+        vitality: 20,
+        willFactor: 2
+      },
+      skills: [
+        { id: 'epee-a-une-main', points: 4 },
+        { id: 'stoicisme', points: 4 },
+        { id: 'commandement', points: 4 },
+        { id: 'observation-du-terrain', points: 4 },
+        { id: 'bouclier', points: 4 }
+      ],
+      spells: []
+    });
+    vi.mocked(getApiBaseUrl).mockReturnValue('http://api.test');
+    vi.mocked(getCatalogDocument).mockImplementation(
+      async (path: string) => catalogDocuments[path]
+    );
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ character, status: 'found' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const readModel = await getCharacterSheetReadModel({ characterId: 'pc-aveline' });
+
+    expect(fetchMock).toHaveBeenCalledWith('http://api.test/characters/pc-aveline', {
+      cache: 'no-store'
+    });
+    expect(readModel.character.id).toBe('pc-aveline');
+    expect(readModel.character.name).toBe('Aveline API');
+    expect(readModel.dataSourceLabel).toBe('Personnage API');
+    expect(readModel.initialInventory.map((item) => item.id)).toEqual(['epee_batarde']);
+  });
 });
+
+const sampleAttributes: CharacterAttributes = {
+  aestheticism: 1,
+  charisma: 2,
+  dexterity: 3,
+  empathy: 1,
+  intelligence: 2,
+  perception: 2,
+  reflexes: 2,
+  stamina: 3,
+  strength: 4
+};
+
+const maxAttributes: CharacterAttributes = {
+  aestheticism: 7,
+  charisma: 7,
+  dexterity: 7,
+  empathy: 7,
+  intelligence: 7,
+  perception: 7,
+  reflexes: 7,
+  stamina: 7,
+  strength: 7
+};
+
+const catalogDocuments: Record<string, unknown> = {
+  'armes.yaml': {
+    weapons: [{ id: 'epee_batarde', name: 'Epee batarde', status: 'active', weight_kg: 2.2 }]
+  },
+  'classes.yaml': {
+    classes: [
+      { id: 'garde', name: 'Garde', orientation_id: 'guerrier', status: 'active' },
+      { id: 'enchanteur', name: 'Enchanteur', orientation_id: 'magicien', status: 'active' }
+    ]
+  },
+  'competences.yaml': {
+    skills: [
+      { id: 'epee-a-une-main', name: 'Epee a une main', status: 'active' },
+      { id: 'stoicisme', name: 'Stoicisme', status: 'active' }
+    ]
+  },
+  'orientations.yaml': {
+    orientations: [
+      { id: 'guerrier', is_magical: false, name: 'Guerrier', status: 'active' },
+      { id: 'magicien', is_magical: true, name: 'Magicien', status: 'active' }
+    ]
+  },
+  'potions.yaml': { potions: [] },
+  'protections.yaml': { armor_pieces: [], shields: [] },
+  'races.yaml': {
+    races: [
+      {
+        attribute_max: maxAttributes,
+        id: 'humain',
+        name: 'Humain',
+        playable: true,
+        speed_factor_base: 2,
+        status: 'active',
+        vitality_base: 20,
+        will_factor_base: 2,
+        xp_category: 20
+      }
+    ]
+  },
+  'spells.yaml': { spells: [] }
+};
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+    status: 200
+  });
+}

--- a/apps/game/src/features/character-sheet/read-models.ts
+++ b/apps/game/src/features/character-sheet/read-models.ts
@@ -52,6 +52,7 @@ export interface CharacterSheetReadModel {
 }
 
 export interface CharacterSheetReadModelOptions {
+  characterId?: string;
   draftId?: string;
 }
 
@@ -69,7 +70,10 @@ export async function getCharacterSheetReadModel(
       getCatalogDocument<ProtectionsCatalogDocument>('protections.yaml'),
       getCatalogDocument<PotionsCatalogDocument>('potions.yaml')
     ]);
-  const draftSnapshot = options.draftId ? await getCharacterDraftSnapshot(options.draftId) : null;
+  const [draftSnapshot, persistedCharacter] = await Promise.all([
+    options.draftId ? getCharacterDraftSnapshot(options.draftId) : null,
+    options.characterId ? getPersistedCharacterSnapshot(options.characterId) : null
+  ]);
   const creationCatalog = buildCharacterCreationCatalogFromReadModels({
     classes,
     orientations,
@@ -80,25 +84,32 @@ export async function getCharacterSheetReadModel(
     spells,
     weapons
   });
-  const character = draftSnapshot
-    ? previewCharacter(fromDraftSnapshot(draftSnapshot), creationCatalog)
-    : buildActiveCharacter({ classes, orientations, races });
+  const character =
+    persistedCharacter ??
+    (draftSnapshot
+      ? previewCharacter(fromDraftSnapshot(draftSnapshot), creationCatalog)
+      : buildActiveCharacter({ classes, orientations, races }));
   const equipmentCatalog = buildEquipmentCatalog({ potions, protections, weapons });
   const skillCatalog = toSkillOptions(skills);
   const skillLabels = Object.fromEntries(skillCatalog.map((skill) => [skill.id, skill.label]));
+  const apiBackedCharacter = persistedCharacter !== null || draftSnapshot !== null;
 
   return {
     attributeLabels,
     attributeOrder: [...ATTRIBUTE_KEYS],
     character,
-    dataSourceLabel: draftSnapshot ? 'Brouillon API' : 'Catalogues API',
+    dataSourceLabel: persistedCharacter
+      ? 'Personnage API'
+      : draftSnapshot
+        ? 'Brouillon API'
+        : 'Catalogues API',
     equipmentCatalog,
-    initialInventory: draftSnapshot
+    initialInventory: apiBackedCharacter
       ? buildInventoryFromCharacterEquipment(character.equipment, equipmentCatalog)
       : buildInventory({ potions, protections, weapons }),
     skillCatalog,
     skillLabels,
-    spells: draftSnapshot ? buildCharacterSpells(character, spells) : buildSpells(spells)
+    spells: apiBackedCharacter ? buildCharacterSpells(character, spells) : buildSpells(spells)
   };
 }
 
@@ -129,6 +140,29 @@ async function getCharacterDraftSnapshot(draftId: string): Promise<DraftSnapshot
 interface CharacterDraftEnvelope extends DraftSnapshot {
   status?: 'found';
   userId?: string;
+}
+
+interface CharacterEnvelope {
+  character: Character;
+  status?: 'found';
+}
+
+async function getPersistedCharacterSnapshot(characterId: string): Promise<Character> {
+  const response = await fetch(`${getApiBaseUrl()}/characters/${encodeURIComponent(characterId)}`, {
+    cache: 'no-store'
+  });
+
+  if (response.status === 404) {
+    throw new Error(`Persisted character ${characterId} not found`);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Unable to load persisted character ${characterId}: HTTP ${response.status}`);
+  }
+
+  const body = (await response.json()) as CharacterEnvelope;
+
+  return body.character;
 }
 
 function buildActiveCharacter(input: {

--- a/apps/game/src/features/session-manager/SessionManager.tsx
+++ b/apps/game/src/features/session-manager/SessionManager.tsx
@@ -47,10 +47,11 @@ const priorityClasses = {
 };
 
 interface SessionManagerProps {
+  currentPlayerId?: string;
   initialState: SessionManagerState;
 }
 
-export function SessionManager({ initialState }: Readonly<SessionManagerProps>) {
+export function SessionManager({ currentPlayerId, initialState }: Readonly<SessionManagerProps>) {
   const [state, setState] = useState(initialState);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
@@ -59,6 +60,10 @@ export function SessionManager({ initialState }: Readonly<SessionManagerProps>) 
     view.rollbackTargets[0]?.sequence.toString() ?? ''
   );
   const busy = pendingAction !== null;
+  const currentPlayer = useMemo(
+    () => state.players.find((player) => player.id === currentPlayerId),
+    [currentPlayerId, state.players]
+  );
 
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -167,6 +172,15 @@ export function SessionManager({ initialState }: Readonly<SessionManagerProps>) 
               <Users aria-hidden="true" className="size-5 text-wine" />
               <h2 className="text-lg font-semibold text-ink">Participants</h2>
             </div>
+            {currentPlayer ? (
+              <p
+                className="mt-3 rounded-md border border-forest/15 bg-forest/8 px-3 py-2 text-sm font-semibold text-forest"
+                data-testid="session-current-identity"
+              >
+                Vous : {currentPlayer.name} · {roleLabel(currentPlayer.role)}
+                {currentPlayer.characterId ? ` · ${currentPlayer.characterId}` : ''}
+              </p>
+            ) : null}
             <ol className="mt-4 grid gap-2">
               {view.playerRows.map((player) => (
                 <li

--- a/apps/game/src/features/session-manager/read-models.test.ts
+++ b/apps/game/src/features/session-manager/read-models.test.ts
@@ -96,6 +96,59 @@ describe('session manager read models', () => {
     expect(readModel.initialState.slug).toBe('brumeval');
     expect(readModel.initialState.events).toEqual([]);
   });
+
+  it('joins the current player identity before rendering the session', async () => {
+    process.env.API_BASE_URL = 'http://api.test';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(sessionSnapshot({ players: [] })))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          session: sessionSnapshot({
+            players: [
+              {
+                characterId: 'pc-aveline',
+                connected: true,
+                id: 'player-aveline',
+                name: 'Aveline API',
+                role: 'player'
+              }
+            ]
+          }),
+          status: 'joined'
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const readModel = await getSessionManagerReadModel('brumeval', {
+      characterId: 'pc-aveline',
+      name: 'Aveline API',
+      playerId: 'player-aveline',
+      role: 'player'
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(2, 'http://api.test/sessions/brumeval/players', {
+      body: JSON.stringify({
+        characterId: 'pc-aveline',
+        name: 'Aveline API',
+        playerId: 'player-aveline',
+        role: 'player'
+      }),
+      cache: 'no-store',
+      headers: { 'content-type': 'application/json' },
+      method: 'POST'
+    });
+    expect(readModel.currentPlayerId).toBe('player-aveline');
+    expect(readModel.initialState.players).toEqual([
+      {
+        characterId: 'pc-aveline',
+        connected: true,
+        id: 'player-aveline',
+        name: 'Aveline API',
+        role: 'player'
+      }
+    ]);
+  });
 });
 
 function jsonResponse(body: unknown): Response {
@@ -103,6 +156,26 @@ function jsonResponse(body: unknown): Response {
     headers: { 'content-type': 'application/json' },
     status: 200
   });
+}
+
+function sessionSnapshot(input: { players: unknown[] }) {
+  return {
+    state: {
+      audit: [],
+      createdAt: '2026-05-26T10:00:00.000Z',
+      decisions: [],
+      events: [],
+      id: 'session-1',
+      metadata: {},
+      mode: 'digital_human_gm',
+      players: input.players,
+      scenes: [],
+      slug: 'brumeval',
+      status: 'active',
+      title: 'Brumeval',
+      updatedAt: '2026-05-26T10:00:00.000Z'
+    }
+  };
 }
 
 function restoreEnv(name: 'API_BASE_URL' | 'NEXT_PUBLIC_API_BASE_URL', value: string | undefined) {

--- a/apps/game/src/features/session-manager/read-models.ts
+++ b/apps/game/src/features/session-manager/read-models.ts
@@ -1,5 +1,6 @@
 import { getApiBaseUrl } from '../../lib/api';
 
+import type { SessionPlayer } from '@knightandwizard/rules-core';
 import {
   DEFAULT_SESSION_SLUG,
   createPersistedSessionPayload,
@@ -9,17 +10,29 @@ import {
 import type { SessionManagerState } from './model';
 
 export interface SessionManagerReadModel {
+  currentPlayerId?: string;
   initialState: SessionManagerState;
 }
 
+export interface SessionJoinIdentity {
+  capability?: string;
+  characterId?: string;
+  name?: string;
+  playerId?: string;
+  role?: SessionPlayer['role'];
+}
+
 export async function getSessionManagerReadModel(
-  slug = DEFAULT_SESSION_SLUG
+  slug = DEFAULT_SESSION_SLUG,
+  identity: SessionJoinIdentity = {}
 ): Promise<SessionManagerReadModel> {
   const baseUrl = getApiBaseUrl();
   const snapshot = await getOrCreateSessionSnapshot(baseUrl, slug);
+  const joinedSnapshot = await joinSessionSnapshot(baseUrl, slug, snapshot, identity);
 
   return {
-    initialState: toSessionManagerState(snapshot)
+    currentPlayerId: identity.playerId,
+    initialState: toSessionManagerState(joinedSnapshot)
   };
 }
 
@@ -58,4 +71,50 @@ async function createSessionSnapshot(
   }
 
   return (await response.json()) as PersistedSessionSnapshot;
+}
+
+async function joinSessionSnapshot(
+  baseUrl: string,
+  slug: string,
+  snapshot: PersistedSessionSnapshot,
+  identity: SessionJoinIdentity
+): Promise<PersistedSessionSnapshot> {
+  const payload = toJoinPayload(identity);
+
+  if (!payload) {
+    return snapshot;
+  }
+
+  const response = await fetch(`${baseUrl}/sessions/${encodeURIComponent(slug)}/players`, {
+    body: JSON.stringify(payload),
+    cache: 'no-store',
+    headers: { 'content-type': 'application/json' },
+    method: 'POST'
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unable to join session ${slug}: HTTP ${response.status}`);
+  }
+
+  const body = (await response.json()) as { session?: PersistedSessionSnapshot };
+
+  return body.session ?? snapshot;
+}
+
+function toJoinPayload(identity: SessionJoinIdentity) {
+  if (!identity.playerId || !identity.name || !identity.role) {
+    return undefined;
+  }
+
+  if (identity.role === 'player' && !identity.characterId) {
+    return undefined;
+  }
+
+  return {
+    ...(identity.capability ? { capability: identity.capability } : {}),
+    ...(identity.characterId ? { characterId: identity.characterId } : {}),
+    name: identity.name,
+    playerId: identity.playerId,
+    role: identity.role
+  };
 }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,6 +1,7 @@
 import Fastify, { type FastifyServerOptions, type FastifyInstance } from 'fastify';
 import { registerCatalogRoutes } from './routes/catalogs.js';
 import { registerCharacterDraftRoutes } from './routes/character-drafts.js';
+import { registerCharacterRoutes } from './routes/characters.js';
 import { registerGameMasterRoutes } from './routes/game-master.js';
 import { registerHealthRoute } from './routes/health.js';
 import { registerReadyRoute } from './routes/ready.js';
@@ -25,6 +26,7 @@ export function buildApp(options: FastifyServerOptions = {}): FastifyInstance {
 
   app.register(registerCatalogRoutes);
   app.register(registerCharacterDraftRoutes);
+  app.register(registerCharacterRoutes);
   app.register(registerGameMasterRoutes);
   app.register(registerHealthRoute);
   app.register(registerReadyRoute);

--- a/apps/server/src/routes/characters.test.ts
+++ b/apps/server/src/routes/characters.test.ts
@@ -1,0 +1,88 @@
+import { randomUUID } from 'node:crypto';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { buildApp } from '../app.js';
+
+const app = buildApp({ logger: false });
+
+beforeAll(async () => {
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+describe('character routes', () => {
+  it('finalizes a saved draft into a persisted character and reads it back by id', async () => {
+    const draftId = `route-character-${randomUUID()}`;
+
+    const saveResponse = await app.inject({
+      method: 'PUT',
+      payload: sampleDraft('Aveline Persistante'),
+      url: `/character-drafts/${draftId}`
+    });
+    const finalizeResponse = await app.inject({
+      method: 'POST',
+      payload: { draftId },
+      url: '/characters/finalize'
+    });
+    const readResponse = await app.inject({
+      method: 'GET',
+      url: `/characters/${draftId}`
+    });
+
+    expect(saveResponse.statusCode).toBe(200);
+    expect(finalizeResponse.statusCode).toBe(201);
+    expect(finalizeResponse.json()).toMatchObject({
+      character: {
+        id: draftId,
+        kind: 'player',
+        name: 'Aveline Persistante'
+      },
+      status: 'finalized'
+    });
+    expect(readResponse.statusCode).toBe(200);
+    expect(readResponse.json()).toEqual({
+      character: finalizeResponse.json().character,
+      status: 'found'
+    });
+  });
+});
+
+function sampleDraft(name: string) {
+  return {
+    currentStep: 'review',
+    payload: {
+      attributes: {
+        aestheticism: 1,
+        charisma: 2,
+        dexterity: 3,
+        empathy: 1,
+        intelligence: 2,
+        perception: 2,
+        reflexes: 2,
+        stamina: 3,
+        strength: 4
+      },
+      background: 'Garde de la porte nord.',
+      classId: 'garde',
+      deity: 'Les Trois Flammes',
+      equipmentIds: ['epee_batarde'],
+      extraSpellPoints: 0,
+      genderId: 'unspecified',
+      name,
+      orientationId: 'guerrier',
+      psychology: 'calme',
+      quote: 'La lame engage.',
+      raceId: 'humain',
+      skills: [
+        { id: 'epee-a-une-main', points: 4 },
+        { id: 'stoicisme', points: 4 },
+        { id: 'commandement', points: 4 },
+        { id: 'observation-du-terrain', points: 4 },
+        { id: 'bouclier', points: 4 }
+      ],
+      spells: []
+    }
+  };
+}

--- a/apps/server/src/routes/characters.ts
+++ b/apps/server/src/routes/characters.ts
@@ -1,0 +1,76 @@
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import {
+  CharacterDraftNotFoundError,
+  CharacterNotFoundError,
+  finalizeCharacterDraft,
+  getPersistedCharacter
+} from '../characters/finalize.js';
+
+interface FinalizeCharacterRequestBody {
+  draftId?: unknown;
+}
+
+interface CharacterParams {
+  id: string;
+}
+
+export async function registerCharacterRoutes(app: FastifyInstance): Promise<void> {
+  app.options('/characters/finalize', async (_request, reply) => reply.code(204).send());
+  app.options('/characters/:id', async (_request, reply) => reply.code(204).send());
+
+  app.post<{ Body: FinalizeCharacterRequestBody }>(
+    '/characters/finalize',
+    async (request, reply) => {
+      const draftId = normalizeOptionalString(request.body?.draftId);
+
+      if (!draftId) {
+        return reply.code(400).send({
+          errors: ['draftId is required'],
+          status: 'invalid'
+        });
+      }
+
+      try {
+        const result = await finalizeCharacterDraft(draftId);
+
+        return reply.code(201).send({
+          character: result.character,
+          status: 'finalized'
+        });
+      } catch (error) {
+        return sendCharacterRouteError(error, reply);
+      }
+    }
+  );
+
+  app.get<{ Params: CharacterParams }>('/characters/:id', async (request, reply) => {
+    try {
+      const result = await getPersistedCharacter(request.params.id);
+
+      return {
+        character: result.character,
+        status: 'found'
+      };
+    } catch (error) {
+      return sendCharacterRouteError(error, reply);
+    }
+  });
+}
+
+function normalizeOptionalString(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function sendCharacterRouteError(error: unknown, reply: FastifyReply) {
+  if (error instanceof CharacterDraftNotFoundError || error instanceof CharacterNotFoundError) {
+    return reply.code(404).send({ status: 'not_found' });
+  }
+
+  throw error;
+}

--- a/apps/server/src/routes/sessions.test.ts
+++ b/apps/server/src/routes/sessions.test.ts
@@ -86,6 +86,67 @@ describe('session routes', () => {
     });
   });
 
+  it('joins a player to a session with a persisted current character and capability link', async () => {
+    const slug = `join-session-${randomUUID()}`;
+    const draftId = `join-character-${randomUUID()}`;
+
+    await app.inject({
+      method: 'PUT',
+      payload: sampleCharacterDraft('Aveline Join'),
+      url: `/character-drafts/${draftId}`
+    });
+    const finalizeResponse = await app.inject({
+      method: 'POST',
+      payload: { draftId },
+      url: '/characters/finalize'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { mode: 'digital_human_gm', slug, status: 'active', title: 'Join API' },
+      url: '/sessions'
+    });
+
+    const joinResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        characterId: finalizeResponse.json().character.id,
+        name: 'Aveline Join',
+        playerId: 'player-aveline',
+        role: 'player'
+      },
+      url: `/sessions/${slug}/players`
+    });
+    const readResponse = await app.inject({ method: 'GET', url: `/sessions/${slug}` });
+
+    expect(joinResponse.statusCode).toBe(200);
+    expect(joinResponse.json()).toMatchObject({
+      join: {
+        playerId: 'player-aveline'
+      },
+      player: {
+        characterId: draftId,
+        connected: true,
+        id: 'player-aveline',
+        name: 'Aveline Join',
+        role: 'player'
+      },
+      status: 'joined'
+    });
+    expect(joinResponse.json().join.href).toEqual(
+      expect.stringContaining(`/session?slug=${slug}&player=player-aveline`)
+    );
+    expect(joinResponse.json().join.capability).toEqual(expect.any(String));
+    expect(readResponse.json().state.players).toMatchObject([
+      {
+        characterId: draftId,
+        connected: true,
+        id: 'player-aveline',
+        name: 'Aveline Join',
+        role: 'player'
+      }
+    ]);
+  });
+
   it('queues and resolves GM decisions with audit-friendly events', async () => {
     const slug = `decision-session-${randomUUID()}`;
 
@@ -481,3 +542,41 @@ describe('session routes', () => {
     });
   });
 });
+
+function sampleCharacterDraft(name: string) {
+  return {
+    currentStep: 'review',
+    payload: {
+      attributes: {
+        aestheticism: 1,
+        charisma: 2,
+        dexterity: 3,
+        empathy: 1,
+        intelligence: 2,
+        perception: 2,
+        reflexes: 2,
+        stamina: 3,
+        strength: 4
+      },
+      background: 'Garde de la porte nord.',
+      classId: 'garde',
+      deity: 'Les Trois Flammes',
+      equipmentIds: ['epee_batarde'],
+      extraSpellPoints: 0,
+      genderId: 'unspecified',
+      name,
+      orientationId: 'guerrier',
+      psychology: 'calme',
+      quote: 'La lame engage.',
+      raceId: 'humain',
+      skills: [
+        { id: 'epee-a-une-main', points: 4 },
+        { id: 'stoicisme', points: 4 },
+        { id: 'commandement', points: 4 },
+        { id: 'observation-du-terrain', points: 4 },
+        { id: 'bouclier', points: 4 }
+      ],
+      spells: []
+    }
+  };
+}

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { FastifyInstance } from 'fastify';
 import {
   type SessionDecision,
@@ -56,6 +57,14 @@ interface RollbackRequestBody {
   targetSequence?: unknown;
 }
 
+interface JoinSessionPlayerRequestBody {
+  capability?: unknown;
+  characterId?: unknown;
+  name?: unknown;
+  playerId?: unknown;
+  role?: unknown;
+}
+
 interface SessionParams {
   slug: string;
 }
@@ -92,6 +101,7 @@ const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 export async function registerSessionRoutes(app: FastifyInstance): Promise<void> {
   app.options('/sessions', async (_request, reply) => reply.code(204).send());
   app.options('/sessions/:slug', async (_request, reply) => reply.code(204).send());
+  app.options('/sessions/:slug/players', async (_request, reply) => reply.code(204).send());
   app.options('/sessions/:slug/events', async (_request, reply) => reply.code(204).send());
   app.options('/sessions/:slug/decisions', async (_request, reply) => reply.code(204).send());
   app.options('/sessions/:slug/decisions/:decisionId/resolve', async (_request, reply) =>
@@ -234,6 +244,146 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
       await sql.end({ timeout: 5 });
     }
   });
+
+  app.post<{ Body: JoinSessionPlayerRequestBody; Params: SessionParams }>(
+    '/sessions/:slug/players',
+    async (request, reply) => {
+      const body = request.body ?? {};
+      const validation = validateJoinSessionPlayerBody(body);
+
+      if (!validation.valid) {
+        return reply.code(400).send({
+          errors: validation.errors,
+          status: 'invalid'
+        });
+      }
+
+      const sql = createSqlClient();
+      const playerId = (body.playerId as string).trim();
+      const name = (body.name as string).trim();
+      const role = (body.role as SessionPlayer['role']).trim() as SessionPlayer['role'];
+      const characterId = isNonEmptyString(body.characterId) ? body.characterId.trim() : undefined;
+      const capability = isNonEmptyString(body.capability) ? body.capability.trim() : randomUUID();
+      const now = new Date().toISOString();
+
+      try {
+        const result = await sql.begin(async (tx) => {
+          const sessionRows = await tx<SessionRow[]>`
+            SELECT id, slug, title, mode, status, metadata, created_at, updated_at
+            FROM game_sessions
+            WHERE slug = ${request.params.slug}
+            FOR UPDATE
+          `;
+          const session = sessionRows[0];
+
+          if (!session) {
+            return { status: 'not_found' as const };
+          }
+
+          if (characterId !== undefined) {
+            const characterRows = await tx<{ id: string }[]>`
+              SELECT id
+              FROM characters
+              WHERE id = ${characterId}
+            `;
+
+            if (characterRows.length === 0) {
+              return { status: 'character_not_found' as const };
+            }
+          }
+
+          const metadata = isRecord(session.metadata) ? { ...session.metadata } : {};
+          const player: SessionPlayer = {
+            connected: true,
+            id: playerId,
+            lastSeenAt: now,
+            name,
+            role
+          };
+
+          if (characterId !== undefined) {
+            player.characterId = characterId;
+          }
+
+          metadata.players = upsertSessionPlayer(toSessionPlayers(metadata.players) ?? [], player);
+          metadata.capabilities = {
+            ...toCapabilityMap(metadata.capabilities),
+            [playerId]: capability
+          };
+
+          const updatedRows = await tx<SessionRow[]>`
+            UPDATE game_sessions
+            SET
+              metadata = ${tx.json(metadata as postgres.JSONValue)}::jsonb,
+              updated_at = now()
+            WHERE id = ${session.id}
+            RETURNING id, slug, title, mode, status, metadata, created_at, updated_at
+          `;
+          const eventRows = await tx<SessionEventRow[]>`
+            SELECT id, session_id, sequence, event_type, actor_id, payload, created_at
+            FROM session_events
+            WHERE session_id = ${session.id}
+            ORDER BY sequence ASC
+          `;
+          const decisionRows = await tx<SessionDecisionRow[]>`
+            SELECT
+              id,
+              session_id,
+              title,
+              requested_by,
+              assigned_to,
+              priority,
+              status,
+              payload,
+              resolution,
+              created_at,
+              resolved_at,
+              updated_at
+            FROM session_decisions
+            WHERE session_id = ${session.id}
+            ORDER BY
+              CASE priority
+                WHEN 'urgent' THEN 4
+                WHEN 'high' THEN 3
+                WHEN 'normal' THEN 2
+                ELSE 1
+              END DESC,
+              created_at ASC
+          `;
+
+          return {
+            capability,
+            decisions: decisionRows,
+            events: eventRows,
+            player,
+            session: updatedRows[0]!,
+            status: 'joined' as const
+          };
+        });
+
+        if (result.status === 'not_found') {
+          return reply.code(404).send({ status: 'not_found' });
+        }
+
+        if (result.status === 'character_not_found') {
+          return reply.code(404).send({ status: 'character_not_found' });
+        }
+
+        return {
+          join: {
+            capability: result.capability,
+            href: buildJoinHref(request.params.slug, result.player.id, result.capability),
+            playerId: result.player.id
+          },
+          player: result.player,
+          session: toSessionResponse(result.session, result.events, result.decisions),
+          status: 'joined'
+        };
+      } finally {
+        await sql.end({ timeout: 5 });
+      }
+    }
+  );
 
   app.post<{ Body: AppendEventRequestBody; Params: SessionParams }>(
     '/sessions/:slug/events',
@@ -879,6 +1029,37 @@ function validateCreateSessionBody(body: CreateSessionRequestBody): ValidationRe
   return { errors, valid: errors.length === 0 };
 }
 
+function validateJoinSessionPlayerBody(body: JoinSessionPlayerRequestBody): ValidationResult {
+  const errors: string[] = [];
+  const role = isNonEmptyString(body.role) ? body.role.trim() : undefined;
+
+  if (!isNonEmptyString(body.playerId)) {
+    errors.push('playerId is required');
+  }
+
+  if (!isNonEmptyString(body.name)) {
+    errors.push('name is required');
+  }
+
+  if (role === undefined || !validControllerRoles.has(role)) {
+    errors.push('role is invalid');
+  }
+
+  if (role === 'player' && !isNonEmptyString(body.characterId)) {
+    errors.push('characterId is required for player role');
+  }
+
+  if (body.characterId !== undefined && !isNonEmptyString(body.characterId)) {
+    errors.push('characterId must be a non-empty string');
+  }
+
+  if (body.capability !== undefined && !isNonEmptyString(body.capability)) {
+    errors.push('capability must be a non-empty string');
+  }
+
+  return { errors, valid: errors.length === 0 };
+}
+
 function validateEventBody(body: AppendEventRequestBody): ValidationResult {
   const errors: string[] = [];
 
@@ -1086,6 +1267,34 @@ function attachLinks(
 
 function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
+}
+
+function upsertSessionPlayer(players: SessionPlayer[], player: SessionPlayer): SessionPlayer[] {
+  const existingIndex = players.findIndex((entry) => entry.id === player.id);
+
+  if (existingIndex === -1) {
+    return [...players, player];
+  }
+
+  return players.map((entry, index) => (index === existingIndex ? { ...entry, ...player } : entry));
+}
+
+function toCapabilityMap(value: unknown): Record<string, string> {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] => isNonEmptyString(entry[0]) && isNonEmptyString(entry[1])
+    )
+  );
+}
+
+function buildJoinHref(slug: string, playerId: string, capability: string): string {
+  return `/session?slug=${encodeURIComponent(slug)}&player=${encodeURIComponent(
+    playerId
+  )}&capability=${encodeURIComponent(capability)}`;
 }
 
 function toSessionResponse(

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -178,6 +178,40 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByText('Niveau 0 · 16 / 20 points')).toBeVisible();
   });
 
+  test('session identity survives reload and opens the persisted current character', async ({
+    page
+  }, testInfo) => {
+    annotateCanonical(testInfo, 'sessionManager');
+
+    const suffix = Date.now().toString();
+    const draftId = `identity-character-${suffix}`;
+    const slug = `identity-session-${suffix}`;
+    const saveResponse = await page.request.put(`${e2eApiBaseUrl}/character-drafts/${draftId}`, {
+      data: savedCharacterDraftPayload('Aveline Identite')
+    });
+    const finalizeResponse = await page.request.post(`${e2eApiBaseUrl}/characters/finalize`, {
+      data: { draftId }
+    });
+
+    expect(saveResponse.ok()).toBe(true);
+    expect(finalizeResponse.ok()).toBe(true);
+
+    await page.goto(
+      `/session?slug=${slug}&player=player-aveline&name=Aveline%20Identite&role=player&characterId=${draftId}`
+    );
+    await expect(page.getByTestId('session-current-identity')).toContainText('Aveline Identite');
+    await expect(page.getByTestId('session-current-identity')).toContainText(draftId);
+    await expect(page.getByText('Aveline Identite', { exact: true })).toBeVisible();
+
+    await page.reload();
+    await expect(page.getByTestId('session-current-identity')).toContainText('Aveline Identite');
+    await expect(page.getByTestId('session-current-identity')).toContainText(draftId);
+
+    await page.goto(`/character?characterId=${draftId}`);
+    await expect(page.getByRole('heading', { name: 'Aveline Identite' })).toBeVisible();
+    await expect(page.getByText('Personnage API')).toBeVisible();
+  });
+
   test('character creation validates fighter and magician creation budgets', async ({
     page
   }, testInfo) => {
@@ -253,9 +287,11 @@ test.describe('K&W player and GM application flows', () => {
   }, testInfo) => {
     annotateCanonical(testInfo, 'sessionManager');
 
-    await page.goto('/session');
+    const slug = `session-flow-${Date.now()}`;
 
-    await expect(page.getByRole('heading', { name: 'Brumeval' })).toBeVisible();
+    await page.goto(`/session?slug=${slug}`);
+
+    await expect(page.getByRole('heading', { name: /Session Flow/ })).toBeVisible();
     await expect(page.getByText('Decisions MJ')).toBeVisible();
 
     await page.getByRole('button', { name: 'RP' }).click();
@@ -294,4 +330,42 @@ async function increaseStepper(page: Page, label: string, times: number): Promis
   for (let index = 0; index < times; index += 1) {
     await page.getByTitle(`Augmenter ${label}`, { exact: true }).click();
   }
+}
+
+function savedCharacterDraftPayload(name: string) {
+  return {
+    currentStep: 'review',
+    payload: {
+      attributes: {
+        aestheticism: 1,
+        charisma: 2,
+        dexterity: 3,
+        empathy: 1,
+        intelligence: 2,
+        perception: 2,
+        reflexes: 2,
+        stamina: 3,
+        strength: 4
+      },
+      background: 'Garde de la porte nord.',
+      classId: 'garde',
+      deity: 'Les Trois Flammes',
+      equipmentIds: ['epee_batarde'],
+      extraSpellPoints: 0,
+      genderId: 'unspecified',
+      name,
+      orientationId: 'guerrier',
+      psychology: 'calme',
+      quote: 'La lame engage.',
+      raceId: 'humain',
+      skills: [
+        { id: 'epee-a-une-main', points: 4 },
+        { id: 'stoicisme', points: 4 },
+        { id: 'commandement', points: 4 },
+        { id: 'observation-du-terrain', points: 4 },
+        { id: 'bouclier', points: 4 }
+      ],
+      spells: []
+    }
+  };
 }


### PR DESCRIPTION
## Summary
- Add REST character finalize/read endpoints around persisted character drafts.
- Add session player join with characterId validation, generated capability and join href.
- Wire session and character pages to load current identity/character via query params, with E2E reload coverage.

## Validation
- pnpm validate

Closes #245