### PR TITLE
feat: make session thread playable

### DIFF
--- a/apps/game/src/features/session-manager/SessionManager.tsx
+++ b/apps/game/src/features/session-manager/SessionManager.tsx
@@ -22,7 +22,7 @@ import { applyLiveSessionEvent, buildSessionManagerView, type SessionManagerStat
 import {
   advancePersistedNarrative,
   appendDiceRollToSession,
-  appendPersistedSessionEvent,
+  appendThreadPostToSession,
   dispelPersistedSpell,
   fetchPersistedSessionState,
   queuePersistedGmDecision,
@@ -55,6 +55,7 @@ export function SessionManager({ currentPlayerId, initialState }: Readonly<Sessi
   const [state, setState] = useState(initialState);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
+  const [postText, setPostText] = useState('');
   const view = useMemo(() => buildSessionManagerView(state), [state]);
   const [rollbackSequence, setRollbackSequence] = useState(
     view.rollbackTargets[0]?.sequence.toString() ?? ''
@@ -64,6 +65,8 @@ export function SessionManager({ currentPlayerId, initialState }: Readonly<Sessi
     () => state.players.find((player) => player.id === currentPlayerId),
     [currentPlayerId, state.players]
   );
+  const currentActorId = currentPlayer?.id ?? 'aveline';
+  const currentActorName = currentPlayer?.name ?? 'Aveline';
 
   const stateRef = useRef(state);
   stateRef.current = state;
@@ -122,6 +125,58 @@ export function SessionManager({ currentPlayerId, initialState }: Readonly<Sessi
   function skipNarrativeTime(by: { days?: number; hours?: number; minutes?: number }) {
     void runPersistedAction('narrative-advance', async (slug) => {
       await advancePersistedNarrative(slug, { actorId: 'gm', by });
+    });
+  }
+
+  function resolvePostText(fallback: string) {
+    const normalized = postText.trim();
+
+    return normalized.length > 0 ? normalized : fallback;
+  }
+
+  function publishThreadPost() {
+    const text = resolvePostText('Aveline precise son intention.');
+
+    void runPersistedAction('thread-post', async (slug) => {
+      await appendThreadPostToSession(slug, {
+        actorId: currentActorId,
+        text
+      });
+      setPostText('');
+    });
+  }
+
+  function publishThreadRoll() {
+    const text = postText.trim();
+
+    void runPersistedAction('dice-roll', async (slug) => {
+      const result = await trpc.dice.roll.mutate({
+        difficulty: 7,
+        pool: 2,
+        reason: 'session-manager'
+      });
+
+      await appendDiceRollToSession(slug, {
+        actorId: currentActorId,
+        postText: text,
+        result: { ...result }
+      });
+      setPostText('');
+    });
+  }
+
+  function requestThreadDecision() {
+    const title = resolvePostText('Valider la consequence narrative');
+
+    void runPersistedAction('gm-decision', async (slug) => {
+      await queuePersistedGmDecision(slug, {
+        assignedTo: 'human_gm',
+        payload: { source: 'session-thread', text: title },
+        priority: 'high',
+        requestedBy: currentActorId,
+        title
+      });
+      setPostText('');
     });
   }
 
@@ -212,57 +267,36 @@ export function SessionManager({ currentPlayerId, initialState }: Readonly<Sessi
         <section className="mt-5 rounded-md border border-ink/10 bg-white/72 p-4">
           <div className="flex items-center gap-2">
             <MessageSquarePlus aria-hidden="true" className="size-5 text-forest" />
-            <h2 className="text-lg font-semibold text-ink">Actions rapides</h2>
+            <h2 className="text-lg font-semibold text-ink">Fil de table</h2>
           </div>
-          <div className="mt-4 grid grid-cols-2 gap-2 sm:grid-cols-4">
+          <label className="mt-4 block text-sm font-semibold text-ink/62" htmlFor="session-post">
+            Message de table
+          </label>
+          <textarea
+            className="mt-2 min-h-24 w-full resize-y rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-medium text-ink outline-none transition focus:border-forest"
+            id="session-post"
+            onChange={(event) => setPostText(event.target.value)}
+            placeholder={`${currentActorName} agit...`}
+            value={postText}
+          />
+          <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-4">
             <ActionButton
               disabled={busy}
               icon={<ScrollText aria-hidden="true" className="size-4" />}
-              label="RP"
-              onClick={() => {
-                void runPersistedAction('player-action', async (slug) => {
-                  await appendPersistedSessionEvent(slug, {
-                    actorId: 'aveline',
-                    eventType: 'player_action',
-                    payload: { text: 'Aveline precise son intention.' }
-                  });
-                });
-              }}
+              label="Publier"
+              onClick={publishThreadPost}
             />
             <ActionButton
               disabled={busy}
               icon={<Dice5 aria-hidden="true" className="size-4" />}
-              label="D10"
-              onClick={() => {
-                void runPersistedAction('dice-roll', async (slug) => {
-                  const result = await trpc.dice.roll.mutate({
-                    difficulty: 7,
-                    pool: 2,
-                    reason: 'session-manager'
-                  });
-
-                  await appendDiceRollToSession(slug, {
-                    actorId: 'aveline',
-                    result: { ...result }
-                  });
-                });
-              }}
+              label="Jeter D10"
+              onClick={publishThreadRoll}
             />
             <ActionButton
               disabled={busy}
               icon={<ShieldAlert aria-hidden="true" className="size-4" />}
-              label="MJ"
-              onClick={() => {
-                void runPersistedAction('gm-decision', async (slug) => {
-                  await queuePersistedGmDecision(slug, {
-                    assignedTo: 'human_gm',
-                    payload: { source: 'session-manager' },
-                    priority: 'high',
-                    requestedBy: 'llm',
-                    title: 'Valider la consequence narrative'
-                  });
-                });
-              }}
+              label="Décision MJ"
+              onClick={requestThreadDecision}
             />
             <ActionButton
               disabled={busy || view.rollbackTargets.length === 0}
@@ -365,6 +399,35 @@ export function SessionManager({ currentPlayerId, initialState }: Readonly<Sessi
       </section>
 
       <div className="grid gap-5">
+        <section className="rounded-md border border-ink/10 bg-white/78 p-5 shadow-sm">
+          <div className="flex items-center gap-2">
+            <ScrollText aria-hidden="true" className="size-5 text-forest" />
+            <h2 className="text-xl font-semibold text-ink">Fil jouable</h2>
+          </div>
+          <ol className="mt-4 grid gap-3">
+            {view.threadRows.length === 0 ? (
+              <li className="rounded-md border border-ink/10 bg-paper p-4 text-sm font-semibold text-ink/58">
+                Fil vide
+              </li>
+            ) : (
+              view.threadRows.map((row) => (
+                <li
+                  className="grid gap-2 rounded-md border border-ink/10 bg-paper p-3"
+                  key={row.id}
+                >
+                  <span className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-semibold text-ink">{row.actorName}</span>
+                    <span className="rounded-sm bg-ink/6 px-2 py-1 text-xs font-semibold uppercase text-ink/52">
+                      {threadKindLabel(row.kind)}
+                    </span>
+                  </span>
+                  <span className="text-sm font-medium leading-6 text-ink/72">{row.detail}</span>
+                </li>
+              ))
+            )}
+          </ol>
+        </section>
+
         <section className="rounded-md border border-ink/10 bg-white/78 p-5 shadow-sm">
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div className="flex items-center gap-2">
@@ -611,6 +674,22 @@ function statusLabel(status: string): string {
   }
 
   return 'Planifiee';
+}
+
+function threadKindLabel(kind: string): string {
+  if (kind === 'roll') {
+    return 'Jet';
+  }
+
+  if (kind === 'decision') {
+    return 'Decision';
+  }
+
+  if (kind === 'rollback') {
+    return 'Rollback';
+  }
+
+  return 'Post';
 }
 
 function roleLabel(role: string): string {

--- a/apps/game/src/features/session-manager/model.test.ts
+++ b/apps/game/src/features/session-manager/model.test.ts
@@ -204,6 +204,76 @@ describe('session manager model', () => {
     ]);
   });
 
+  it('builds a playable table thread with explicit actors, posts, rolls and GM decisions', () => {
+    const state = createSessionManagerState({
+      events: [
+        {
+          actorId: 'aveline',
+          createdAt: '2026-04-30T10:00:00.000Z',
+          id: 'event-post',
+          payload: { kind: 'table_post', text: 'Je fouille la porte.' },
+          sequence: 1,
+          type: 'player_action'
+        },
+        {
+          actorId: 'aveline',
+          createdAt: '2026-04-30T10:01:00.000Z',
+          id: 'event-roll',
+          payload: {
+            difficulty: 7,
+            kind: 'table_roll',
+            postText: 'Je force la serrure.',
+            rolls: [9, 3],
+            successes: 1
+          },
+          sequence: 2,
+          type: 'dice_roll'
+        },
+        {
+          actorId: 'gm',
+          createdAt: '2026-04-30T10:02:00.000Z',
+          id: 'event-decision',
+          payload: {
+            decisionId: 'decision-1',
+            kind: 'table_decision',
+            title: 'Valider le bruit de la serrure'
+          },
+          sequence: 3,
+          type: 'gm_decision_requested'
+        }
+      ],
+      players: samplePlayers()
+    });
+    const view = buildSessionManagerView(state);
+
+    expect(view.threadRows).toEqual([
+      {
+        actorName: 'Aveline',
+        createdAt: '2026-04-30T10:00:00.000Z',
+        detail: 'Je fouille la porte.',
+        id: 'event-post',
+        kind: 'post',
+        sequence: 1
+      },
+      {
+        actorName: 'Aveline',
+        createdAt: '2026-04-30T10:01:00.000Z',
+        detail: 'Je force la serrure. · 1 succes',
+        id: 'event-roll',
+        kind: 'roll',
+        sequence: 2
+      },
+      {
+        actorName: 'MJ',
+        createdAt: '2026-04-30T10:02:00.000Z',
+        detail: 'Valider le bruit de la serrure',
+        id: 'event-decision',
+        kind: 'decision',
+        sequence: 3
+      }
+    ]);
+  });
+
   it('queues and resolves the next GM decision', () => {
     const state = createSessionManagerState();
     const queued = submitGmDecisionRequest(state, 'Valider le discours du PNJ', {

--- a/apps/game/src/features/session-manager/model.ts
+++ b/apps/game/src/features/session-manager/model.ts
@@ -51,6 +51,15 @@ export interface SessionEventRow {
   tone: 'audit' | 'decision' | 'neutral' | 'rules';
 }
 
+export interface SessionThreadRow {
+  actorName: string;
+  createdAt: string;
+  detail: string;
+  id: string;
+  kind: 'decision' | 'post' | 'roll' | 'rollback';
+  sequence: number;
+}
+
 export interface SessionDecisionRow {
   assignedTo: string;
   createdAt: string;
@@ -94,6 +103,7 @@ export interface SessionManagerView {
   recentEvents: SessionEventRow[];
   rollbackTargets: RollbackTargetRow[];
   summaryMetrics: SessionManagerMetric[];
+  threadRows: SessionThreadRow[];
 }
 
 const eventLabels: Record<SessionEventType, string> = {
@@ -174,7 +184,8 @@ export function buildSessionManagerView(state: SessionManagerState): SessionMana
       { label: 'Scenes', value: metrics.scenes },
       { label: 'Evenements', value: metrics.events },
       { label: 'Decisions MJ', value: metrics.pendingDecisions }
-    ]
+    ],
+    threadRows: buildSessionThreadRows(state)
   };
 }
 
@@ -361,6 +372,67 @@ function toEventRow(state: SessionManagerState, event: SessionEvent): SessionEve
   };
 }
 
+function buildSessionThreadRows(state: SessionManagerState): SessionThreadRow[] {
+  return [...state.events]
+    .sort((left, right) => left.sequence - right.sequence)
+    .map((event) => toThreadRow(state, event))
+    .filter((row): row is SessionThreadRow => row !== undefined);
+}
+
+function toThreadRow(
+  state: SessionManagerState,
+  event: SessionEvent
+): SessionThreadRow | undefined {
+  const kind = threadKind(event.type);
+
+  if (!kind) {
+    return undefined;
+  }
+
+  return {
+    actorName: actorName(state, event.actorId),
+    createdAt: event.createdAt,
+    detail: threadDetail(event),
+    id: event.id,
+    kind,
+    sequence: event.sequence
+  };
+}
+
+function threadKind(type: SessionEventType): SessionThreadRow['kind'] | undefined {
+  if (type === 'player_action' || type === 'narration') {
+    return 'post';
+  }
+
+  if (type === 'dice_roll') {
+    return 'roll';
+  }
+
+  if (type === 'gm_decision_requested' || type === 'gm_decision_resolved') {
+    return 'decision';
+  }
+
+  if (type === 'rollback_requested') {
+    return 'rollback';
+  }
+
+  return undefined;
+}
+
+function threadDetail(event: SessionEvent): string {
+  if (event.type === 'dice_roll') {
+    const rollDetail = diceEventDetail(event);
+    const postText =
+      typeof event.payload.postText === 'string' && event.payload.postText.trim().length > 0
+        ? event.payload.postText.trim()
+        : undefined;
+
+    return postText ? `${postText} · ${rollDetail}` : rollDetail;
+  }
+
+  return eventDetail(event);
+}
+
 function eventTone(type: SessionEventType): SessionEventRow['tone'] {
   if (type === 'dice_roll' || type === 'combat' || type === 'gm_ruling') {
     return 'rules';
@@ -395,23 +467,29 @@ function eventDetail(event: SessionEvent): string {
   }
 
   if (typeof event.payload.successes === 'number') {
-    const parts = [`${event.payload.successes} succes`];
-
-    if (event.payload.isCriticalSuccess === true) {
-      parts.push('reussite critique');
-    }
-
-    if (event.payload.isCriticalFailure === true) {
-      const severity = event.payload.criticalFailureSeverity;
-      parts.push(
-        typeof severity === 'number' ? `echec critique D100 ${severity}` : 'echec critique'
-      );
-    }
-
-    return parts.join(' · ');
+    return diceEventDetail(event);
   }
 
   return 'Entree canonique';
+}
+
+function diceEventDetail(event: SessionEvent): string {
+  if (typeof event.payload.successes !== 'number') {
+    return 'Jet de des';
+  }
+
+  const parts = [`${event.payload.successes} succes`];
+
+  if (event.payload.isCriticalSuccess === true) {
+    parts.push('reussite critique');
+  }
+
+  if (event.payload.isCriticalFailure === true) {
+    const severity = event.payload.criticalFailureSeverity;
+    parts.push(typeof severity === 'number' ? `echec critique D100 ${severity}` : 'echec critique');
+  }
+
+  return parts.join(' · ');
 }
 
 function actorName(state: SessionManagerState, actorId: string | undefined): string {

--- a/apps/game/src/features/session-manager/persistence.test.ts
+++ b/apps/game/src/features/session-manager/persistence.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   appendCombatResolutionToSession,
   appendDiceRollToSession,
+  appendThreadPostToSession,
   queuePersistedGmDecision,
   requestPersistedRollback,
   resolvePersistedGmDecision
@@ -16,6 +17,30 @@ afterEach(() => {
 });
 
 describe('session manager persistence', () => {
+  it('appends a table post with an explicit actor', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://browser-api.test';
+    const fetchMock = vi.fn().mockResolvedValue(okJson({ status: 'created' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await appendThreadPostToSession('brumeval', {
+      actorId: 'player-aveline',
+      text: 'Je fouille la porte.'
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('http://browser-api.test/sessions/brumeval/events', {
+      body: JSON.stringify({
+        actorId: 'player-aveline',
+        eventType: 'player_action',
+        payload: {
+          kind: 'table_post',
+          text: 'Je fouille la porte.'
+        }
+      }),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST'
+    });
+  });
+
   it('appends a resolved dice roll as a typed persisted session event', async () => {
     process.env.NEXT_PUBLIC_API_BASE_URL = 'http://browser-api.test';
     const fetchMock = vi.fn().mockResolvedValue(okJson({ status: 'created' }));
@@ -23,6 +48,7 @@ describe('session manager persistence', () => {
 
     await appendDiceRollToSession('brumeval', {
       actorId: 'aveline',
+      postText: 'Je force la serrure.',
       result: {
         difficulty: 7,
         isCriticalFailure: false,
@@ -35,21 +61,26 @@ describe('session manager persistence', () => {
       }
     });
 
-    expect(fetchMock).toHaveBeenCalledWith('http://browser-api.test/sessions/brumeval/events', {
-      body: JSON.stringify({
-        actorId: 'aveline',
-        eventType: 'dice_roll',
-        payload: {
-          difficulty: 7,
-          isCriticalFailure: false,
-          isCriticalSuccess: false,
-          pool: 2,
-          reason: 'session-manager',
-          rolls: [9, 3],
-          status: 'ok',
-          successes: 1
-        }
-      }),
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+
+    expect(url).toBe('http://browser-api.test/sessions/brumeval/events');
+    expect(JSON.parse(init.body as string)).toEqual({
+      actorId: 'aveline',
+      eventType: 'dice_roll',
+      payload: {
+        difficulty: 7,
+        isCriticalFailure: false,
+        isCriticalSuccess: false,
+        kind: 'table_roll',
+        pool: 2,
+        postText: 'Je force la serrure.',
+        reason: 'session-manager',
+        rolls: [9, 3],
+        status: 'ok',
+        successes: 1
+      }
+    });
+    expect(init).toMatchObject({
       headers: { 'content-type': 'application/json' },
       method: 'POST'
     });

--- a/apps/game/src/features/session-manager/persistence.ts
+++ b/apps/game/src/features/session-manager/persistence.ts
@@ -16,7 +16,13 @@ import type { SessionManagerState } from './model';
 
 export interface AppendResolvedEventInput {
   actorId: string;
+  postText?: string;
   result: Record<string, unknown>;
+}
+
+export interface AppendThreadPostInput {
+  actorId: string;
+  text: string;
 }
 
 export interface QueuePersistedGmDecisionInput {
@@ -49,10 +55,32 @@ export async function appendDiceRollToSession(
   slug: string,
   input: AppendResolvedEventInput
 ): Promise<void> {
+  const postText = normalizeOptionalText(input.postText);
+
   await appendPersistedSessionEvent(slug, {
     actorId: input.actorId,
     eventType: 'dice_roll',
-    payload: input.result
+    payload: {
+      ...(postText ? { kind: 'table_roll', postText } : {}),
+      ...input.result
+    }
+  });
+}
+
+export async function appendThreadPostToSession(
+  slug: string,
+  input: AppendThreadPostInput
+): Promise<void> {
+  const text = normalizeOptionalText(input.text);
+
+  if (!text) {
+    return;
+  }
+
+  await appendPersistedSessionEvent(slug, {
+    actorId: input.actorId,
+    eventType: 'player_action',
+    payload: { kind: 'table_post', text }
   });
 }
 
@@ -203,4 +231,10 @@ async function createPersistedSessionSnapshot(slug: string): Promise<PersistedSe
   }
 
   return (await response.json()) as PersistedSessionSnapshot;
+}
+
+function normalizeOptionalText(value: string | undefined): string | undefined {
+  const normalized = value?.trim();
+
+  return normalized && normalized.length > 0 ? normalized : undefined;
 }

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -294,15 +294,18 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByRole('heading', { name: /Session Flow/ })).toBeVisible();
     await expect(page.getByText('Decisions MJ')).toBeVisible();
 
-    await page.getByRole('button', { name: 'RP' }).click();
-    await expect(page.getByText('Aveline precise son intention.')).toBeVisible();
+    await page.getByLabel('Message de table').fill('Aveline precise son intention.');
+    await page.getByRole('button', { name: 'Publier' }).click();
+    await expect(page.getByText('Aveline precise son intention.').first()).toBeVisible();
 
-    await page.getByRole('button', { name: 'D10' }).click();
+    await page.getByLabel('Message de table').fill('Aveline tente un jet.');
+    await page.getByRole('button', { name: 'Jeter D10' }).click();
     // Le de est resolu cote serveur (rng reel) : on verifie qu'un jet est journalise,
     // pas un resultat aleatoire exact.
     await expect(page.getByText(/Jet de d/).first()).toBeVisible();
 
-    await page.getByRole('button', { name: 'MJ' }).click();
+    await page.getByLabel('Message de table').fill('Valider la consequence narrative');
+    await page.getByRole('button', { name: 'Décision MJ' }).click();
     await expect(page.getByText('Valider la consequence narrative').first()).toBeVisible();
 
     await page.getByLabel('Approuver').click();

--- a/tests/e2e/session-multiplayer.spec.ts
+++ b/tests/e2e/session-multiplayer.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from '@playwright/test';
 
+const e2eApiBaseUrl =
+  process.env.E2E_API_URL ?? `http://127.0.0.1:${process.env.E2E_API_PORT ?? '3102'}`;
+
 /**
  * End-to-end proof of "jeu en reseau" (E-C journal -> E-N broadcast -> E-S feed).
  *
@@ -7,9 +10,20 @@ import { expect, test } from '@playwright/test';
  * by one player must appear on the other player's screen with no reload and no action
  * on their side: the only path for that text to reach them is the live WebSocket feed.
  */
-test('two networked players see each other journal actions live', async ({ browser }) => {
+test('two networked players see each other journal actions live', async ({ browser, request }) => {
   const slug = `e2e-net-${Date.now()}`;
-  const url = `/session?slug=${slug}`;
+  const draftId = `e2e-net-character-${Date.now()}`;
+  const saveResponse = await request.put(`${e2eApiBaseUrl}/character-drafts/${draftId}`, {
+    data: savedCharacterDraftPayload('Aveline Reseau')
+  });
+  const finalizeResponse = await request.post(`${e2eApiBaseUrl}/characters/finalize`, {
+    data: { draftId }
+  });
+  const hostUrl = `/session?slug=${slug}&player=gm-e2e&name=MJ%20E2E&role=human_gm`;
+  const guestUrl = `/session?slug=${slug}&player=player-aveline&name=Aveline%20Reseau&role=player&characterId=${draftId}`;
+
+  expect(saveResponse.ok()).toBe(true);
+  expect(finalizeResponse.ok()).toBe(true);
 
   const hostContext = await browser.newContext();
   const guestContext = await browser.newContext();
@@ -17,24 +31,73 @@ test('two networked players see each other journal actions live', async ({ brows
   try {
     // Host creates + loads the room first, so the guest joins an existing session.
     const host = await hostContext.newPage();
-    await host.goto(url);
-    await expect(host.getByRole('button', { name: 'RP' })).toBeVisible();
+    await host.goto(hostUrl);
+    await expect(host.getByRole('button', { name: 'Publier' })).toBeVisible();
 
     // Guest joins; wait until its live feed is actually connected before acting,
     // otherwise a broadcast could fire before the guest is subscribed.
     const guest = await guestContext.newPage();
-    await guest.goto(url);
+    await guest.goto(guestUrl);
     await expect(guest.getByTestId('session-live-status')).toContainText('En direct');
 
-    // Host plays a role-play beat. The guest did nothing: this can only arrive live.
-    await host.getByRole('button', { name: 'RP' }).click();
-    await expect(guest.getByText('Aveline precise son intention.')).toBeVisible();
+    // Host plays a table-thread post. The guest did nothing: this can only arrive live.
+    await host.getByLabel('Message de table').fill('MJ ouvre le fil jouable.');
+    await host.getByRole('button', { name: 'Publier' }).click();
+    await expect(guest.getByText('MJ ouvre le fil jouable.').first()).toBeVisible();
+    await expect(guest.getByText('MJ E2E').first()).toBeVisible();
 
-    // A server-resolved dice roll from the host also propagates live to the guest.
-    await host.getByRole('button', { name: 'D10' }).click();
-    await expect(guest.getByText(/Jet de d/).first()).toBeVisible();
+    // A player dice roll stays attached to the post and also propagates live.
+    await guest.getByLabel('Message de table').fill('Je force la serrure.');
+    await guest.getByRole('button', { name: 'Jeter D10' }).click();
+    await expect(host.getByText(/Je force la serrure\..*succes/).first()).toBeVisible();
+
+    // A GM decision created from the thread is visible to the other client and survives reload.
+    await host.getByLabel('Message de table').fill('Valider le bruit de la serrure');
+    await host.getByRole('button', { name: 'Décision MJ' }).click();
+    await expect(guest.getByText('Valider le bruit de la serrure').first()).toBeVisible();
+    await guest.reload();
+    await expect(guest.getByText('MJ ouvre le fil jouable.').first()).toBeVisible();
+    await expect(guest.getByText('Valider le bruit de la serrure').first()).toBeVisible();
   } finally {
     await hostContext.close();
     await guestContext.close();
   }
 });
+
+function savedCharacterDraftPayload(name: string) {
+  return {
+    currentStep: 'review',
+    payload: {
+      attributes: {
+        aestheticism: 1,
+        charisma: 2,
+        dexterity: 3,
+        empathy: 1,
+        intelligence: 2,
+        perception: 2,
+        reflexes: 2,
+        stamina: 3,
+        strength: 4
+      },
+      background: 'Garde de la porte nord.',
+      classId: 'garde',
+      deity: 'Les Trois Flammes',
+      equipmentIds: ['epee_batarde'],
+      extraSpellPoints: 0,
+      genderId: 'unspecified',
+      name,
+      orientationId: 'guerrier',
+      psychology: 'calme',
+      quote: 'La lame engage.',
+      raceId: 'humain',
+      skills: [
+        { id: 'epee-a-une-main', points: 4 },
+        { id: 'stoicisme', points: 4 },
+        { id: 'commandement', points: 4 },
+        { id: 'observation-du-terrain', points: 4 },
+        { id: 'bouclier', points: 4 }
+      ],
+      spells: []
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Add a playable table thread derived from canonical session events.
- Add explicit actor posting, dice rolls attached to message text, and GM decisions from the thread composer.
- Extend multi-client E2E to cover actor identity, live propagation, decision visibility and reload persistence.

## Validation
- pnpm validate

Closes #247