### PR TITLE
feat: connect combat tracker to sessions

### DIFF
--- a/apps/game/src/app/combat/page.tsx
+++ b/apps/game/src/app/combat/page.tsx
@@ -3,14 +3,34 @@ import { getCombatTrackerReadModel } from '@/features/combat-tracker/read-models
 
 export const dynamic = 'force-dynamic';
 
-export default async function CombatPage() {
-  const readModel = await getCombatTrackerReadModel();
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export default async function CombatPage({
+  searchParams
+}: Readonly<{ searchParams: Promise<Record<string, string | string[] | undefined>> }>) {
+  const params = await searchParams;
+  const slug = normalizeSlug(normalizeSearchParam(params.slug));
+  const characterId = normalizeSearchParam(params.characterId);
+  const readModel = await getCombatTrackerReadModel({ characterId, sessionSlug: slug });
 
   return (
     <CombatTracker
       combatantTemplates={readModel.combatantTemplates}
+      currentCharacterId={characterId}
       initialState={readModel.initialState}
-      sessionSlug="brumeval"
+      sessionSlug={readModel.sessionSlug}
     />
   );
+}
+
+function normalizeSlug(value: string | undefined): string | undefined {
+  return value && SLUG_PATTERN.test(value) ? value : undefined;
+}
+
+function normalizeSearchParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
 }

