### PR TITLE
fix: hide zero skills on character sheet

### DIFF
--- a/apps/game/src/app/globals.css
+++ b/apps/game/src/app/globals.css
@@ -1059,6 +1059,16 @@ a {
   min-width: 0;
 }
 
+.kw-sheet__hero {
+  flex-direction: column;
+}
+
+.kw-sheet__hero-head,
+.kw-sheet__resources {
+  width: 100%;
+  min-width: 0;
+}
+
 .kw-sheet__title-lockup {
   min-width: 0;
   align-items: center;
@@ -1074,7 +1084,7 @@ a {
 
 .kw-sheet__resources {
   display: grid;
-  grid-template-columns: minmax(180px, 1fr) minmax(180px, 1fr) minmax(240px, 0.9fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 0.9fr);
   gap: 12px;
 }
 

--- a/apps/game/src/features/character-sheet/CharacterSheet.tsx
+++ b/apps/game/src/features/character-sheet/CharacterSheet.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   Card,
   Die,
+  Field,
   Label,
   ProgressBar,
   Seal,
@@ -23,10 +24,13 @@ import {
   addInventoryItem,
   attributeRollOutcomeLabels,
   buildCharacterSheetView,
+  filterEquipmentCatalog,
   removeInventoryItem,
   rollAttributeCheck,
+  shouldShowGrimoire,
   skillTreeRows,
   socialAttributeKeys,
+  visibleSkillTreeRows,
   type AttributeRollResult,
   type CharacterSheetMode,
   type EquipmentCatalogEntry,
@@ -76,6 +80,7 @@ export function CharacterSheet({
   const [mode, setMode] = useState<CharacterSheetMode>('complete');
   const [inventory, setInventory] = useState(initialInventory);
   const [lastRoll, setLastRoll] = useState<AttributeRollResult | null>(null);
+  const [equipmentSearch, setEquipmentSearch] = useState('');
   const [rollHistory, setRollHistory] = useState<AttributeRollResult[]>([]);
   const [selectedEquipmentId, setSelectedEquipmentId] = useState<string>(
     () => equipmentCatalog[0]?.id ?? ''
@@ -106,9 +111,18 @@ export function CharacterSheet({
     (total, key) => total + character.attributes[key],
     0
   );
-  const skills = skillTreeRows(character.skills, skillCatalog);
-  const trainedSkillCount = skills.filter((skill) => !skill.isImplicitZero).length;
+  const allSkillRows = skillTreeRows(character.skills, skillCatalog);
+  const skills = visibleSkillTreeRows(allSkillRows);
+  const trainedSkillCount = skills.length;
   const combatStatuses = combatStatusesFromMetadata(character.metadata.combat);
+  const showGrimoire = shouldShowGrimoire(character, spells);
+  const filteredEquipmentCatalog = useMemo(
+    () => filterEquipmentCatalog(equipmentCatalog, equipmentSearch),
+    [equipmentCatalog, equipmentSearch]
+  );
+  const selectedEquipment =
+    filteredEquipmentCatalog.find((entry) => entry.id === selectedEquipmentId) ??
+    filteredEquipmentCatalog[0];
 
   function roll(attribute: AttributeKey) {
     const result = rollAttributeCheck(
@@ -251,15 +265,19 @@ export function CharacterSheet({
                   ` · ${view.creationBudget.convertedSkillPoints} convertis en sorts`}
               </p>
               <p className="kw-sheet__muted">
-                Catalogue implicite : {skills.length} entrées, {trainedSkillCount} notées sur la
-                fiche.
+                {trainedSkillCount} compétence{trainedSkillCount > 1 ? 's' : ''} ou spécialisation
+                {trainedSkillCount > 1 ? 's' : ''} notée{trainedSkillCount > 1 ? 's' : ''}.
               </p>
               {character.orientation.isMagical && (
                 <Toast title="Magicien" tone="info">
                   Pas de compétence primaire mécanique, les sorts comptent double en progression.
                 </Toast>
               )}
-              <SkillTreeRows skills={skills} skillLabels={skillLabels} />
+              {skills.length > 0 ? (
+                <SkillTreeRows skills={skills} skillLabels={skillLabels} />
+              ) : (
+                <p className="kw-sheet__muted">Aucune compétence notée.</p>
+              )}
             </SectionCard>
           </div>
         );
@@ -310,12 +328,14 @@ export function CharacterSheet({
               {status}
             </Badge>
           ))}
-          <ProgressBar
-            label="Énergie"
-            max={character.energy.max}
-            tone="info"
-            value={character.energy.current}
-          />
+          {character.energy.max > 0 || character.energy.current > 0 ? (
+            <ProgressBar
+              label="Énergie"
+              max={character.energy.max}
+              tone="info"
+              value={character.energy.current}
+            />
+          ) : null}
           <StatBlock
             items={[
               { label: 'Facteur vitesse', value: character.speedFactor },
@@ -337,19 +357,32 @@ export function CharacterSheet({
           action={
             equipmentCatalog.length > 0 ? (
               <div className="kw-sheet__inventory-tools">
+                <Field
+                  id="equipment-search"
+                  label="Recherche"
+                  onChange={(event) => setEquipmentSearch(event.target.value)}
+                  placeholder="Épée, potion, bouclier..."
+                  type="search"
+                  value={equipmentSearch}
+                />
                 <SelectField
                   id="equipment-picker"
-                  label="Équipement du catalogue"
+                  label="Équipement"
                   onChange={(event) => setSelectedEquipmentId(event.target.value)}
-                  options={equipmentCatalog.map((option) => ({
-                    label: option.name,
-                    value: option.id
-                  }))}
-                  value={selectedEquipmentId}
+                  options={
+                    filteredEquipmentCatalog.length > 0
+                      ? filteredEquipmentCatalog.map((option) => ({
+                          label: option.name,
+                          value: option.id
+                        }))
+                      : [{ disabled: true, label: 'Aucun résultat', value: '' }]
+                  }
+                  value={selectedEquipment?.id ?? ''}
                 />
                 <Button
                   className="kw-sheet__add-button"
-                  onClick={() => addEquipment(selectedEquipmentId)}
+                  disabled={!selectedEquipment}
+                  onClick={() => selectedEquipment && addEquipment(selectedEquipment.id)}
                   type="button"
                 >
                   <PackagePlus aria-hidden="true" className="kw-sheet__button-icon" />
@@ -391,32 +424,34 @@ export function CharacterSheet({
           </div>
         </SectionCard>
 
-        <SectionCard title="Grimoire">
-          <StatBlock
-            items={[
-              { label: 'Sorts', value: view.spellSummary.knownSpells },
-              { label: 'Points', value: view.spellSummary.pointsCommitted },
-              { label: 'Énergie', value: view.spellSummary.energyAvailable }
-            ]}
-          />
-          {character.orientation.isMagical && (
-            <InfoLine
-              label="Création"
-              value={`${view.creationBudget.spellPoints} points de sort = ${view.creationBudget.freeSpellPoints} gratuits + ${view.creationBudget.extraSpellPoints} achetés.`}
+        {showGrimoire ? (
+          <SectionCard title="Grimoire">
+            <StatBlock
+              items={[
+                { label: 'Sorts', value: view.spellSummary.knownSpells },
+                { label: 'Points', value: view.spellSummary.pointsCommitted },
+                { label: 'Énergie', value: view.spellSummary.energyAvailable }
+              ]}
             />
-          )}
-          <div className="kw-sheet__row-list">
-            {spells.map((spell) => (
-              <div className="kw-sheet__spell-row" key={spell.id}>
-                <div>
-                  <h3>{spell.name}</h3>
-                  <p>{spell.active ? 'Actif' : 'Disponible'}</p>
+            {character.orientation.isMagical && (
+              <InfoLine
+                label="Création"
+                value={`${view.creationBudget.spellPoints} points de sort = ${view.creationBudget.freeSpellPoints} gratuits + ${view.creationBudget.extraSpellPoints} achetés.`}
+              />
+            )}
+            <div className="kw-sheet__row-list">
+              {spells.map((spell) => (
+                <div className="kw-sheet__spell-row" key={spell.id}>
+                  <div>
+                    <h3>{spell.name}</h3>
+                    <p>{spell.active ? 'Actif' : 'Disponible'}</p>
+                  </div>
+                  <Badge tone={spell.active ? 'info' : 'neutral'}>{spell.points} pt</Badge>
                 </div>
-                <Badge tone={spell.active ? 'info' : 'neutral'}>{spell.points} pt</Badge>
-              </div>
-            ))}
-          </div>
-        </SectionCard>
+              ))}
+            </div>
+          </SectionCard>
+        ) : null}
 
         <SectionCard title="Prédilections">
           {view.predilections.length === 0 ? (
@@ -575,7 +610,7 @@ function SkillTreeRows({
               {skill.depth > 0 && <span aria-hidden="true">↪ </span>}
               {skill.label ?? skillLabels[skill.id] ?? skill.id}
             </h3>
-            <p>{skillDescription(skill)}</p>
+            <p>{skillDescription(skill, skillLabels)}</p>
           </div>
           <Badge tone={skill.isImplicitZero ? 'neutral' : 'success'}>
             {skill.points} {skill.points > 1 ? 'pts' : 'pt'}
@@ -592,7 +627,8 @@ function InventoryRow({ item, onRemove }: Readonly<{ item: InventoryItem; onRemo
       <div>
         <h3>{item.name}</h3>
         <p>
-          {item.equipped ? 'Équipé' : item.category} · {item.weightKg ?? 0} kg
+          {item.equipped ? 'Équipé' : inventoryCategoryLabel(item.category)} · {item.weightKg ?? 0}{' '}
+          kg
         </p>
       </div>
       <Badge tone={item.equipped ? 'info' : 'neutral'}>x{item.quantity}</Badge>
@@ -618,7 +654,7 @@ function InfoLine({ label, value }: Readonly<{ label: string; value: string }>) 
   );
 }
 
-function skillDescription(skill: SkillTreeRow): string {
+function skillDescription(skill: SkillTreeRow, skillLabels: Record<string, string>): string {
   if (skill.isImplicitZero) {
     return skill.parentId ? 'Spécialisation implicite à 0' : 'Compétence implicite à 0';
   }
@@ -632,10 +668,29 @@ function skillDescription(skill: SkillTreeRow): string {
   }
 
   if (skill.implicitParentId) {
-    return `Spécialisation, parent implicite à 0 (${skill.implicitParentId})`;
+    const parentLabel = skillLabels[skill.implicitParentId];
+
+    return parentLabel
+      ? `Spécialisation, parent non noté : ${parentLabel}`
+      : 'Spécialisation, parent non noté';
   }
 
   return skill.parentId ? 'Spécialisation' : 'Compétence';
+}
+
+function inventoryCategoryLabel(category: InventoryItem['category']): string {
+  switch (category) {
+    case 'armor':
+      return 'Armure';
+    case 'consumable':
+      return 'Consommable';
+    case 'gear':
+      return 'Équipement';
+    case 'shield':
+      return 'Bouclier';
+    case 'weapon':
+      return 'Arme';
+  }
 }
 
 function rollTone(result: AttributeRollResult): ToastTone {

--- a/apps/game/src/features/character-sheet/model.test.ts
+++ b/apps/game/src/features/character-sheet/model.test.ts
@@ -11,11 +11,14 @@ import {
   attributeRollOutcomeLabels,
   buildCharacterSheetView,
   buildInventoryFromCharacterEquipment,
+  filterEquipmentCatalog,
   removeInventoryItem,
   rollAttributeCheck,
+  shouldShowGrimoire,
   skillPoints,
   skillTreeRows,
   summarizeSpellSlots,
+  visibleSkillTreeRows,
   type InventoryItem,
   type SpellEntry
 } from './model.js';
@@ -46,6 +49,26 @@ describe('character sheet model', () => {
         (section) => section.id
       )
     ).toEqual(['identity', 'full-audit', 'gm-notes', 'gm-controls']);
+  });
+
+  it('hides the grimoire for non-magicians without known spells', () => {
+    const view = buildCharacterSheetView({
+      character: sampleCharacter(),
+      inventory: sampleInventory(),
+      mode: 'complete',
+      spells: []
+    });
+
+    expect(view.sections.map((section) => section.id)).toEqual([
+      'identity',
+      'resources',
+      'attributes',
+      'skills',
+      'inventory'
+    ]);
+    expect(shouldShowGrimoire(sampleCharacter(), [])).toBe(false);
+    expect(shouldShowGrimoire(sampleMagicianCharacter(), [])).toBe(true);
+    expect(shouldShowGrimoire(sampleCharacter(), sampleSpells())).toBe(true);
   });
 
   it('exposes level-point progression separately from creation skill distribution', () => {
@@ -215,6 +238,26 @@ describe('character sheet model', () => {
     ]);
   });
 
+  it('filters the equipment picker without rendering the full catalog at once', () => {
+    const catalog = [
+      { category: 'weapon' as const, id: 'epee_batarde', name: 'Épée bâtarde' },
+      { category: 'weapon' as const, id: 'arc_long', name: 'Arc long' },
+      { category: 'shield' as const, id: 'bouclier_bois', name: 'Bouclier (bois)' },
+      { category: 'consumable' as const, id: 'potion_soin', name: 'Potion de Soin' }
+    ];
+
+    expect(filterEquipmentCatalog(catalog, '', 2).map((entry) => entry.id)).toEqual([
+      'epee_batarde',
+      'arc_long'
+    ]);
+    expect(filterEquipmentCatalog(catalog, 'epee').map((entry) => entry.id)).toEqual([
+      'epee_batarde'
+    ]);
+    expect(filterEquipmentCatalog(catalog, 'potion').map((entry) => entry.id)).toEqual([
+      'potion_soin'
+    ]);
+  });
+
   it('adds and removes inventory quantities without duplicating item rows', () => {
     const inventory = sampleInventory();
     const next = addInventoryItem(inventory, {
@@ -281,6 +324,31 @@ describe('character sheet model', () => {
       ['cuisine', 0, 0, true, 'Cuisine'],
       ['cuisine-corteganne', 2, 1, false, 'Cuisine corteganne'],
       ['cuisine-alterienne', 0, 1, true, 'Cuisine altérienne']
+    ]);
+  });
+
+  it('hides zero score skills from sheet display while preserving orphan specializations', () => {
+    const rows = skillTreeRows(
+      [
+        { id: 'combat', isMain: true, points: 4 },
+        { id: 'combat-parade', parentId: 'combat', points: 2 },
+        { id: 'cuisine-corteganne', parentId: 'cuisine', points: 2 }
+      ],
+      [
+        { id: 'combat', label: 'Combat' },
+        { id: 'combat-parade', label: 'Parade', parentId: 'combat' },
+        { id: 'cuisine', label: 'Cuisine' },
+        { id: 'cuisine-corteganne', label: 'Cuisine corteganne', parentId: 'cuisine' },
+        { id: 'cuisine-alterienne', label: 'Cuisine altérienne', parentId: 'cuisine' }
+      ]
+    );
+
+    expect(
+      visibleSkillTreeRows(rows).map((row) => [row.id, row.points, row.depth, row.implicitParentId])
+    ).toEqual([
+      ['combat', 4, 0, undefined],
+      ['combat-parade', 2, 1, undefined],
+      ['cuisine-corteganne', 2, 0, 'cuisine']
     ]);
   });
 

--- a/apps/game/src/features/character-sheet/model.ts
+++ b/apps/game/src/features/character-sheet/model.ts
@@ -156,6 +156,21 @@ export function buildInventory(input: {
   return items.filter((item): item is InventoryItem => item !== undefined);
 }
 
+export function filterEquipmentCatalog(
+  catalog: EquipmentCatalogEntry[],
+  query: string,
+  limit = 40
+): EquipmentCatalogEntry[] {
+  const normalizedQuery = normalizeSearchText(query);
+  const source = normalizedQuery
+    ? catalog.filter((entry) =>
+        normalizeSearchText(`${entry.name} ${entry.category}`).includes(normalizedQuery)
+      )
+    : catalog;
+
+  return source.slice(0, limit);
+}
+
 export function buildInventoryFromCharacterEquipment(
   equipment: CharacterEquipmentItem[],
   catalog: EquipmentCatalogEntry[]
@@ -346,7 +361,9 @@ export function buildCharacterSheetView(input: {
     levelProgression: calculateLevelProgression(input.character),
     mode: input.mode,
     predilections: buildPredilectionRows(input.character),
-    sections: sectionsByMode[input.mode].map((id) => ({ id, label: sectionLabels[id] })),
+    sections: sectionsByMode[input.mode]
+      .filter((id) => id !== 'grimoire' || shouldShowGrimoire(input.character, input.spells))
+      .map((id) => ({ id, label: sectionLabels[id] })),
     spellSummary: summarizeSpellSlots(input.character, input.spells),
     vitalityState: summarizeVitalityState(input.character.vitality)
   };
@@ -490,6 +507,10 @@ export function summarizeSpellSlots(character: Character, spells: SpellEntry[]):
   };
 }
 
+export function shouldShowGrimoire(character: Character, spells: SpellEntry[]): boolean {
+  return isMagicianCharacter(character) || spells.length > 0;
+}
+
 export function summarizeCreationBudget(character: Character): CreationBudgetSummary {
   const skillPointsSpent = sumEntryPoints(character.skills);
   const spellPoints = sumEntryPoints(character.spells);
@@ -548,6 +569,68 @@ export function skillTreeRows(
   return rows;
 }
 
+export function visibleSkillTreeRows(rows: SkillTreeRow[]): SkillTreeRow[] {
+  const rowsById = new Map(rows.map((row) => [row.id, row]));
+  const visibleIds = new Set(rows.filter((row) => row.points > 0).map((row) => row.id));
+
+  function visibleDepthFor(row: SkillTreeRow): number {
+    let depth = 0;
+    let parentId = row.parentId;
+    const visited = new Set<string>();
+
+    while (parentId && !visited.has(parentId)) {
+      visited.add(parentId);
+      const parent = rowsById.get(parentId);
+
+      if (!parent) {
+        break;
+      }
+
+      if (visibleIds.has(parent.id)) {
+        depth += 1;
+      }
+
+      parentId = parent.parentId;
+    }
+
+    return depth;
+  }
+
+  function implicitParentIdFor(row: SkillTreeRow): string | undefined {
+    if (row.implicitParentId) {
+      return row.implicitParentId;
+    }
+
+    let parentId = row.parentId;
+    const visited = new Set<string>();
+
+    while (parentId && !visited.has(parentId)) {
+      visited.add(parentId);
+      const parent = rowsById.get(parentId);
+
+      if (!parent) {
+        return parentId;
+      }
+
+      if (!visibleIds.has(parent.id)) {
+        return parent.id;
+      }
+
+      parentId = parent.parentId;
+    }
+
+    return undefined;
+  }
+
+  return rows
+    .filter((row) => visibleIds.has(row.id))
+    .map((row) => ({
+      ...row,
+      depth: visibleDepthFor(row),
+      implicitParentId: implicitParentIdFor(row)
+    }));
+}
+
 export function totalInventoryWeight(inventory: InventoryItem[]): number {
   return roundToTenth(
     inventory.reduce((total, item) => total + (item.weightKg ?? 0) * item.quantity, 0)
@@ -559,6 +642,14 @@ function normalizeInventoryItem(item: InventoryItem): InventoryItem {
     ...item,
     quantity: Math.max(1, item.quantity)
   };
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .trim();
 }
 
 function roundToTenth(value: number): number {

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -77,10 +77,14 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByRole('heading', { name: '9 aptitudes' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Compétences' })).toBeVisible();
     await expect(page.getByText('Niveau 1 · 24 / 40 points')).toBeVisible();
-    await expect(page.getByText('Cuisine', { exact: true })).toBeVisible();
-    await expect(page.getByText('Compétence implicite à 0').first()).toBeVisible();
+    await expect(page.getByText('7 compétences ou spécialisations notées.')).toBeVisible();
+    await expect(page.getByText('Cuisine', { exact: true })).toHaveCount(0);
+    await expect(page.getByText('Compétence implicite à 0')).toHaveCount(0);
+    await expect(page.getByText('Catalogue implicite')).toHaveCount(0);
     await expect(page.getByText('Cuisine corteganne')).toBeVisible();
-    await expect(page.getByText(/Catalogue implicite : \d+ entrées, 7 notées/)).toBeVisible();
+    await expect(page.getByText('Spécialisation, parent non noté : Cuisine')).toBeVisible();
+    await expect(page.getByText('consumable')).toHaveCount(0);
+    await expect(page.getByText('Consommable · 0 kg')).toBeVisible();
 
     await page.getByRole('button', { name: /Esthétisme/ }).click();
     await expect(page.getByTestId('last-roll-forced-failure')).toHaveText(


### PR DESCRIPTION
## Summary
- hide zero-point skills and specializations from the character sheet while preserving implicit-zero catalog behavior in the model
- keep bought specializations visible even when their parent skill is implicit at 0, without exposing raw internal ids in the UI
- hide the grimoire for non-magicians without known spells, hide the energy bar for characters with energy max 0, and fix the character sheet hero/resource mobile overflow
- add a searchable, capped equipment picker and replace raw inventory category ids with player-facing labels
- update the E2E contract to assert the new MVP-facing character sheet behavior

## Verification
- pnpm vitest run apps/game/src/features/character-sheet/model.test.ts
- pnpm exec playwright test tests/e2e/app-features.spec.ts -g "character sheet exposes canonical attributes"
- pnpm format:check
- pnpm typecheck
- pnpm lint
- pnpm test
- Chrome DevTools: character sheet shows only noted skills, no implicit-zero catalog rows, no 0/100 energy bar, no grimoire for warrior/no spells, searchable equipment picker capped at 40 options, and no raw consumable/category ids