### PR TITLE
feat: persist GM XP awards

### DIFF
--- a/apps/game/src/features/character-sheet/CharacterSheet.tsx
+++ b/apps/game/src/features/character-sheet/CharacterSheet.tsx
@@ -285,6 +285,9 @@ export function CharacterSheet({
             <Badge tone={dataSourceLabel === 'Brouillon API' ? 'info' : 'neutral'}>
               {dataSourceLabel}
             </Badge>
+            <Badge tone="success">
+              XP {character.progression.experiencePoints} / {character.progression.experienceTotal}
+            </Badge>
           </div>
         </div>
 

--- a/apps/game/src/features/gm-cockpit/GmCockpit.tsx
+++ b/apps/game/src/features/gm-cockpit/GmCockpit.tsx
@@ -7,6 +7,7 @@ import { ArrowUpRight, CheckCircle2, RotateCcw, ScrollText, Swords, Users } from
 import type { SessionManagerState } from '../session-manager/model';
 import {
   appendGmRulingToSession,
+  awardCharacterXp,
   fetchPersistedSessionState,
   requestPersistedRollback
 } from '../session-manager/persistence';
@@ -58,6 +59,12 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
     }
 
     void run('xp', async () => {
+      await awardCharacterXp(effectiveXpTarget.characterId, {
+        actorId: 'gm',
+        amount: 1,
+        reason: 'Fin de session',
+        sessionSlug: state.slug
+      });
       await appendGmRulingToSession(state.slug, {
         actorId: 'gm',
         payload: {

--- a/apps/game/src/features/session-manager/persistence.test.ts
+++ b/apps/game/src/features/session-manager/persistence.test.ts
@@ -5,6 +5,7 @@ import {
   appendDiceRollToSession,
   appendGmRulingToSession,
   appendThreadPostToSession,
+  awardCharacterXp,
   queuePersistedGmDecision,
   requestPersistedRollback,
   resolvePersistedGmDecision,
@@ -169,6 +170,33 @@ describe('session manager persistence', () => {
       headers: { 'content-type': 'application/json' },
       method: 'POST'
     });
+  });
+
+  it('awards character XP through the persisted character API', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://browser-api.test';
+    const fetchMock = vi.fn().mockResolvedValue(okJson({ status: 'updated' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await awardCharacterXp('pc-aveline', {
+      actorId: 'gm',
+      amount: 1,
+      reason: 'Fin de session',
+      sessionSlug: 'brumeval'
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://browser-api.test/characters/pc-aveline/xp-awards',
+      {
+        body: JSON.stringify({
+          actorId: 'gm',
+          amount: 1,
+          reason: 'Fin de session',
+          sessionSlug: 'brumeval'
+        }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST'
+      }
+    );
   });
 
   it('persists GM decision queue, resolution and rollback requests through journal routes', async () => {

--- a/apps/game/src/features/session-manager/persistence.ts
+++ b/apps/game/src/features/session-manager/persistence.ts
@@ -58,6 +58,14 @@ export interface SyncCharacterCombatStateInput {
   vitality?: CombatVitality;
 }
 
+export interface AwardCharacterXpInput {
+  actorId?: string;
+  amount: number;
+  questPoints?: number;
+  reason?: string;
+  sessionSlug?: string;
+}
+
 export async function fetchPersistedSessionState(slug: string): Promise<SessionManagerState> {
   const snapshot = await getPersistedSessionSnapshot(slug);
 
@@ -137,6 +145,25 @@ export async function syncCharacterCombatState(
     throw new Error(
       `Unable to sync character combat state for ${characterId}: HTTP ${response.status}`
     );
+  }
+}
+
+export async function awardCharacterXp(
+  characterId: string,
+  input: AwardCharacterXpInput
+): Promise<void> {
+  const baseUrl = getClientApiBaseUrl();
+  const response = await fetch(
+    `${baseUrl}/characters/${encodeURIComponent(characterId)}/xp-awards`,
+    {
+      body: JSON.stringify(input),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST'
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`Unable to award XP to character ${characterId}: HTTP ${response.status}`);
   }
 }
 

--- a/apps/server/src/characters/finalize.ts
+++ b/apps/server/src/characters/finalize.ts
@@ -19,7 +19,8 @@ import {
   type CharacterSkill,
   type CharacterSpell,
   type CombatStatus,
-  type RaceProfile
+  type RaceProfile,
+  gainXP
 } from '@knightandwizard/rules-core';
 import { eq, sql as drizzleSql } from 'drizzle-orm';
 import { z } from 'zod';
@@ -51,6 +52,14 @@ export interface CharacterCombatStateUpdate {
     current?: number;
     max?: number;
   };
+}
+
+export interface CharacterXpAwardUpdate {
+  actorId?: string;
+  amount: number;
+  questPoints?: number;
+  reason?: string;
+  sessionSlug?: string;
 }
 
 interface CharacterCreationCatalog {
@@ -287,6 +296,61 @@ export async function updatePersistedCharacterCombatState(
   }
 }
 
+export async function awardPersistedCharacterXp(
+  id: string,
+  input: CharacterXpAwardUpdate
+): Promise<CharacterPersistenceResult> {
+  const sql = createSqlClient();
+  const db = createDbClient(sql);
+
+  try {
+    const rows = await db
+      .select({ character: characters.payload })
+      .from(characters)
+      .where(eq(characters.id, id))
+      .limit(1);
+    const row = rows[0];
+
+    if (row === undefined) {
+      throw new CharacterNotFoundError(id);
+    }
+
+    const now = new Date().toISOString();
+    const awarded = gainXP(row.character, input.amount, {
+      questPoints: input.questPoints ?? 0
+    });
+    const awardRecord = {
+      ...(input.actorId ? { actorId: input.actorId } : {}),
+      amount: input.amount,
+      awardedAt: now,
+      ...(input.questPoints !== undefined ? { questPoints: input.questPoints } : {}),
+      ...(input.reason ? { reason: input.reason } : {}),
+      ...(input.sessionSlug ? { sessionSlug: input.sessionSlug } : {})
+    };
+    const character: Character = {
+      ...awarded,
+      metadata: {
+        ...awarded.metadata,
+        xpAwards: [...readXpAwardRecords(awarded.metadata.xpAwards), awardRecord]
+      }
+    };
+    const updatedRows = await db
+      .update(characters)
+      .set({
+        payload: character,
+        updatedAt: drizzleSql`now()`
+      })
+      .where(eq(characters.id, id))
+      .returning({ character: characters.payload });
+
+    return {
+      character: updatedRows[0]!.character
+    };
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
 async function loadCharacterCreationCatalog(): Promise<CharacterCreationCatalog> {
   const [races, orientations, classes, weapons, protections, potions] = await Promise.all([
     loadValidatedCatalog('races.yaml'),
@@ -311,6 +375,14 @@ function clampResource(current: number, max: number): number {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readXpAwardRecords(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(isRecord);
 }
 
 function buildCharacterFromDraft(

--- a/apps/server/src/routes/characters.test.ts
+++ b/apps/server/src/routes/characters.test.ts
@@ -99,6 +99,63 @@ describe('character routes', () => {
       { durationDT: 8, id: 'bleeding' }
     ]);
   });
+
+  it('awards persisted XP to a character for session-end GM rewards', async () => {
+    const draftId = `route-xp-character-${randomUUID()}`;
+
+    await app.inject({
+      method: 'PUT',
+      payload: sampleDraft('Aveline Recompensee'),
+      url: `/character-drafts/${draftId}`
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { draftId },
+      url: '/characters/finalize'
+    });
+    const awardResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        amount: 2,
+        reason: 'Fin de session',
+        sessionSlug: 'mvp-xp'
+      },
+      url: `/characters/${draftId}/xp-awards`
+    });
+    const readResponse = await app.inject({
+      method: 'GET',
+      url: `/characters/${draftId}`
+    });
+
+    expect(awardResponse.statusCode).toBe(200);
+    expect(awardResponse.json()).toMatchObject({
+      character: {
+        id: draftId,
+        metadata: {
+          xpAwards: [
+            {
+              actorId: 'gm',
+              amount: 2,
+              reason: 'Fin de session',
+              sessionSlug: 'mvp-xp'
+            }
+          ]
+        },
+        progression: {
+          experiencePoints: 2,
+          experienceTotal: 2,
+          questPoints: 0
+        }
+      },
+      status: 'updated'
+    });
+    expect(readResponse.json().character.progression).toEqual({
+      experiencePoints: 2,
+      experienceTotal: 2,
+      questPoints: 0
+    });
+  });
 });
 
 function sampleDraft(name: string) {

--- a/apps/server/src/routes/characters.ts
+++ b/apps/server/src/routes/characters.ts
@@ -2,10 +2,12 @@ import type { FastifyInstance, FastifyReply } from 'fastify';
 import {
   CharacterDraftNotFoundError,
   CharacterNotFoundError,
+  awardPersistedCharacterXp,
   finalizeCharacterDraft,
   getPersistedCharacter,
   updatePersistedCharacterCombatState,
-  type CharacterCombatStateUpdate
+  type CharacterCombatStateUpdate,
+  type CharacterXpAwardUpdate
 } from '../characters/finalize.js';
 
 interface FinalizeCharacterRequestBody {
@@ -18,6 +20,14 @@ interface UpdateCharacterCombatStateRequestBody {
   vitality?: unknown;
 }
 
+interface AwardCharacterXpRequestBody {
+  actorId?: unknown;
+  amount?: unknown;
+  questPoints?: unknown;
+  reason?: unknown;
+  sessionSlug?: unknown;
+}
+
 interface CharacterParams {
   id: string;
 }
@@ -25,6 +35,7 @@ interface CharacterParams {
 export async function registerCharacterRoutes(app: FastifyInstance): Promise<void> {
   app.options('/characters/finalize', async (_request, reply) => reply.code(204).send());
   app.options('/characters/:id/combat-state', async (_request, reply) => reply.code(204).send());
+  app.options('/characters/:id/xp-awards', async (_request, reply) => reply.code(204).send());
   app.options('/characters/:id', async (_request, reply) => reply.code(204).send());
 
   app.post<{ Body: FinalizeCharacterRequestBody }>(
@@ -82,6 +93,31 @@ export async function registerCharacterRoutes(app: FastifyInstance): Promise<voi
           request.params.id,
           validation.input
         );
+
+        return {
+          character: result.character,
+          status: 'updated'
+        };
+      } catch (error) {
+        return sendCharacterRouteError(error, reply);
+      }
+    }
+  );
+
+  app.post<{ Body: AwardCharacterXpRequestBody; Params: CharacterParams }>(
+    '/characters/:id/xp-awards',
+    async (request, reply) => {
+      const validation = validateXpAward(request.body ?? {});
+
+      if (!validation.valid) {
+        return reply.code(400).send({
+          errors: validation.errors,
+          status: 'invalid'
+        });
+      }
+
+      try {
+        const result = await awardPersistedCharacterXp(request.params.id, validation.input);
 
         return {
           character: result.character,
@@ -176,6 +212,40 @@ function validateCombatStateUpdate(
   }
 
   return { input, valid: true };
+}
+
+function validateXpAward(
+  body: AwardCharacterXpRequestBody
+): { input: CharacterXpAwardUpdate; valid: true } | { errors: string[]; valid: false } {
+  const errors: string[] = [];
+  const amount = readOptionalPositiveInteger(body.amount, 'amount');
+  const questPoints = readOptionalNonNegativeInteger(body.questPoints, 'questPoints');
+  const actorId = normalizeOptionalString(body.actorId);
+  const reason = normalizeOptionalString(body.reason);
+  const sessionSlug = normalizeOptionalString(body.sessionSlug);
+
+  errors.push(...amount.errors, ...questPoints.errors);
+
+  const amountValue = amount.value;
+
+  if (amountValue === undefined) {
+    errors.push('amount is required');
+  }
+
+  if (errors.length > 0 || amountValue === undefined) {
+    return { errors, valid: false };
+  }
+
+  return {
+    input: {
+      ...(actorId ? { actorId } : {}),
+      amount: amountValue,
+      ...(questPoints.value !== undefined ? { questPoints: questPoints.value } : {}),
+      ...(reason ? { reason } : {}),
+      ...(sessionSlug ? { sessionSlug } : {})
+    },
+    valid: true
+  };
 }
 
 function readOptionalNonNegativeInteger(value: unknown, label: string) {

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -290,6 +290,11 @@ test.describe('K&W player and GM application flows', () => {
     await page.getByRole('button', { name: 'Attribuer 1 XP' }).click();
     await expect(page.getByText('XP attribue a Aveline Cockpit')).toBeVisible();
 
+    await page.goto(`/character?characterId=${draftId}`);
+    await expect(page.getByRole('heading', { name: 'Aveline Cockpit' })).toBeVisible();
+    await expect(page.getByText('XP 1 / 1')).toBeVisible();
+
+    await page.goto(`/mj?slug=${slug}`);
     await page.getByRole('button', { name: 'PNJ rapide' }).click();
     await expect(page.getByText('PNJ rapide ajoute au suivi MJ')).toBeVisible();
 


### PR DESCRIPTION
## Summary
- Add `POST /characters/:id/xp-awards` backed by `rules-core` `gainXP` so GM rewards update persisted character progression.
- Make the GM cockpit XP action write both the character progression and the session journal.
- Display persisted XP on the character sheet and extend the cockpit e2e to verify cockpit -> sheet sync.

## Validation
- `pnpm test apps/server/src/routes/characters.test.ts apps/game/src/features/session-manager/persistence.test.ts`
- `pnpm exec playwright test tests/e2e/app-features.spec.ts -g "GM cockpit"`
- `pnpm typecheck`
- `pnpm validate`

Refs #167