--- a/apps/game/src/features/character-sheet/CharacterSheet.tsx
+++ b/apps/game/src/features/character-sheet/CharacterSheet.tsx
@@ -108,6 +108,7 @@ export function CharacterSheet({
   );
   const skills = skillTreeRows(character.skills, skillCatalog);
   const trainedSkillCount = skills.filter((skill) => !skill.isImplicitZero).length;
+  const combatStatuses = combatStatusesFromMetadata(character.metadata.combat);
 
   function roll(attribute: AttributeKey) {
     const result = rollAttributeCheck(
@@ -301,6 +302,11 @@ export function CharacterSheet({
                 : `Affaibli · −${view.vitalityState.physicalMalus} Force / Dextérité / Endurance`}
             </Badge>
           ) : null}
+          {combatStatuses.map((status) => (
+            <Badge key={status} tone="warn">
+              {status}
+            </Badge>
+          ))}
           <ProgressBar
             label="Énergie"
             max={character.energy.max}
@@ -635,6 +641,20 @@ function rollTone(result: AttributeRollResult): ToastTone {
   }
 
   return result.isCriticalSuccess ? 'success' : 'info';
+}
+
+function combatStatusesFromMetadata(value: unknown): string[] {
+  if (!isRecord(value) || !Array.isArray(value.statuses)) {
+    return [];
+  }
+
+  return value.statuses
+    .map((status) => (isRecord(status) && typeof status.id === 'string' ? status.id : undefined))
+    .filter((status): status is string => Boolean(status));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function dieKindForRoll(value: number, difficulty: number) {

--- a/apps/game/src/features/combat-tracker/CombatTracker.tsx
+++ b/apps/game/src/features/combat-tracker/CombatTracker.tsx
@@ -38,12 +38,16 @@ import {
   type ToastTone
 } from '@knightandwizard/ui';
 import { trpc } from '@/lib/trpc';
-import { appendCombatResolutionToSession } from '@/features/session-manager/persistence';
+import {
+  appendCombatResolutionToSession,
+  syncCharacterCombatState
+} from '@/features/session-manager/persistence';
 
 import {
   addTrackerCombatant,
   applyTrackerDamage,
   buildCombatTrackerView,
+  combatantMetadata,
   queueTrackerAction,
   removeTrackerCombatant,
   type CombatantTemplate,
@@ -75,12 +79,14 @@ const actionLabels: Record<CombatActionType, string> = {
 
 interface CombatTrackerProps {
   combatantTemplates: CombatantTemplate[];
+  currentCharacterId?: string;
   initialState: CombatState;
   sessionSlug?: string;
 }
 
 export function CombatTracker({
   combatantTemplates,
+  currentCharacterId,
   initialState,
   sessionSlug = 'brumeval'
 }: Readonly<CombatTrackerProps>) {
@@ -111,18 +117,60 @@ export function CombatTracker({
     ? damageTargetId
     : (state.timeline[0]?.id ?? '');
 
+  function persistCombatState(nextState: CombatState, summary: string) {
+    void appendCombatResolutionToSession(sessionSlug, {
+      actorId: 'gm',
+      result: {
+        kind: 'combat_state',
+        state: nextState,
+        summary
+      }
+    }).catch(() => {
+      // Combat can continue locally; the next explicit session reload will reveal persistence errors.
+    });
+    syncCurrentCharacter(nextState);
+  }
+
+  function syncCurrentCharacter(nextState: CombatState) {
+    if (!currentCharacterId) {
+      return;
+    }
+
+    const participant = nextState.timeline.find((combatant) => {
+      const metadata = combatantMetadata(combatant);
+
+      return metadata.characterId === currentCharacterId || combatant.id === currentCharacterId;
+    });
+
+    if (!participant) {
+      return;
+    }
+
+    void syncCharacterCombatState(currentCharacterId, {
+      sessionSlug,
+      statuses: participant.statuses,
+      vitality: participant.vitality
+    }).catch(() => {
+      // The combat journal remains the source of recovery if sheet sync is temporarily unavailable.
+    });
+  }
+
   function queueAction(type: CombatActionType) {
     if (!activeCombatant) {
       return;
     }
 
-    setState((current) =>
-      queueTrackerAction(
+    setState((current) => {
+      const nextState = queueTrackerAction(
         current,
         activeCombatant.id,
         buildAction(type, activeCombatant, effectiveTargetId)
-      )
-    );
+      );
+
+      persistCombatState(nextState, `${activeCombatant.name} declare ${actionLabels[type]}`);
+
+      return nextState;
+    });
   }
 
   function resolveNext() {
@@ -137,12 +185,7 @@ export function CombatTracker({
       .mutate({ state })
       .then((result) => {
         setState(result.state);
-        void appendCombatResolutionToSession(sessionSlug, {
-          actorId: 'gm',
-          result: { ...result }
-        }).catch(() => {
-          // Journal append is best-effort; never block the authoritative result render.
-        });
+        persistCombatState(result.state, 'Resolution combat');
       })
       .catch((error: unknown) => {
         setResolveError(error instanceof Error ? error.message : 'Résolution impossible');
@@ -157,7 +200,13 @@ export function CombatTracker({
       return;
     }
 
-    setState((current) => applyTrackerDamage(current, effectiveDamageTargetId, damage));
+    setState((current) => {
+      const nextState = applyTrackerDamage(current, effectiveDamageTargetId, damage);
+
+      persistCombatState(nextState, `Vitalite ajustee ${damage}`);
+
+      return nextState;
+    });
   }
 
   function addTemplate() {
@@ -167,11 +216,23 @@ export function CombatTracker({
       return;
     }
 
-    setState((current) => addTrackerCombatant(current, withUniqueId(template, current)));
+    setState((current) => {
+      const nextState = addTrackerCombatant(current, withUniqueId(template, current));
+
+      persistCombatState(nextState, `${template.name} rejoint le combat`);
+
+      return nextState;
+    });
   }
 
   function removeCombatant(combatantId: string) {
-    setState((current) => removeTrackerCombatant(current, combatantId));
+    setState((current) => {
+      const nextState = removeTrackerCombatant(current, combatantId);
+
+      persistCombatState(nextState, `${combatantId} quitte le combat`);
+
+      return nextState;
+    });
   }
 
   return (
@@ -469,6 +530,12 @@ function RosterCard({
           <HeartPulse aria-hidden="true" className="kw-combat__badge-icon" />
           {combatant.vitality.current}/{combatant.vitality.max}
         </Badge>
+        {combatant.sourceLabel ? <Badge tone="neutral">{combatant.sourceLabel}</Badge> : null}
+        {combatant.loadoutLabels.map((label) => (
+          <Badge key={label} tone="neutral">
+            {label}
+          </Badge>
+        ))}
         {combatant.statusLabels.map((status) => (
           <Badge key={status} tone={statusTone(status)}>
             {status}
@@ -544,13 +611,19 @@ function logTone(tone: CombatLogRow['tone']): ToastTone {
 }
 
 function buildAction(type: CombatActionType, actor: Combatant, targetId: string): CombatAction {
+  const metadata = combatantMetadata(actor);
+
   if (type === 'attack') {
+    const skillPoints = metadata.attackSkillId
+      ? (actor.skills[metadata.attackSkillId] ?? 0)
+      : strongestSkill(actor);
+
     return {
       attack: {
-        difficulty: 7,
-        pool: actor.attributes.dexterity + strongestSkill(actor)
+        difficulty: metadata.attackDifficulty ?? 7,
+        pool: actor.attributes.dexterity + skillPoints
       },
-      damageOnHit: Math.max(1, Math.round(actor.attributes.strength / 2)),
+      damageOnHit: metadata.damageOnHit ?? Math.max(1, Math.round(actor.attributes.strength / 2)),
       targetId,
       type
     };

--- a/apps/game/src/features/combat-tracker/model.ts
+++ b/apps/game/src/features/combat-tracker/model.ts
@@ -15,7 +15,19 @@ import {
 export type VitalityState = 'critical' | 'dead' | 'healthy' | 'wounded';
 export type CombatLogTone = 'danger' | 'neutral' | 'success' | 'warning';
 
-export interface CombatantTemplate extends Omit<Combatant, 'baseAttributes'> {
+export interface CombatantRuntimeMetadata {
+  attackDifficulty?: number;
+  attackSkillId?: string;
+  characterId?: string;
+  damageOnHit?: number;
+  loadoutLabels?: string[];
+  sourceLabel?: string;
+}
+
+export type TrackedCombatant = Combatant & CombatantRuntimeMetadata;
+
+export interface CombatantTemplate
+  extends Omit<Combatant, 'baseAttributes'>, CombatantRuntimeMetadata {
   baseAttributes?: Combatant['baseAttributes'];
 }
 
@@ -40,7 +52,10 @@ export interface CombatTimelineRow {
 }
 
 export interface CombatRosterRow extends CombatTimelineRow {
+  characterId?: string;
+  loadoutLabels: string[];
   reflexes: number;
+  sourceLabel?: string;
   speedFactor: number;
   vitality: {
     current: number;
@@ -91,7 +106,7 @@ export function createCombatTrackerState(input: CombatTrackerStateInput = {}): C
   );
 }
 
-export function createTrackerCombatant(template: CombatantTemplate): Combatant {
+export function createTrackerCombatant(template: CombatantTemplate): TrackedCombatant {
   const baseAttributes = template.baseAttributes ?? template.attributes;
 
   return {
@@ -168,7 +183,10 @@ export function buildCombatTrackerView(state: CombatState): CombatTrackerView {
     nextActor: timeline[0],
     roster: sortRoster(state.timeline).map((combatant) => ({
       ...toTimelineRow(combatant, state, timeline[0]?.id === combatant.id),
+      characterId: combatantMetadata(combatant).characterId,
+      loadoutLabels: combatantMetadata(combatant).loadoutLabels ?? [],
       reflexes: combatant.reflexes,
+      sourceLabel: combatantMetadata(combatant).sourceLabel,
       speedFactor: combatant.speedFactor,
       vitality: { ...combatant.vitality }
     })),
@@ -258,6 +276,10 @@ function toTimelineRow(
     vitalityPercent: vitalityPercent(combatant),
     vitalityState: vitalityState(combatant)
   };
+}
+
+export function combatantMetadata(combatant: Combatant): CombatantRuntimeMetadata {
+  return combatant as TrackedCombatant;
 }
 
 function actionIntent(action: CombatAction | undefined): string {

--- a/apps/game/src/features/combat-tracker/read-models.test.ts
+++ b/apps/game/src/features/combat-tracker/read-models.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Character, CombatState } from '@knightandwizard/rules-core';
+
+import { getCombatTrackerReadModel } from './read-models.js';
+
+const originalApiBaseUrl = process.env.API_BASE_URL;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  restoreEnv('API_BASE_URL', originalApiBaseUrl);
+});
+
+describe('combat tracker read models', () => {
+  it('resumes the latest combat state from the session journal', async () => {
+    process.env.API_BASE_URL = 'http://api.test';
+    const persistedState = combatState({ currentVitality: 7 });
+    vi.stubGlobal('fetch', fetchForReadModel({ combatState: persistedState }));
+
+    const readModel = await getCombatTrackerReadModel({
+      characterId: 'pc-aveline',
+      sessionSlug: 'brumeval'
+    });
+
+    expect(readModel.sessionSlug).toBe('brumeval');
+    expect(readModel.initialState).toMatchObject({
+      currentDT: 6,
+      timeline: [
+        {
+          id: 'pc-aveline',
+          name: 'Aveline API',
+          vitality: { current: 7, max: 20 }
+        }
+      ]
+    });
+  });
+
+  it('seeds a new combat from the persisted character and available bestiary templates', async () => {
+    process.env.API_BASE_URL = 'http://api.test';
+    vi.stubGlobal('fetch', fetchForReadModel());
+
+    const readModel = await getCombatTrackerReadModel({
+      characterId: 'pc-aveline',
+      sessionSlug: 'brumeval'
+    });
+
+    expect(readModel.initialState.timeline[0]).toMatchObject({
+      id: 'pc-aveline',
+      name: 'Aveline API',
+      vitality: { current: 20, max: 20 }
+    });
+    expect(readModel.combatantTemplates[0]).toMatchObject({
+      characterId: 'pc-aveline',
+      id: 'pc-aveline',
+      loadoutLabels: ['Épée bâtarde'],
+      sourceLabel: 'PJ'
+    });
+    expect(
+      readModel.combatantTemplates.some((combatant) => combatant.sourceLabel === 'Bestiaire')
+    ).toBe(true);
+  });
+});
+
+function fetchForReadModel(input: { combatState?: CombatState } = {}) {
+  return vi.fn(async (url: string | URL | Request) => {
+    const href = String(url);
+
+    if (href === 'http://api.test/sessions/brumeval') {
+      return jsonResponse({
+        createdAt: '2026-05-29T08:00:00.000Z',
+        events: input.combatState
+          ? [
+              {
+                actorId: 'gm',
+                createdAt: '2026-05-29T08:01:00.000Z',
+                eventType: 'combat',
+                id: 'event-combat-1',
+                payload: {
+                  kind: 'combat_state',
+                  state: input.combatState
+                },
+                sequence: 1
+              }
+            ]
+          : [],
+        id: 'session-1',
+        metadata: {},
+        mode: 'digital_human_gm',
+        slug: 'brumeval',
+        status: 'active',
+        title: 'Brumeval',
+        updatedAt: '2026-05-29T08:01:00.000Z'
+      });
+    }
+
+    if (href === 'http://api.test/catalogs/bestiaire.yaml') {
+      return jsonResponse({
+        catalog: {
+          document: {
+            creatures: [{ id: 'squelette', name: 'Squelette', status: 'active' }]
+          }
+        },
+        status: 'found'
+      });
+    }
+
+    if (href === 'http://api.test/catalogs/armes.yaml') {
+      return jsonResponse({
+        catalog: {
+          document: {
+            weapons: [
+              {
+                damage_formula: 'F+6',
+                difficulty: 8,
+                id: 'epee_batarde',
+                name: 'Épée bâtarde',
+                status: 'active'
+              }
+            ]
+          }
+        },
+        status: 'found'
+      });
+    }
+
+    if (href === 'http://api.test/characters/pc-aveline') {
+      return jsonResponse({
+        character: sampleCharacter(),
+        status: 'found'
+      });
+    }
+
+    return new Response(JSON.stringify({ status: 'not_found' }), { status: 404 });
+  });
+}
+
+function combatState(input: { currentVitality: number }): CombatState {
+  return {
+    currentDT: 6,
+    log: [],
+    round: 1,
+    timeline: [
+      {
+        attributes: { dexterity: 3, stamina: 3, strength: 4 },
+        baseAttributes: { dexterity: 3, stamina: 3, strength: 4 },
+        id: 'pc-aveline',
+        name: 'Aveline API',
+        nextActionAt: 11,
+        reflexes: 2,
+        skills: { epee_batarde: 4 },
+        speedFactor: 5,
+        statuses: [{ id: 'bleeding' }],
+        vitality: { current: input.currentVitality, max: 20 }
+      }
+    ]
+  };
+}
+
+function sampleCharacter(): Character {
+  return {
+    attributes: {
+      aestheticism: 1,
+      charisma: 2,
+      dexterity: 3,
+      empathy: 1,
+      intelligence: 2,
+      perception: 2,
+      reflexes: 2,
+      stamina: 3,
+      strength: 4
+    },
+    classProfile: {
+      id: 'garde',
+      name: 'Garde',
+      orientationId: 'guerrier',
+      primarySkillIds: ['epee_batarde']
+    },
+    energy: { current: 0, max: 0 },
+    equipment: [{ id: 'epee_batarde', name: 'Épée bâtarde' }],
+    id: 'pc-aveline',
+    kind: 'player',
+    metadata: {},
+    modifiers: [],
+    name: 'Aveline API',
+    orientation: { id: 'guerrier', name: 'Guerrier' },
+    progression: { experiencePoints: 0, experienceTotal: 0, questPoints: 0 },
+    race: {
+      attributeMax: {
+        aestheticism: 8,
+        charisma: 8,
+        dexterity: 8,
+        empathy: 8,
+        intelligence: 8,
+        perception: 8,
+        reflexes: 8,
+        stamina: 8,
+        strength: 8
+      },
+      category: 20,
+      id: 'humain',
+      name: 'Humain',
+      speedFactor: 5,
+      vitality: 20,
+      willFactor: 5
+    },
+    rulesVersion: 1,
+    skills: [{ id: 'epee_batarde', points: 4 }],
+    speedFactor: 5,
+    spells: [],
+    vitality: { current: 20, max: 20 },
+    willFactor: 5
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { 'content-type': 'application/json' },
+    status: 200
+  });
+}
+
+function restoreEnv(name: 'API_BASE_URL', value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+}

--- a/apps/game/src/features/combat-tracker/read-models.ts
+++ b/apps/game/src/features/combat-tracker/read-models.ts
@@ -1,6 +1,7 @@
-import type { CombatState } from '@knightandwizard/rules-core';
+import { toCombatant, type Character, type CombatState } from '@knightandwizard/rules-core';
 
-import { getCatalogDocument } from '@/lib/catalogs';
+import { getApiBaseUrl, getCatalogDocument } from '../../lib/catalogs';
+import type { PersistedSessionSnapshot } from '../session-manager/session-api';
 
 import { createCombatTrackerState, type CombatantTemplate } from './model';
 
@@ -8,46 +9,92 @@ interface BestiaryCatalogDocument {
   creatures?: Array<{ id?: string; name?: string; status?: string }>;
 }
 
+interface WeaponCatalogEntry {
+  damage_formula?: string;
+  difficulty?: number;
+  id?: string;
+  name?: string;
+  status?: string;
+}
+
+interface WeaponsCatalogDocument {
+  weapons?: WeaponCatalogEntry[];
+}
+
 export interface CombatTrackerReadModel {
   combatantTemplates: CombatantTemplate[];
   initialState: CombatState;
+  sessionSlug: string;
 }
 
-export async function getCombatTrackerReadModel(): Promise<CombatTrackerReadModel> {
-  const bestiary = await getCatalogDocument<BestiaryCatalogDocument>('bestiaire.yaml');
-  const combatantTemplates = buildCombatantTemplates(bestiary);
+export interface CombatTrackerReadModelOptions {
+  characterId?: string;
+  sessionSlug?: string;
+}
+
+export async function getCombatTrackerReadModel(
+  options: CombatTrackerReadModelOptions = {}
+): Promise<CombatTrackerReadModel> {
+  const sessionSlug = options.sessionSlug ?? 'brumeval';
+  const [bestiary, weapons, session, character] = await Promise.all([
+    getCatalogDocument<BestiaryCatalogDocument>('bestiaire.yaml'),
+    getCatalogDocument<WeaponsCatalogDocument>('armes.yaml'),
+    options.sessionSlug ? getPersistedSessionSnapshot(sessionSlug) : null,
+    options.characterId ? getPersistedCharacterSnapshot(options.characterId) : null
+  ]);
+  const combatantTemplates = buildCombatantTemplates(bestiary, {
+    character,
+    weapons
+  });
+  const journalState = latestCombatStateFromSession(session);
 
   return {
     combatantTemplates,
-    initialState: createCombatTrackerState({
-      combatants: combatantTemplates.slice(0, 3),
-      currentDT: 1
-    })
+    initialState:
+      journalState ??
+      createCombatTrackerState({
+        combatants: combatantTemplates.slice(0, 3),
+        currentDT: 1
+      }),
+    sessionSlug
   };
 }
 
-export function buildCombatantTemplates(bestiary: BestiaryCatalogDocument): CombatantTemplate[] {
+export function buildCombatantTemplates(
+  bestiary: BestiaryCatalogDocument,
+  options: { character?: Character | null; weapons?: WeaponsCatalogDocument } = {}
+): CombatantTemplate[] {
   const skeletonName =
     bestiary.creatures?.find((creature) => creature.id === 'squelette')?.name ?? 'Squelette';
+  const characterCombatant = options.character
+    ? [toPlayerCombatantTemplate(options.character, options.weapons ?? {})]
+    : [];
+  const demoAveline: CombatantTemplate[] = options.character
+    ? []
+    : [
+        {
+          attributes: { dexterity: 5, stamina: 4, strength: 4 },
+          id: 'aveline',
+          name: 'Aveline',
+          nextActionAt: 6,
+          pendingAction: {
+            attack: { difficulty: 7, pool: 7 },
+            damageOnHit: 3,
+            targetId: 'brigand',
+            type: 'attack'
+          },
+          reflexes: 4,
+          skills: { 'epee-batarde': 3, bouclier: 2 },
+          sourceLabel: 'Démo',
+          speedFactor: 5,
+          statuses: [],
+          vitality: { current: 24, max: 24 }
+        }
+      ];
 
   return [
-    {
-      attributes: { dexterity: 5, stamina: 4, strength: 4 },
-      id: 'aveline',
-      name: 'Aveline',
-      nextActionAt: 6,
-      pendingAction: {
-        attack: { difficulty: 7, pool: 7 },
-        damageOnHit: 3,
-        targetId: 'brigand',
-        type: 'attack'
-      },
-      reflexes: 4,
-      skills: { 'epee-batarde': 3, bouclier: 2 },
-      speedFactor: 5,
-      statuses: [],
-      vitality: { current: 24, max: 24 }
-    },
+    ...characterCombatant,
+    ...demoAveline,
     {
       attributes: { dexterity: 4, stamina: 4, strength: 5 },
       id: 'brigand',
@@ -55,6 +102,7 @@ export function buildCombatantTemplates(bestiary: BestiaryCatalogDocument): Comb
       nextActionAt: 8,
       reflexes: 3,
       skills: { hache: 2, esquive: 2 },
+      sourceLabel: 'PNJ',
       speedFactor: 7,
       statuses: [{ id: 'bleeding', durationDT: 10 }],
       vitality: { current: 13, max: 18 }
@@ -67,6 +115,7 @@ export function buildCombatantTemplates(bestiary: BestiaryCatalogDocument): Comb
       pendingAction: { costDT: 8, type: 'spell' },
       reflexes: 2,
       skills: { arcana: 4, rituals: 2 },
+      sourceLabel: 'PNJ',
       speedFactor: 8,
       statuses: [],
       vitality: { current: 16, max: 16 }
@@ -79,6 +128,7 @@ export function buildCombatantTemplates(bestiary: BestiaryCatalogDocument): Comb
       nextActionAt: 0,
       reflexes: 1,
       skills: { claws: 2 },
+      sourceLabel: 'Bestiaire',
       speedFactor: 9,
       statuses: [],
       vitality: { current: 10, max: 10 }
@@ -88,4 +138,113 @@ export function buildCombatantTemplates(bestiary: BestiaryCatalogDocument): Comb
 
 function cleanCreatureName(name: string): string {
   return name.replace(/,\s*-.*/, '').trim();
+}
+
+function toPlayerCombatantTemplate(
+  character: Character,
+  weapons: WeaponsCatalogDocument
+): CombatantTemplate {
+  const combatant = toCombatant(character);
+  const equippedWeapons = character.equipment
+    .map((item) => weapons.weapons?.find((weapon) => weapon.id === item.id))
+    .filter((weapon): weapon is WeaponCatalogEntry => Boolean(weapon?.id && weapon.name));
+  const primaryWeapon = equippedWeapons[0];
+  const damageOnHit = parseDamageBonus(primaryWeapon?.damage_formula);
+
+  return {
+    ...combatant,
+    attackDifficulty: primaryWeapon?.difficulty,
+    attackSkillId: preferredAttackSkillId(character, primaryWeapon),
+    characterId: character.id,
+    damageOnHit,
+    loadoutLabels: equippedWeapons.map((weapon) => weapon.name as string),
+    sourceLabel: 'PJ'
+  };
+}
+
+async function getPersistedSessionSnapshot(slug: string): Promise<PersistedSessionSnapshot | null> {
+  const response = await fetch(`${getApiBaseUrl()}/sessions/${encodeURIComponent(slug)}`, {
+    cache: 'no-store'
+  });
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error(`Unable to load session ${slug}: HTTP ${response.status}`);
+  }
+
+  return (await response.json()) as PersistedSessionSnapshot;
+}
+
+async function getPersistedCharacterSnapshot(characterId: string): Promise<Character> {
+  const response = await fetch(`${getApiBaseUrl()}/characters/${encodeURIComponent(characterId)}`, {
+    cache: 'no-store'
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unable to load character ${characterId}: HTTP ${response.status}`);
+  }
+
+  const body = (await response.json()) as { character: Character };
+
+  return body.character;
+}
+
+function latestCombatStateFromSession(
+  session: PersistedSessionSnapshot | null
+): CombatState | null {
+  const events = session?.events ?? [];
+
+  for (const event of [...events].reverse()) {
+    const type = 'eventType' in event ? event.eventType : event.type;
+
+    if (type !== 'combat') {
+      continue;
+    }
+
+    const state = isRecord(event.payload) ? event.payload.state : undefined;
+
+    if (isCombatState(state)) {
+      return state;
+    }
+  }
+
+  return null;
+}
+
+function isCombatState(value: unknown): value is CombatState {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.timeline) &&
+    Number.isInteger(value.currentDT) &&
+    Number.isInteger(value.round) &&
+    Array.isArray(value.log)
+  );
+}
+
+function preferredAttackSkillId(
+  character: Character,
+  primaryWeapon: WeaponCatalogEntry | undefined
+): string | undefined {
+  const equipmentSkill = primaryWeapon?.id
+    ? character.skills.find((skill) => skill.id === primaryWeapon.id)
+    : undefined;
+
+  return equipmentSkill?.id ?? [...character.skills].sort((a, b) => b.points - a.points)[0]?.id;
+}
+
+function parseDamageBonus(formula: string | undefined): number | undefined {
+  if (!formula) {
+    return undefined;
+  }
+
+  const match = formula.match(/F\+(\d+)/);
+
+  return match ? Number.parseInt(match[1]!, 10) : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/apps/game/src/features/session-manager/SessionManager.tsx
+++ b/apps/game/src/features/session-manager/SessionManager.tsx
@@ -228,13 +228,23 @@ export function SessionManager({ currentPlayerId, initialState }: Readonly<Sessi
               <h2 className="text-lg font-semibold text-ink">Participants</h2>
             </div>
             {currentPlayer ? (
-              <p
+              <div
                 className="mt-3 rounded-md border border-forest/15 bg-forest/8 px-3 py-2 text-sm font-semibold text-forest"
                 data-testid="session-current-identity"
               >
-                Vous : {currentPlayer.name} · {roleLabel(currentPlayer.role)}
-                {currentPlayer.characterId ? ` · ${currentPlayer.characterId}` : ''}
-              </p>
+                <span>
+                  Vous : {currentPlayer.name} · {roleLabel(currentPlayer.role)}
+                  {currentPlayer.characterId ? ` · ${currentPlayer.characterId}` : ''}
+                </span>
+                {currentPlayer.characterId ? (
+                  <a
+                    className="ml-3 inline-flex rounded-sm bg-forest px-2 py-1 text-xs font-semibold text-white"
+                    href={combatHref(state.slug, currentPlayer.characterId)}
+                  >
+                    Ouvrir combat
+                  </a>
+                ) : null}
+              </div>
             ) : null}
             <ol className="mt-4 grid gap-2">
               {view.playerRows.map((player) => (
@@ -706,4 +716,8 @@ function roleLabel(role: string): string {
   }
 
   return 'Joueur';
+}
+
+function combatHref(slug: string, characterId: string): string {
+  return `/combat?slug=${encodeURIComponent(slug)}&characterId=${encodeURIComponent(characterId)}`;
 }

--- a/apps/game/src/features/session-manager/persistence.test.ts
+++ b/apps/game/src/features/session-manager/persistence.test.ts
@@ -6,7 +6,8 @@ import {
   appendThreadPostToSession,
   queuePersistedGmDecision,
   requestPersistedRollback,
-  resolvePersistedGmDecision
+  resolvePersistedGmDecision,
+  syncCharacterCombatState
 } from './persistence.js';
 
 const originalPublicApiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
@@ -121,6 +122,31 @@ describe('session manager persistence', () => {
       headers: { 'content-type': 'application/json' },
       method: 'POST'
     });
+  });
+
+  it('syncs a combat participant back to the persisted character sheet', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://browser-api.test';
+    const fetchMock = vi.fn().mockResolvedValue(okJson({ status: 'updated' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await syncCharacterCombatState('pc-aveline', {
+      sessionSlug: 'brumeval',
+      statuses: [{ id: 'bleeding' }],
+      vitality: { current: 9, max: 20 }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://browser-api.test/characters/pc-aveline/combat-state',
+      {
+        body: JSON.stringify({
+          sessionSlug: 'brumeval',
+          statuses: [{ id: 'bleeding' }],
+          vitality: { current: 9, max: 20 }
+        }),
+        headers: { 'content-type': 'application/json' },
+        method: 'PATCH'
+      }
+    );
   });
 
   it('persists GM decision queue, resolution and rollback requests through journal routes', async () => {

--- a/apps/game/src/features/session-manager/persistence.ts
+++ b/apps/game/src/features/session-manager/persistence.ts
@@ -1,4 +1,6 @@
 import type {
+  CombatStatus,
+  CombatVitality,
   SessionControllerRole,
   SessionDecisionPriority,
   SessionDecisionStatus,
@@ -43,6 +45,12 @@ export interface RequestPersistedRollbackInput {
   actorId: string;
   reason: string;
   targetSequence: number;
+}
+
+export interface SyncCharacterCombatStateInput {
+  sessionSlug?: string;
+  statuses?: CombatStatus[];
+  vitality?: CombatVitality;
 }
 
 export async function fetchPersistedSessionState(slug: string): Promise<SessionManagerState> {
@@ -93,6 +101,27 @@ export async function appendCombatResolutionToSession(
     eventType: 'combat',
     payload: input.result
   });
+}
+
+export async function syncCharacterCombatState(
+  characterId: string,
+  input: SyncCharacterCombatStateInput
+): Promise<void> {
+  const baseUrl = getClientApiBaseUrl();
+  const response = await fetch(
+    `${baseUrl}/characters/${encodeURIComponent(characterId)}/combat-state`,
+    {
+      body: JSON.stringify(input),
+      headers: { 'content-type': 'application/json' },
+      method: 'PATCH'
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Unable to sync character combat state for ${characterId}: HTTP ${response.status}`
+    );
+  }
 }
 
 export async function appendPersistedSessionEvent(

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -16,7 +16,7 @@ export function buildApp(options: FastifyServerOptions = {}): FastifyInstance {
     const origin = request.headers.origin ?? '*';
 
     reply.header('access-control-allow-origin', origin);
-    reply.header('access-control-allow-methods', 'GET,PUT,POST,OPTIONS');
+    reply.header('access-control-allow-methods', 'GET,PUT,POST,PATCH,OPTIONS');
     reply.header('access-control-allow-headers', 'content-type,authorization');
 
     if (request.method === 'OPTIONS') {

--- a/apps/server/src/characters/finalize.ts
+++ b/apps/server/src/characters/finalize.ts
@@ -18,6 +18,7 @@ import {
   type CharacterOrientationProfile,
   type CharacterSkill,
   type CharacterSpell,
+  type CombatStatus,
   type RaceProfile
 } from '@knightandwizard/rules-core';
 import { eq, sql as drizzleSql } from 'drizzle-orm';
@@ -41,6 +42,15 @@ export class CharacterNotFoundError extends Error {
 
 export interface CharacterPersistenceResult {
   character: Character;
+}
+
+export interface CharacterCombatStateUpdate {
+  sessionSlug?: string;
+  statuses?: CombatStatus[];
+  vitality?: {
+    current?: number;
+    max?: number;
+  };
 }
 
 interface CharacterCreationCatalog {
@@ -218,6 +228,65 @@ export async function getPersistedCharacter(id: string): Promise<CharacterPersis
   }
 }
 
+export async function updatePersistedCharacterCombatState(
+  id: string,
+  input: CharacterCombatStateUpdate
+): Promise<CharacterPersistenceResult> {
+  const sql = createSqlClient();
+  const db = createDbClient(sql);
+
+  try {
+    const rows = await db
+      .select({ character: characters.payload })
+      .from(characters)
+      .where(eq(characters.id, id))
+      .limit(1);
+    const row = rows[0];
+
+    if (row === undefined) {
+      throw new CharacterNotFoundError(id);
+    }
+
+    const now = new Date().toISOString();
+    const vitality = input.vitality
+      ? {
+          current: clampResource(
+            input.vitality.current ?? row.character.vitality.current,
+            input.vitality.max ?? row.character.vitality.max
+          ),
+          max: Math.max(1, input.vitality.max ?? row.character.vitality.max)
+        }
+      : row.character.vitality;
+    const character: Character = {
+      ...row.character,
+      metadata: {
+        ...row.character.metadata,
+        combat: {
+          ...(isRecord(row.character.metadata.combat) ? row.character.metadata.combat : {}),
+          ...(input.sessionSlug ? { sessionSlug: input.sessionSlug } : {}),
+          ...(input.statuses ? { statuses: input.statuses.map((status) => ({ ...status })) } : {}),
+          updatedAt: now
+        }
+      },
+      vitality
+    };
+    const updatedRows = await db
+      .update(characters)
+      .set({
+        payload: character,
+        updatedAt: drizzleSql`now()`
+      })
+      .where(eq(characters.id, id))
+      .returning({ character: characters.payload });
+
+    return {
+      character: updatedRows[0]!.character
+    };
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
 async function loadCharacterCreationCatalog(): Promise<CharacterCreationCatalog> {
   const [races, orientations, classes, weapons, protections, potions] = await Promise.all([
     loadValidatedCatalog('races.yaml'),
@@ -234,6 +303,14 @@ async function loadCharacterCreationCatalog(): Promise<CharacterCreationCatalog>
     orientations: toOrientationProfiles(orientations),
     races: toRaceProfiles(races)
   };
+}
+
+function clampResource(current: number, max: number): number {
+  return Math.min(Math.max(0, current), Math.max(1, max));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function buildCharacterFromDraft(

--- a/apps/server/src/routes/characters.test.ts
+++ b/apps/server/src/routes/characters.test.ts
@@ -47,6 +47,58 @@ describe('character routes', () => {
       status: 'found'
     });
   });
+
+  it('updates persisted combat vitality and statuses for the character sheet', async () => {
+    const draftId = `route-combat-character-${randomUUID()}`;
+
+    await app.inject({
+      method: 'PUT',
+      payload: sampleDraft('Aveline Combattante'),
+      url: `/character-drafts/${draftId}`
+    });
+    const finalizeResponse = await app.inject({
+      method: 'POST',
+      payload: { draftId },
+      url: '/characters/finalize'
+    });
+    const finalizedCharacter = finalizeResponse.json().character;
+    const nextVitality = finalizedCharacter.vitality.max - 5;
+    const updateResponse = await app.inject({
+      method: 'PATCH',
+      payload: {
+        sessionSlug: 'mvp-combat',
+        statuses: [{ durationDT: 8, id: 'bleeding' }],
+        vitality: { current: nextVitality }
+      },
+      url: `/characters/${draftId}/combat-state`
+    });
+    const readResponse = await app.inject({
+      method: 'GET',
+      url: `/characters/${draftId}`
+    });
+
+    expect(updateResponse.statusCode).toBe(200);
+    expect(updateResponse.json()).toMatchObject({
+      character: {
+        id: draftId,
+        metadata: {
+          combat: {
+            sessionSlug: 'mvp-combat',
+            statuses: [{ durationDT: 8, id: 'bleeding' }]
+          }
+        },
+        vitality: {
+          current: nextVitality,
+          max: finalizedCharacter.vitality.max
+        }
+      },
+      status: 'updated'
+    });
+    expect(readResponse.json().character.vitality.current).toBe(nextVitality);
+    expect(readResponse.json().character.metadata.combat.statuses).toEqual([
+      { durationDT: 8, id: 'bleeding' }
+    ]);
+  });
 });
 
 function sampleDraft(name: string) {

--- a/apps/server/src/routes/characters.ts
+++ b/apps/server/src/routes/characters.ts
@@ -3,11 +3,19 @@ import {
   CharacterDraftNotFoundError,
   CharacterNotFoundError,
   finalizeCharacterDraft,
-  getPersistedCharacter
+  getPersistedCharacter,
+  updatePersistedCharacterCombatState,
+  type CharacterCombatStateUpdate
 } from '../characters/finalize.js';
 
 interface FinalizeCharacterRequestBody {
   draftId?: unknown;
+}
+
+interface UpdateCharacterCombatStateRequestBody {
+  sessionSlug?: unknown;
+  statuses?: unknown;
+  vitality?: unknown;
 }
 
 interface CharacterParams {
@@ -16,6 +24,7 @@ interface CharacterParams {
 
 export async function registerCharacterRoutes(app: FastifyInstance): Promise<void> {
   app.options('/characters/finalize', async (_request, reply) => reply.code(204).send());
+  app.options('/characters/:id/combat-state', async (_request, reply) => reply.code(204).send());
   app.options('/characters/:id', async (_request, reply) => reply.code(204).send());
 
   app.post<{ Body: FinalizeCharacterRequestBody }>(
@@ -55,6 +64,34 @@ export async function registerCharacterRoutes(app: FastifyInstance): Promise<voi
       return sendCharacterRouteError(error, reply);
     }
   });
+
+  app.patch<{ Body: UpdateCharacterCombatStateRequestBody; Params: CharacterParams }>(
+    '/characters/:id/combat-state',
+    async (request, reply) => {
+      const validation = validateCombatStateUpdate(request.body ?? {});
+
+      if (!validation.valid) {
+        return reply.code(400).send({
+          errors: validation.errors,
+          status: 'invalid'
+        });
+      }
+
+      try {
+        const result = await updatePersistedCharacterCombatState(
+          request.params.id,
+          validation.input
+        );
+
+        return {
+          character: result.character,
+          status: 'updated'
+        };
+      } catch (error) {
+        return sendCharacterRouteError(error, reply);
+      }
+    }
+  );
 }
 
 function normalizeOptionalString(value: unknown): string | undefined {
@@ -73,4 +110,98 @@ function sendCharacterRouteError(error: unknown, reply: FastifyReply) {
   }
 
   throw error;
+}
+
+function validateCombatStateUpdate(
+  body: UpdateCharacterCombatStateRequestBody
+): { input: CharacterCombatStateUpdate; valid: true } | { errors: string[]; valid: false } {
+  const errors: string[] = [];
+  const input: CharacterCombatStateUpdate = {};
+
+  if (body.sessionSlug !== undefined) {
+    if (typeof body.sessionSlug !== 'string' || body.sessionSlug.trim().length === 0) {
+      errors.push('sessionSlug must be a non-empty string');
+    } else {
+      input.sessionSlug = body.sessionSlug.trim();
+    }
+  }
+
+  if (body.vitality !== undefined) {
+    if (!isRecord(body.vitality)) {
+      errors.push('vitality must be an object');
+    } else {
+      const current = readOptionalNonNegativeInteger(body.vitality.current, 'vitality.current');
+      const max = readOptionalPositiveInteger(body.vitality.max, 'vitality.max');
+
+      errors.push(...current.errors, ...max.errors);
+      input.vitality = {
+        ...(current.value !== undefined ? { current: current.value } : {}),
+        ...(max.value !== undefined ? { max: max.value } : {})
+      };
+    }
+  }
+
+  if (body.statuses !== undefined) {
+    if (!Array.isArray(body.statuses)) {
+      errors.push('statuses must be an array');
+    } else {
+      input.statuses = body.statuses.map((status, index) => {
+        if (!isRecord(status) || typeof status.id !== 'string' || status.id.trim().length === 0) {
+          errors.push(`statuses[${index}].id must be a non-empty string`);
+          return { id: 'invalid' };
+        }
+
+        const duration = readOptionalNonNegativeInteger(
+          status.durationDT,
+          `statuses[${index}].durationDT`
+        );
+        const appliedAt = readOptionalNonNegativeInteger(
+          status.appliedAtDT,
+          `statuses[${index}].appliedAtDT`
+        );
+
+        errors.push(...duration.errors, ...appliedAt.errors);
+
+        return {
+          ...(appliedAt.value !== undefined ? { appliedAtDT: appliedAt.value } : {}),
+          ...(duration.value !== undefined ? { durationDT: duration.value } : {}),
+          id: status.id.trim()
+        };
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { errors, valid: false };
+  }
+
+  return { input, valid: true };
+}
+
+function readOptionalNonNegativeInteger(value: unknown, label: string) {
+  if (value === undefined) {
+    return { errors: [] as string[], value: undefined };
+  }
+
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+    return { errors: [`${label} must be a non-negative integer`], value: undefined };
+  }
+
+  return { errors: [] as string[], value: value as number };
+}
+
+function readOptionalPositiveInteger(value: unknown, label: string) {
+  if (value === undefined) {
+    return { errors: [] as string[], value: undefined };
+  }
+
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    return { errors: [`${label} must be a positive integer`], value: undefined };
+  }
+
+  return { errors: [] as string[], value: value as number };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -282,6 +282,66 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByRole('heading', { name: 'Squelette' }).first()).toBeVisible();
   });
 
+  test('session combat starts from a persisted character and syncs vitality to the sheet', async ({
+    page
+  }, testInfo) => {
+    annotateCanonical(testInfo, 'combatTracker');
+
+    const suffix = Date.now().toString();
+    const draftId = `combat-character-${suffix}`;
+    const slug = `combat-session-${suffix}`;
+    const saveResponse = await page.request.put(`${e2eApiBaseUrl}/character-drafts/${draftId}`, {
+      data: savedCharacterDraftPayload('Aveline Combattante')
+    });
+    const finalizeResponse = await page.request.post(`${e2eApiBaseUrl}/characters/finalize`, {
+      data: { draftId }
+    });
+
+    expect(saveResponse.ok()).toBe(true);
+    expect(finalizeResponse.ok()).toBe(true);
+
+    await page.goto(
+      `/session?slug=${slug}&player=player-aveline&name=Aveline%20Combattante&role=player&characterId=${draftId}`
+    );
+    await page.getByRole('link', { name: 'Ouvrir combat' }).click();
+
+    await expect(page.locator('html')).toHaveAttribute('data-skin', 'registre');
+    await expect(page.getByRole('heading', { name: 'Aveline Combattante' })).toBeVisible();
+    await expect(page.getByText('Épée bâtarde').first()).toBeVisible();
+    await page.waitForLoadState('networkidle');
+
+    const journalWrite = page.waitForResponse(
+      (response) =>
+        response.url().includes(`/sessions/${slug}/events`) &&
+        response.request().method() === 'POST'
+    );
+    const sheetSync = page.waitForResponse(
+      (response) =>
+        response.url().includes(`/characters/${draftId}/combat-state`) &&
+        response.request().method() === 'PATCH'
+    );
+    await page.getByLabel('Cible vitalité').selectOption(draftId);
+    await page.locator('.kw-combat__small-buttons button').first().click();
+    await journalWrite;
+    await sheetSync;
+
+    await expect(
+      page.getByRole('progressbar', { name: 'Vitalité Aveline Combattante' })
+    ).toHaveAttribute('aria-valuenow', '17');
+
+    await page.reload();
+    await expect(
+      page.getByRole('progressbar', { name: 'Vitalité Aveline Combattante' })
+    ).toHaveAttribute('aria-valuenow', '17');
+
+    await page.goto(`/character?characterId=${draftId}`);
+    await expect(page.getByRole('heading', { name: 'Aveline Combattante' })).toBeVisible();
+    await expect(page.getByRole('progressbar', { name: 'Vitalité' })).toHaveAttribute(
+      'aria-valuenow',
+      '17'
+    );
+  });
+
   test('session manager records events, GM decisions and rollback requests', async ({
     page
   }, testInfo) => {


### PR DESCRIPTION
## Summary
- connect /combat to session slug + persisted character query params
- seed combat from a real persisted PJ plus PNJ/bestiary templates and display loadout/source labels
- persist combat state snapshots into session journal and sync PJ vitality/status metadata back to the character sheet
- add session -> combat entry point and E2E coverage for reload persistence

## Validation
- pnpm validate

Refs #246