### PR TITLE
feat: add playable GM cockpit

### DIFF
--- a/apps/game/src/app/mj/page.tsx
+++ b/apps/game/src/app/mj/page.tsx
@@ -1,0 +1,28 @@
+import { GmCockpit } from '@/features/gm-cockpit/GmCockpit';
+import { getSessionManagerReadModel } from '@/features/session-manager/read-models';
+
+export const dynamic = 'force-dynamic';
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export default async function GmPage({
+  searchParams
+}: Readonly<{ searchParams: Promise<Record<string, string | string[] | undefined>> }>) {
+  const params = await searchParams;
+  const slug = normalizeSlug(normalizeSearchParam(params.slug));
+  const readModel = await getSessionManagerReadModel(slug);
+
+  return <GmCockpit initialState={readModel.initialState} />;
+}
+
+function normalizeSlug(value: string | undefined): string | undefined {
+  return value && SLUG_PATTERN.test(value) ? value : undefined;
+}
+
+function normalizeSearchParam(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}

--- a/apps/game/src/components/app-shell.tsx
+++ b/apps/game/src/components/app-shell.tsx
@@ -3,6 +3,7 @@
 import {
   BookOpen,
   BookUser,
+  ClipboardList,
   Dices,
   FileArchive,
   LayoutDashboard,
@@ -35,6 +36,7 @@ const THEME_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
 
 const navIcons: Record<string, LucideIcon> = {
   '/': LayoutDashboard,
+  '/mj': ClipboardList,
   '/character': BookUser,
   '/character/create': PenLine,
   '/bestiaire': PawPrint,

--- a/apps/game/src/features/gm-cockpit/GmCockpit.tsx
+++ b/apps/game/src/features/gm-cockpit/GmCockpit.tsx
@@ -1,0 +1,316 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { ArrowUpRight, CheckCircle2, RotateCcw, ScrollText, Swords, Users } from 'lucide-react';
+
+import type { SessionManagerState } from '../session-manager/model';
+import {
+  appendGmRulingToSession,
+  fetchPersistedSessionState,
+  requestPersistedRollback
+} from '../session-manager/persistence';
+
+import { buildGmCockpitView } from './model';
+
+interface GmCockpitProps {
+  initialState: SessionManagerState;
+}
+
+export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
+  const [state, setState] = useState(initialState);
+  const view = useMemo(() => buildGmCockpitView(state), [state]);
+  const [selectedXpTarget, setSelectedXpTarget] = useState(view.xpTargets[0]?.characterId ?? '');
+  const [rollbackSequence, setRollbackSequence] = useState(
+    view.rollbackTargets[0]?.sequence.toString() ?? ''
+  );
+  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const effectiveXpTarget =
+    view.xpTargets.find((target) => target.characterId === selectedXpTarget) ?? view.xpTargets[0];
+  const effectiveRollbackSequence =
+    rollbackSequence.length > 0
+      ? Number.parseInt(rollbackSequence, 10)
+      : (view.rollbackTargets[0]?.sequence ?? 0);
+
+  async function run(action: string, mutation: () => Promise<SessionManagerState | void>) {
+    if (pendingAction) {
+      return;
+    }
+
+    setPendingAction(action);
+    setError(null);
+
+    try {
+      const nextState = await mutation();
+      setState(nextState ?? (await fetchPersistedSessionState(state.slug)));
+    } catch (unknownError) {
+      setError(unknownError instanceof Error ? unknownError.message : 'Action MJ impossible');
+    } finally {
+      setPendingAction(null);
+    }
+  }
+
+  function awardXp() {
+    if (!effectiveXpTarget) {
+      return;
+    }
+
+    void run('xp', async () => {
+      await appendGmRulingToSession(state.slug, {
+        actorId: 'gm',
+        payload: {
+          characterId: effectiveXpTarget.characterId,
+          kind: 'xp_award',
+          text: `XP attribue a ${effectiveXpTarget.name}`,
+          xp: 1
+        }
+      });
+    });
+  }
+
+  function addQuickNpc() {
+    void run('npc', async () => {
+      await appendGmRulingToSession(state.slug, {
+        actorId: 'gm',
+        payload: {
+          kind: 'quick_npc',
+          name: 'PNJ rapide',
+          text: 'PNJ rapide ajoute au suivi MJ'
+        }
+      });
+    });
+  }
+
+  function closeSession() {
+    void run('close', async () => {
+      await appendGmRulingToSession(state.slug, {
+        actorId: 'gm',
+        payload: {
+          kind: 'session_closed',
+          text: 'Fin de session marquee par le MJ'
+        }
+      });
+    });
+  }
+
+  function rollback() {
+    if (effectiveRollbackSequence <= 0) {
+      return;
+    }
+
+    void run('rollback', async () =>
+      requestPersistedRollback(state.slug, {
+        actorId: 'gm',
+        reason: 'Rollback depuis cockpit MJ',
+        targetSequence: effectiveRollbackSequence
+      })
+    );
+  }
+
+  return (
+    <main className="grid gap-5">
+      <section className="rounded-md border border-ink/10 bg-white/72 p-5 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-wine">
+              Cockpit MJ
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold text-ink">{view.title}</h1>
+            <p className="mt-2 text-sm leading-6 text-ink/68">
+              {view.activeScene?.title ?? 'Aucune scene active'} ·{' '}
+              {view.activeScene?.location ?? 'Hors scene'} · {view.metrics.pendingDecisions}{' '}
+              decision(s) MJ
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <CockpitLink href={view.sessionHref} label="Session" />
+            <CockpitLink href={view.primaryCombatHref} label="Combat" />
+          </div>
+        </div>
+        {error ? (
+          <p className="mt-4 rounded-md border border-wine/20 bg-wine/10 px-3 py-2 text-sm font-semibold text-wine">
+            {error}
+          </p>
+        ) : null}
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+        <article className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
+          <div className="flex items-center gap-2">
+            <ScrollText aria-hidden="true" className="size-5 text-forest" />
+            <h2 className="text-lg font-semibold text-ink">Scene active</h2>
+          </div>
+          <p className="mt-4 text-xl font-semibold text-ink">
+            {view.activeScene?.title ?? 'Aucune scene'}
+          </p>
+          <p className="mt-1 text-sm font-semibold text-forest">
+            {view.activeScene?.location ?? 'Hors scene'}
+          </p>
+          <p className="mt-3 text-sm leading-6 text-ink/70">
+            {view.activeScene?.description ?? 'Le MJ peut reprendre depuis le journal de session.'}
+          </p>
+        </article>
+
+        <article className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
+          <div className="flex items-center gap-2">
+            <Users aria-hidden="true" className="size-5 text-wine" />
+            <h2 className="text-lg font-semibold text-ink">Participants</h2>
+          </div>
+          <ol className="mt-4 grid gap-2">
+            {view.participants.map((participant) => (
+              <li
+                className="grid grid-cols-[1fr_auto] gap-3 rounded-md bg-paper px-3 py-2"
+                key={participant.id}
+              >
+                <span>
+                  <span className="block text-sm font-semibold text-ink">{participant.name}</span>
+                  <span className="block text-xs font-medium text-ink/55">
+                    {participant.role} · {participant.statusLabel}
+                  </span>
+                </span>
+                {participant.characterHref ? (
+                  <Link
+                    className="text-xs font-semibold text-forest"
+                    href={participant.characterHref}
+                  >
+                    Fiche
+                  </Link>
+                ) : null}
+              </li>
+            ))}
+          </ol>
+        </article>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <article className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
+          <h2 className="text-lg font-semibold text-ink">File MJ</h2>
+          <ol className="mt-4 grid gap-2">
+            {view.pendingDecisions.length === 0 ? (
+              <li className="rounded-md bg-forest/8 px-3 py-2 text-sm font-semibold text-forest">
+                Aucune decision bloquante.
+              </li>
+            ) : (
+              view.pendingDecisions.map((decision) => (
+                <li className="rounded-md bg-paper px-3 py-2" key={decision.id}>
+                  <span className="block text-sm font-semibold text-ink">{decision.title}</span>
+                  <span className="block text-xs font-medium text-ink/55">
+                    {decision.requestedBy}
+                    {' -> '}
+                    {decision.assignedTo} · {decision.priority}
+                  </span>
+                </li>
+              ))
+            )}
+          </ol>
+        </article>
+
+        <article className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
+          <h2 className="text-lg font-semibold text-ink">Rollback</h2>
+          <label className="mt-4 block text-sm font-semibold text-ink/70" htmlFor="gm-rollback">
+            Point de reprise
+          </label>
+          <select
+            className="mt-2 w-full rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-semibold text-ink"
+            id="gm-rollback"
+            onChange={(event) => setRollbackSequence(event.target.value)}
+            value={rollbackSequence}
+          >
+            {view.rollbackTargets.map((target) => (
+              <option key={target.sequence} value={target.sequence}>
+                {target.label}
+              </option>
+            ))}
+          </select>
+          <button
+            className="mt-3 inline-flex items-center gap-2 rounded-md bg-wine px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+            disabled={pendingAction !== null || view.rollbackTargets.length === 0}
+            onClick={rollback}
+            type="button"
+          >
+            <RotateCcw aria-hidden="true" className="size-4" />
+            Rollback
+          </button>
+        </article>
+
+        <article className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
+          <h2 className="text-lg font-semibold text-ink">Actions MJ</h2>
+          <label className="mt-4 block text-sm font-semibold text-ink/70" htmlFor="gm-xp-target">
+            Cible XP
+          </label>
+          <select
+            className="mt-2 w-full rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-semibold text-ink"
+            id="gm-xp-target"
+            onChange={(event) => setSelectedXpTarget(event.target.value)}
+            value={selectedXpTarget}
+          >
+            {view.xpTargets.map((target) => (
+              <option key={target.characterId} value={target.characterId}>
+                {target.name}
+              </option>
+            ))}
+          </select>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              className="inline-flex items-center gap-2 rounded-md bg-forest px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+              disabled={pendingAction !== null || !effectiveXpTarget}
+              onClick={awardXp}
+              type="button"
+            >
+              <CheckCircle2 aria-hidden="true" className="size-4" />
+              Attribuer 1 XP
+            </button>
+            <button
+              className="inline-flex items-center gap-2 rounded-md bg-ink px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+              disabled={pendingAction !== null}
+              onClick={addQuickNpc}
+              type="button"
+            >
+              <Users aria-hidden="true" className="size-4" />
+              PNJ rapide
+            </button>
+            <button
+              className="inline-flex items-center gap-2 rounded-md bg-gold px-3 py-2 text-sm font-semibold text-ink disabled:opacity-50"
+              disabled={pendingAction !== null}
+              onClick={closeSession}
+              type="button"
+            >
+              Fin de session
+            </button>
+          </div>
+        </article>
+      </section>
+
+      <section className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
+        <div className="flex items-center gap-2">
+          <Swords aria-hidden="true" className="size-5 text-forest" />
+          <h2 className="text-lg font-semibold text-ink">Journal recent</h2>
+        </div>
+        <ol className="mt-4 grid gap-2">
+          {view.recentEvents.map((event) => (
+            <li className="rounded-md bg-paper px-3 py-2" key={event.sequence}>
+              <span className="block text-sm font-semibold text-ink">
+                #{event.sequence} · {event.label}
+              </span>
+              <span className="block text-xs font-medium text-ink/55">{event.detail}</span>
+            </li>
+          ))}
+        </ol>
+      </section>
+    </main>
+  );
+}
+
+function CockpitLink({ href, label }: Readonly<{ href: string; label: string }>) {
+  return (
+    <Link
+      className="inline-flex items-center gap-2 rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-semibold text-ink hover:border-forest hover:text-forest"
+      href={href}
+    >
+      {label}
+      <ArrowUpRight aria-hidden="true" className="size-4" />
+    </Link>
+  );
+}

--- a/apps/game/src/features/gm-cockpit/model.test.ts
+++ b/apps/game/src/features/gm-cockpit/model.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { createSessionManagerState } from '../session-manager/model.js';
+
+import { buildGmCockpitView } from './model.js';
+
+describe('GM cockpit model', () => {
+  it('aggregates the active scene, participants, decision queue and action links', () => {
+    const state = createSessionManagerState({
+      decisions: [
+        {
+          assignedTo: 'human_gm',
+          createdAt: '2026-05-29T08:00:00.000Z',
+          id: 'decision-1',
+          payload: { source: 'thread' },
+          priority: 'high',
+          requestedBy: 'player-aveline',
+          status: 'pending',
+          title: 'Valider le bruit de la serrure'
+        }
+      ],
+      events: [
+        {
+          actorId: 'gm',
+          createdAt: '2026-05-29T08:01:00.000Z',
+          id: 'event-1',
+          payload: { text: 'Ouverture de table.' },
+          sequence: 1,
+          type: 'narration'
+        }
+      ],
+      players: [
+        {
+          connected: true,
+          id: 'gm',
+          name: 'MJ',
+          role: 'human_gm'
+        },
+        {
+          characterId: 'pc-aveline',
+          connected: true,
+          id: 'player-aveline',
+          name: 'Aveline',
+          role: 'player'
+        }
+      ],
+      scenes: [
+        {
+          id: 'porte',
+          location: 'Brumeval',
+          status: 'active',
+          title: 'Porte nord'
+        }
+      ],
+      slug: 'brumeval'
+    });
+
+    const view = buildGmCockpitView(state);
+
+    expect(view.activeScene).toMatchObject({
+      location: 'Brumeval',
+      title: 'Porte nord'
+    });
+    expect(view.participants.map((participant) => participant.name)).toEqual(['MJ', 'Aveline']);
+    expect(view.pendingDecisions).toEqual([
+      {
+        assignedTo: 'MJ humain',
+        id: 'decision-1',
+        priority: 'high',
+        requestedBy: 'Aveline',
+        title: 'Valider le bruit de la serrure'
+      }
+    ]);
+    expect(view.primaryCombatHref).toBe('/combat?slug=brumeval&characterId=pc-aveline');
+    expect(view.sessionHref).toBe('/session?slug=brumeval');
+    expect(view.xpTargets).toEqual([
+      {
+        characterId: 'pc-aveline',
+        id: 'player-aveline',
+        name: 'Aveline'
+      }
+    ]);
+    expect(view.rollbackTargets).toEqual([{ label: '#1 narration', sequence: 1 }]);
+  });
+});

--- a/apps/game/src/features/gm-cockpit/model.ts
+++ b/apps/game/src/features/gm-cockpit/model.ts
@@ -1,0 +1,120 @@
+import type { SessionScene } from '@knightandwizard/rules-core';
+
+import {
+  buildSessionManagerView,
+  type SessionManagerState,
+  type SessionManagerView
+} from '../session-manager/model.js';
+
+export interface GmCockpitParticipant {
+  characterHref?: string;
+  characterId?: string;
+  id: string;
+  name: string;
+  role: string;
+  statusLabel: string;
+}
+
+export interface GmCockpitDecision {
+  assignedTo: string;
+  id: string;
+  priority: string;
+  requestedBy: string;
+  title: string;
+}
+
+export interface GmCockpitRollbackTarget {
+  label: string;
+  sequence: number;
+}
+
+export interface GmCockpitXpTarget {
+  characterId: string;
+  id: string;
+  name: string;
+}
+
+export interface GmCockpitView {
+  activeScene?: SessionScene;
+  metrics: SessionManagerView['metrics'];
+  participants: GmCockpitParticipant[];
+  pendingDecisions: GmCockpitDecision[];
+  primaryCombatHref: string;
+  recentEvents: SessionManagerView['recentEvents'];
+  rollbackTargets: GmCockpitRollbackTarget[];
+  sessionHref: string;
+  slug: string;
+  title: string;
+  xpTargets: GmCockpitXpTarget[];
+}
+
+export function buildGmCockpitView(state: SessionManagerState): GmCockpitView {
+  const session = buildSessionManagerView(state);
+  const xpTargets = session.playerRows
+    .filter((player) => player.characterId)
+    .map((player) => ({
+      characterId: player.characterId as string,
+      id: player.id,
+      name: player.name
+    }));
+  const primaryCharacterId = xpTargets[0]?.characterId;
+
+  return {
+    activeScene: session.activeScene,
+    metrics: session.metrics,
+    participants: session.playerRows.map((player) => ({
+      ...(player.characterId
+        ? {
+            characterHref: `/character?characterId=${encodeURIComponent(player.characterId)}`,
+            characterId: player.characterId
+          }
+        : {}),
+      id: player.id,
+      name: player.name,
+      role: roleLabel(player.role),
+      statusLabel: player.statusLabel
+    })),
+    pendingDecisions: session.decisionQueue.map((decision) => ({
+      assignedTo: decision.assignedTo,
+      id: decision.id,
+      priority: decision.priority,
+      requestedBy: decision.requestedBy,
+      title: decision.title
+    })),
+    primaryCombatHref: primaryCharacterId
+      ? `/combat?slug=${encodeURIComponent(state.slug)}&characterId=${encodeURIComponent(primaryCharacterId)}`
+      : `/combat?slug=${encodeURIComponent(state.slug)}`,
+    recentEvents: session.recentEvents,
+    rollbackTargets: session.rollbackTargets.map((target) => ({
+      label: compactRollbackLabel(target.label, target.sequence),
+      sequence: target.sequence
+    })),
+    sessionHref: `/session?slug=${encodeURIComponent(state.slug)}`,
+    slug: state.slug,
+    title: state.title,
+    xpTargets
+  };
+}
+
+function compactRollbackLabel(label: string, sequence: number): string {
+  const parts = label.split(' · ');
+  const eventLabel = parts.at(-1) ?? label;
+
+  return `#${sequence} ${eventLabel}`.toLowerCase();
+}
+
+function roleLabel(role: string): string {
+  if (role === 'human_gm') {
+    return 'MJ humain';
+  }
+
+  if (role === 'llm') {
+    return 'LLM';
+  }
+
+  if (role === 'auto') {
+    return 'Auto';
+  }
+
+  return 'Joueur';
+}

--- a/apps/game/src/features/session-manager/persistence.test.ts
+++ b/apps/game/src/features/session-manager/persistence.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   appendCombatResolutionToSession,
   appendDiceRollToSession,
+  appendGmRulingToSession,
   appendThreadPostToSession,
   queuePersistedGmDecision,
   requestPersistedRollback,
@@ -147,6 +148,27 @@ describe('session manager persistence', () => {
         method: 'PATCH'
       }
     );
+  });
+
+  it('appends a GM ruling event for cockpit actions', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://browser-api.test';
+    const fetchMock = vi.fn().mockResolvedValue(okJson({ status: 'created' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await appendGmRulingToSession('brumeval', {
+      actorId: 'gm',
+      payload: { characterId: 'pc-aveline', kind: 'xp_award', xp: 1 }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('http://browser-api.test/sessions/brumeval/events', {
+      body: JSON.stringify({
+        actorId: 'gm',
+        eventType: 'gm_ruling',
+        payload: { characterId: 'pc-aveline', kind: 'xp_award', xp: 1 }
+      }),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST'
+    });
   });
 
   it('persists GM decision queue, resolution and rollback requests through journal routes', async () => {

--- a/apps/game/src/features/session-manager/persistence.ts
+++ b/apps/game/src/features/session-manager/persistence.ts
@@ -27,6 +27,11 @@ export interface AppendThreadPostInput {
   text: string;
 }
 
+export interface AppendGmRulingInput {
+  actorId: string;
+  payload: Record<string, unknown>;
+}
+
 export interface QueuePersistedGmDecisionInput {
   assignedTo?: SessionControllerRole;
   payload?: Record<string, unknown>;
@@ -89,6 +94,17 @@ export async function appendThreadPostToSession(
     actorId: input.actorId,
     eventType: 'player_action',
     payload: { kind: 'table_post', text }
+  });
+}
+
+export async function appendGmRulingToSession(
+  slug: string,
+  input: AppendGmRulingInput
+): Promise<void> {
+  await appendPersistedSessionEvent(slug, {
+    actorId: input.actorId,
+    eventType: 'gm_ruling',
+    payload: input.payload
   });
 }
 

--- a/apps/game/src/lib/surface-theme.test.ts
+++ b/apps/game/src/lib/surface-theme.test.ts
@@ -10,6 +10,7 @@ import {
 describe('surface theme contract', () => {
   it('maps the product routes to their in-world skins', () => {
     expect(resolveSkinForPath('/')).toBe('gazette');
+    expect(resolveSkinForPath('/mj')).toBe('gazette');
     expect(resolveSkinForPath('/atouts')).toBe('armorial');
     expect(resolveSkinForPath('/character')).toBe('armorial');
     expect(resolveSkinForPath('/character/create')).toBe('armorial');
@@ -31,6 +32,15 @@ describe('surface theme contract', () => {
       label: 'Greffe',
       shortLabel: 'Greffe',
       skin: 'archives'
+    });
+  });
+
+  it('exposes the GM cockpit in the surface navigation', () => {
+    expect(surfaceNavItems).toContainEqual({
+      href: '/mj',
+      label: 'Cockpit MJ',
+      shortLabel: 'MJ',
+      skin: 'gazette'
     });
   });
 

--- a/apps/game/src/lib/surface-theme.ts
+++ b/apps/game/src/lib/surface-theme.ts
@@ -24,6 +24,7 @@ export type SurfaceNavItem = {
 
 export const surfaceNavItems: readonly SurfaceNavItem[] = [
   { href: '/', label: 'Dashboard', shortLabel: 'Poste', skin: 'gazette' },
+  { href: '/mj', label: 'Cockpit MJ', shortLabel: 'MJ', skin: 'gazette' },
   { href: '/atouts', label: 'Atouts', shortLabel: 'Atouts', skin: 'armorial' },
   { href: '/character', label: 'Personnage', shortLabel: 'Fiche', skin: 'armorial' },
   { href: '/character/create', label: 'Creation', shortLabel: 'Creer', skin: 'armorial' },
@@ -42,6 +43,7 @@ export const surfaceNavItems: readonly SurfaceNavItem[] = [
 export const routeSkins: readonly [prefix: string, skin: KwSkin][] = [
   ['/design-proto/registre', 'registre'],
   ['/design-proto/fiche', 'armorial'],
+  ['/mj', 'gazette'],
   ['/atouts', 'armorial'],
   ['/character/create', 'armorial'],
   ['/character', 'armorial'],

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -35,6 +35,7 @@ test.describe('K&W player and GM application flows', () => {
 
     const routeSkins = [
       ['/', 'gazette'],
+      ['/mj', 'gazette'],
       ['/character', 'armorial'],
       ['/combat', 'registre'],
       ['/session', 'gazette'],
@@ -210,6 +211,90 @@ test.describe('K&W player and GM application flows', () => {
     await page.goto(`/character?characterId=${draftId}`);
     await expect(page.getByRole('heading', { name: 'Aveline Identite' })).toBeVisible();
     await expect(page.getByText('Personnage API')).toBeVisible();
+  });
+
+  test('GM cockpit coordinates scene, queue, combat access and closing actions', async ({
+    page
+  }, testInfo) => {
+    annotateCanonical(testInfo, 'sessionManager');
+
+    const suffix = Date.now().toString();
+    const draftId = `gm-cockpit-character-${suffix}`;
+    const slug = `gm-cockpit-${suffix}`;
+    const saveResponse = await page.request.put(`${e2eApiBaseUrl}/character-drafts/${draftId}`, {
+      data: savedCharacterDraftPayload('Aveline Cockpit')
+    });
+    const finalizeResponse = await page.request.post(`${e2eApiBaseUrl}/characters/finalize`, {
+      data: { draftId }
+    });
+    const sessionResponse = await page.request.post(`${e2eApiBaseUrl}/sessions`, {
+      data: {
+        metadata: {
+          players: [{ connected: true, id: 'gm', name: 'MJ', role: 'human_gm' }],
+          scenes: [
+            {
+              description: 'La serrure resiste et la brume monte.',
+              id: 'north-gate',
+              location: 'Brumeval',
+              status: 'active',
+              title: 'Porte nord'
+            }
+          ]
+        },
+        mode: 'digital_human_gm',
+        slug,
+        status: 'active',
+        title: 'Table Cockpit'
+      }
+    });
+    const joinResponse = await page.request.post(`${e2eApiBaseUrl}/sessions/${slug}/players`, {
+      data: {
+        characterId: draftId,
+        name: 'Aveline Cockpit',
+        playerId: 'player-aveline',
+        role: 'player'
+      }
+    });
+    const decisionResponse = await page.request.post(
+      `${e2eApiBaseUrl}/sessions/${slug}/decisions`,
+      {
+        data: {
+          assignedTo: 'human_gm',
+          priority: 'high',
+          requestedBy: 'player-aveline',
+          title: 'Valider le bruit de la serrure'
+        }
+      }
+    );
+
+    expect(saveResponse.ok()).toBe(true);
+    expect(finalizeResponse.ok()).toBe(true);
+    expect(sessionResponse.ok()).toBe(true);
+    expect(joinResponse.ok()).toBe(true);
+    expect(decisionResponse.ok()).toBe(true);
+
+    await page.goto(`/mj?slug=${slug}`);
+
+    await expect(page.locator('html')).toHaveAttribute('data-skin', 'gazette');
+    await expect(page.getByRole('heading', { name: 'Table Cockpit' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Scene active' })).toBeVisible();
+    await expect(page.getByText('Porte nord', { exact: true })).toBeVisible();
+    await expect(page.getByText('Brumeval', { exact: true })).toBeVisible();
+    await expect(page.getByText('Aveline Cockpit', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Valider le bruit de la serrure').first()).toBeVisible();
+    await expect(page.locator('main').getByRole('link', { name: 'Combat' })).toHaveAttribute(
+      'href',
+      `/combat?slug=${slug}&characterId=${draftId}`
+    );
+
+    await page.getByRole('button', { name: 'Attribuer 1 XP' }).click();
+    await expect(page.getByText('XP attribue a Aveline Cockpit')).toBeVisible();
+
+    await page.getByRole('button', { name: 'PNJ rapide' }).click();
+    await expect(page.getByText('PNJ rapide ajoute au suivi MJ')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Fin de session' }).click();
+    await expect(page.getByText('Fin de session marquee par le MJ')).toBeVisible();
   });
 
   test('character creation validates fighter and magician creation budgets', async ({


### PR DESCRIPTION
## Summary
- Add `/mj` as the minimum playable GM cockpit surface backed by the persisted session read model.
- Aggregate active scene, participants, GM decision queue, rollback targets, current combat access, XP award, quick NPC and session-close journal actions.
- Register the cockpit in the surface navigation/skin system and cover it with unit and Playwright flows.

## Validation
- `pnpm test apps/game/src/features/gm-cockpit/model.test.ts apps/game/src/features/session-manager/persistence.test.ts apps/game/src/lib/surface-theme.test.ts`
- `pnpm exec playwright test tests/e2e/app-features.spec.ts -g "GM cockpit"`
- `pnpm typecheck`
- `pnpm validate`

Refs #248