### PR TITLE
fix: align surface ux copy and mobile layout

### DIFF
--- a/apps/game/src/app/bibliotheque/page.tsx
+++ b/apps/game/src/app/bibliotheque/page.tsx
@@ -6,7 +6,7 @@ export default function BibliothequePage() {
   return (
     <div className="kw-surface-page">
       <Card>
-        <Label>Bibliotheque</Label>
+        <Label>Bibliothèque</Label>
         <h1>La chancellerie classe avant de contredire.</h1>
         <Badge tone="neutral">Skin bibliotheque</Badge>
       </Card>

--- a/apps/game/src/app/dashboard/page.tsx
+++ b/apps/game/src/app/dashboard/page.tsx
@@ -57,14 +57,14 @@ export default function DashboardPage() {
           <h1 style={titleStyle}>Poste de table · {sessionState.title}</h1>
           <p style={dekStyle}>
             {modeLabel(sessionState.mode)} · {statusLabel(sessionState.status)} · scene active :{' '}
-            {activeScene?.title ?? 'hors scene'}
+            {activeScene?.title ?? 'hors scène'}
           </p>
           <div style={badgeRowStyle}>
             <Badge tone="info">{session.metrics.activePlayers} joueurs actifs</Badge>
             <Badge tone={session.metrics.pendingDecisions > 0 ? 'warn' : 'success'}>
-              {session.metrics.pendingDecisions} decisions MJ
+              {session.metrics.pendingDecisions} décisions MJ
             </Badge>
-            <Badge tone="neutral">{session.metrics.events} entrees au journal</Badge>
+            <Badge tone="neutral">{session.metrics.events} entrées au journal</Badge>
           </div>
         </div>
 
@@ -76,16 +76,16 @@ export default function DashboardPage() {
             variant="secondary"
           >
             <ThemeIcon aria-hidden="true" style={iconStyle} />
-            {night ? 'Veillee' : 'Jour'}
+            {night ? 'Veillée' : 'Jour'}
           </Button>
           <Seal>Poste</Seal>
         </div>
       </header>
 
-      <section style={summaryGridStyle} aria-label="Etat de session">
+      <section style={summaryGridStyle} aria-label="État de session">
         <Card>
           <StatBlock
-            title="Etat de session"
+            title="État de session"
             items={session.summaryMetrics.map((metric) => ({
               label: metric.label,
               value: metric.value
@@ -168,11 +168,11 @@ export default function DashboardPage() {
         <Card>
           <div style={labelIconStyle}>
             <ScrollText aria-hidden="true" style={iconStyle} />
-            <Label>Scene active</Label>
+            <Label>Scène active</Label>
           </div>
-          <h2 style={sectionTitleStyle}>{activeScene?.title ?? 'Aucune scene ouverte'}</h2>
-          <p style={bodyCopyStyle}>{activeScene?.description ?? 'La session attend une scene.'}</p>
-          <p style={metaStyle}>{activeScene?.location ?? 'Hors scene'}</p>
+          <h2 style={sectionTitleStyle}>{activeScene?.title ?? 'Aucune scène ouverte'}</h2>
+          <p style={bodyCopyStyle}>{activeScene?.description ?? 'La session attend une scène.'}</p>
+          <p style={metaStyle}>{activeScene?.location ?? 'Hors scène'}</p>
         </Card>
 
         <Card>
@@ -189,7 +189,7 @@ export default function DashboardPage() {
         <div style={panelHeadStyle}>
           <div style={labelIconStyle}>
             <Newspaper aria-hidden="true" style={iconStyle} />
-            <Label>Journal recent</Label>
+            <Label>Journal récent</Label>
           </div>
           <Badge tone="neutral">#{session.recentEvents[0]?.sequence ?? 0}</Badge>
         </div>

--- a/apps/game/src/app/dice/page.tsx
+++ b/apps/game/src/app/dice/page.tsx
@@ -16,7 +16,7 @@ export default function DicePage() {
       </Card>
 
       <Card>
-        <div className="flex flex-wrap gap-2" aria-label="Des de reference">
+        <div className="flex flex-wrap gap-2" aria-label="Dés de référence">
           {dice.map((die) => (
             <Die key={die.value} kind={die.kind} value={die.value} />
           ))}

--- a/apps/game/src/app/globals.css
+++ b/apps/game/src/app/globals.css
@@ -29,6 +29,10 @@ a {
   text-decoration: none;
 }
 
+code {
+  overflow-wrap: anywhere;
+}
+
 button,
 a {
   -webkit-tap-highlight-color: transparent;
@@ -189,18 +193,21 @@ a {
 }
 
 .app-shell__main {
+  min-width: 0;
   padding: 24px 0 32px;
 }
 
 .kw-surface-page {
   display: grid;
   gap: 16px;
+  min-width: 0;
 }
 
 .kw-surface-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 12px;
+  min-width: 0;
 }
 
 .kw-swatch-row {

--- a/apps/game/src/app/greffe/page.tsx
+++ b/apps/game/src/app/greffe/page.tsx
@@ -57,7 +57,11 @@ const surfaceStyle: CSSProperties = {
   display: 'grid',
   fontFamily: 'var(--font-body)',
   gap: 16,
-  padding: 24
+  maxWidth: '100%',
+  minWidth: 0,
+  overflow: 'hidden',
+  padding: 24,
+  width: '100%'
 };
 
 const heroStyle: CSSProperties = {
@@ -65,7 +69,8 @@ const heroStyle: CSSProperties = {
   display: 'flex',
   flexWrap: 'wrap',
   gap: 16,
-  justifyContent: 'space-between'
+  justifyContent: 'space-between',
+  minWidth: 0
 };
 
 const titleStyle: CSSProperties = {
@@ -90,19 +95,23 @@ const panelTitleStyle: CSSProperties = {
 const cardGridStyle: CSSProperties = {
   display: 'grid',
   gap: 16,
-  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 280px), 1fr))'
+  gridTemplateColumns: 'repeat(auto-fit, minmax(min(100%, 280px), 1fr))',
+  minWidth: 0
 };
 
 const stackStyle: CSSProperties = {
   display: 'grid',
-  gap: 12
+  gap: 12,
+  minWidth: 0
 };
 
 const inlineStackStyle: CSSProperties = {
   alignItems: 'center',
   display: 'flex',
   flexWrap: 'wrap',
-  gap: 8
+  gap: 8,
+  maxWidth: '100%',
+  minWidth: 0
 };
 
 const buttonIconStyle: CSSProperties = {
@@ -129,11 +138,13 @@ const eventRowStyle: CSSProperties = {
   display: 'grid',
   gap: 8,
   gridTemplateColumns: 'auto minmax(0, 1fr)',
+  minWidth: 0,
   padding: 10
 };
 
 const mutedStyle: CSSProperties = {
-  color: 'var(--color-text-muted)'
+  color: 'var(--color-text-muted)',
+  overflowWrap: 'anywhere'
 };
 
 const actorNames: Record<string, string> = {
@@ -156,6 +167,13 @@ const priorityTones: Record<SessionDecision['priority'], BadgeTone> = {
   low: 'neutral',
   normal: 'info',
   urgent: 'danger'
+};
+
+const priorityLabels: Record<SessionDecision['priority'], string> = {
+  high: 'haute',
+  low: 'basse',
+  normal: 'normale',
+  urgent: 'urgente'
 };
 
 const statusTones: Record<SessionDecisionStatus, BadgeTone> = {
@@ -187,7 +205,7 @@ const decisionColumns: readonly TableColumn<DecisionRow>[] = [
     id: 'assignedTo'
   },
   {
-    cell: (row) => <Badge tone={priorityTones[row.priority]}>{row.priority}</Badge>,
+    cell: (row) => <Badge tone={priorityTones[row.priority]}>{priorityLabels[row.priority]}</Badge>,
     header: 'Priorité',
     id: 'priority'
   },
@@ -290,9 +308,9 @@ export default function GreffePage() {
             cassation.
           </p>
           <div style={inlineStackStyle}>
-            <Badge tone="danger">Skin archives</Badge>
-            <Badge tone="info">Issue #107</Badge>
-            <Badge tone="neutral">Lié #57 · Epic #96</Badge>
+            <Badge tone="danger">D13</Badge>
+            <Badge tone="info">Renvoi</Badge>
+            <Badge tone="neutral">Cassation</Badge>
           </div>
         </div>
         <div style={inlineStackStyle}>
@@ -305,7 +323,7 @@ export default function GreffePage() {
 
       <Card>
         <StatBlock
-          title="Etat du greffe"
+          title="État du greffe"
           items={[
             { label: 'Causes', value: state.decisions.length },
             { label: 'En instance', value: pendingDecisions.length },
@@ -322,8 +340,8 @@ export default function GreffePage() {
               <Label>Multi-arbitrage</Label>
               <h2 style={panelTitleStyle}>Ordre d'autorité</h2>
               <p style={subtitleStyle}>
-                La hiérarchie provient de <code>ARBITER_PRECEDENCE</code> et les surclasses de{' '}
-                <code>hasArbiterAuthorityOver</code>.
+                La règle D13 donne la main au MJ humain, puis au joueur, au LLM et à l'automate.
+                Chaque rang peut casser les rangs inférieurs.
               </p>
             </div>
             <Seal>
@@ -341,7 +359,7 @@ export default function GreffePage() {
                     </strong>
                     <div style={mutedStyle}>Peut casser : {row.overrides}</div>
                   </div>
-                  <Badge tone={row.rank === 1 ? 'success' : 'neutral'}>{row.arbiter}</Badge>
+                  <Badge tone={row.rank === 1 ? 'success' : 'neutral'}>Rang {row.rank}</Badge>
                 </div>
                 <ProgressBar
                   label={`Autorité ${row.label}`}

--- a/apps/game/src/app/grimoire/page.tsx
+++ b/apps/game/src/app/grimoire/page.tsx
@@ -4,16 +4,16 @@ import { Badge, Card, Label } from '@knightandwizard/ui';
 
 const schools = [
   ['Abjuration', 'abjuration'],
-  ['Alteration', 'alteration'],
+  ['Altération', 'alteration'],
   ['Blanche', 'blanche'],
   ['Divination', 'divination'],
   ['Enchantement', 'enchantement'],
-  ['Elementaire', 'elementaire'],
+  ['Élémentaire', 'elementaire'],
   ['Illusion', 'illusion'],
   ['Invocation', 'invocation'],
   ['Naturelle', 'naturelle'],
   ['Noire', 'noire'],
-  ['Necromancie', 'necromancie']
+  ['Nécromancie', 'necromancie']
 ] as const;
 
 export default function GrimoirePage() {
@@ -21,11 +21,11 @@ export default function GrimoirePage() {
     <div className="kw-surface-page">
       <Card>
         <Label>Grimoire</Label>
-        <h1>Onze ecoles, une roue peu charitable.</h1>
+        <h1>Onze écoles, une roue peu charitable.</h1>
         <Badge tone="info">Skin grimoire</Badge>
       </Card>
 
-      <section className="kw-surface-grid" aria-label="Ecoles de magie">
+      <section className="kw-surface-grid" aria-label="Écoles de magie">
         {schools.map(([label, token]) => (
           <div className="kw-swatch-row" key={token}>
             <span

--- a/apps/game/src/app/layout.tsx
+++ b/apps/game/src/app/layout.tsx
@@ -17,7 +17,7 @@ export const metadata: Metadata = {
   description: 'Compagnon de table digital pour les joueurs et le MJ Knight & Wizard.'
 };
 
-// Polices des skins du design system (pack Terres Oubliees + pack moderne).
+// Polices des skins du design system (pack Terres Oubliées + pack moderne).
 const FONTS_HREF =
   'https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@400;700;900&family=Bitter:ital,wght@0,400;0,700&family=Cormorant+Garamond:ital,wght@0,400;0,600;1,400&family=Cormorant+SC:wght@400;600&family=Courier+Prime&family=EB+Garamond:ital,wght@0,400;0,500;1,400&family=IBM+Plex+Mono&family=Inter:wght@400;500;600;700&family=Libre+Caslon+Display&family=Playfair+Display:wght@400;700;900&family=PT+Serif:ital,wght@0,400;0,700;1,400&family=Source+Serif+4:wght@400;600&family=Special+Elite&display=swap';
 

--- a/apps/game/src/components/app-shell.tsx
+++ b/apps/game/src/components/app-shell.tsx
@@ -91,14 +91,14 @@ export function AppShell({
           </Link>
 
           <button
-            aria-label={nextTheme === 'night' ? 'Passer en mode Veillee' : 'Passer en mode Jour'}
+            aria-label={nextTheme === 'night' ? 'Passer en mode Veillée' : 'Passer en mode Jour'}
             className="app-shell__theme-button"
             onClick={() => setTheme(nextTheme)}
-            title={nextTheme === 'night' ? 'Passer en mode Veillee' : 'Passer en mode Jour'}
+            title={nextTheme === 'night' ? 'Passer en mode Veillée' : 'Passer en mode Jour'}
             type="button"
           >
             <ThemeIcon aria-hidden="true" className="app-shell__theme-icon" />
-            <span>{theme === 'night' ? 'Veillee' : 'Jour'}</span>
+            <span>{theme === 'night' ? 'Veillée' : 'Jour'}</span>
           </button>
         </div>
 

--- a/apps/game/src/features/atouts/AtoutsCompanionSurface.tsx
+++ b/apps/game/src/features/atouts/AtoutsCompanionSurface.tsx
@@ -26,7 +26,7 @@ export function AtoutsCompanionSurface({ view }: Readonly<{ view: AtoutsCompanio
   const catalogStats = [
     { label: 'Atouts', value: formatNumber(view.stats.atoutTotal) },
     { label: 'Actifs', value: formatNumber(view.stats.activeAtouts) },
-    { label: 'Competences', value: formatNumber(view.stats.skillTotal) },
+    { label: 'Compétences', value: formatNumber(view.stats.skillTotal) },
     { label: 'Familles', value: formatNumber(view.stats.families) }
   ];
 
@@ -42,7 +42,7 @@ export function AtoutsCompanionSurface({ view }: Readonly<{ view: AtoutsCompanio
           onClick={() => setNight((current) => !current)}
           variant="secondary"
         >
-          Mode : {night ? 'Veillee' : 'Jour'}
+          Mode : {night ? 'Veillée' : 'Jour'}
         </Button>
       </Card>
 
@@ -79,7 +79,7 @@ export function AtoutsCompanionSurface({ view }: Readonly<{ view: AtoutsCompanio
               <div className="kw-atouts-section-head">
                 <div>
                   <Label>Atouts en vue</Label>
-                  <h2>Privileges, handicaps et dons</h2>
+                  <h2>Privilèges, handicaps et dons</h2>
                 </div>
                 <Badge tone="success">{formatNumber(view.stats.permanentAtouts)} permanents</Badge>
               </div>
@@ -93,10 +93,10 @@ export function AtoutsCompanionSurface({ view }: Readonly<{ view: AtoutsCompanio
             <Card>
               <div className="kw-atouts-section-head">
                 <div>
-                  <Label>Competences pivots</Label>
-                  <h2>Reperes de feuille</h2>
+                  <Label>Compétences pivots</Label>
+                  <h2>Repères de feuille</h2>
                 </div>
-                <Badge tone="info">{formatNumber(view.stats.skillTotal)} entrees</Badge>
+                <Badge tone="info">{formatNumber(view.stats.skillTotal)} entrées</Badge>
               </div>
               <div className="kw-atouts-skill-grid">
                 {view.focusSkills.map((skill) => (

--- a/apps/game/src/features/bestiaire/BestiaireSurface.tsx
+++ b/apps/game/src/features/bestiaire/BestiaireSurface.tsx
@@ -28,7 +28,7 @@ export function BestiaireSurface({ view }: Readonly<BestiaireSurfaceProps>) {
           <p>Fiches especes chargees depuis le catalogue canonique bestiaire.yaml.</p>
         </div>
         <Button variant="secondary" onClick={() => setNight((current) => !current)}>
-          Mode : {night ? 'Veillee (nuit)' : 'Jour'}
+          Mode : {night ? 'Veillée (nuit)' : 'Jour'}
         </Button>
       </div>
 
@@ -61,7 +61,7 @@ export function BestiaireSurface({ view }: Readonly<BestiaireSurfaceProps>) {
         <div className="kw-bestiary__overview">
           <Card>
             <StatBlock
-              title="Etat du catalogue"
+              title="État du catalogue"
               items={[
                 { label: 'Fiches actives', value: view.metrics.activeEntries },
                 { label: 'Races jouables', value: view.metrics.playableEntries },
@@ -139,7 +139,7 @@ function BestiaryDetail({ entry }: Readonly<{ entry: BestiaryEntryView | undefin
       </div>
 
       <p className="kw-bestiary__lore">
-        {entry.lore ?? 'Description non renseignee dans le catalogue.'}
+        {entry.lore ?? 'Description non renseignée dans le catalogue.'}
       </p>
 
       <div className="kw-bestiary__detail-grid">

--- a/apps/game/src/features/cartulaire/CartulaireSurface.tsx
+++ b/apps/game/src/features/cartulaire/CartulaireSurface.tsx
@@ -54,7 +54,7 @@ export function CartulaireSurface({ readModel }: Readonly<{ readModel: Cartulair
           ) : (
             <Sun aria-hidden="true" className="kw-cartulaire__button-icon" />
           )}
-          <span>{night ? 'Veillee' : 'Jour'}</span>
+          <span>{night ? 'Veillée' : 'Jour'}</span>
         </Button>
       </div>
 
@@ -62,7 +62,7 @@ export function CartulaireSurface({ readModel }: Readonly<{ readModel: Cartulair
         <Card className="kw-cartulaire__hero">
           <div className="kw-cartulaire__hero-copy">
             <Label>Cartulaire royal · emaux et marches</Label>
-            <h1>Terres Oubliees</h1>
+            <h1>Terres Oubliées</h1>
             <div className="kw-cartulaire__badge-row">
               <Badge tone="info">Skin armorial</Badge>
               <Badge tone="neutral">Source nations.yaml</Badge>
@@ -77,7 +77,7 @@ export function CartulaireSurface({ readModel }: Readonly<{ readModel: Cartulair
             <div className="kw-cartulaire__panel-head">
               <div>
                 <Label>Carte vectorisee</Label>
-                <h2>Frontieres canoniques</h2>
+                <h2>Frontières canoniques</h2>
               </div>
               <Badge tone="neutral">{selectedRegion?.category ?? 'region'}</Badge>
             </div>

--- a/apps/game/src/features/character-creation/CharacterCreationWizard.tsx
+++ b/apps/game/src/features/character-creation/CharacterCreationWizard.tsx
@@ -159,7 +159,7 @@ export function CharacterCreationWizard({
         <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
           <div>
             <p className="text-sm font-semibold uppercase tracking-[0.18em] text-wine">
-              Creation PJ
+              Création PJ
             </p>
             <h1 className="mt-1 text-3xl font-semibold text-ink">Nouveau personnage</h1>
             <p className="mt-2 text-sm text-ink/62">
@@ -527,7 +527,7 @@ function SkillsStep({
     <div className="grid gap-4">
       <BudgetStrip
         items={[
-          ['Competences', `${view.skillBudget.spent}/${view.skillBudget.limit}`],
+          ['Compétences', `${view.skillBudget.spent}/${view.skillBudget.limit}`],
           ['Convertis', String(view.skillBudget.convertedToSpells)]
         ]}
       />
@@ -709,7 +709,7 @@ function PreviewPanel({
   return (
     <section className="rounded-md border border-ink/10 bg-white/78 p-5 shadow-sm">
       <div className="flex items-center justify-between gap-3">
-        <h2 className="text-xl font-semibold text-ink">Apercu</h2>
+        <h2 className="text-xl font-semibold text-ink">Aperçu</h2>
         <UserPlus aria-hidden="true" className="size-5 text-wine" />
       </div>
       <dl className="mt-4 grid gap-3 text-sm">
@@ -717,7 +717,7 @@ function PreviewPanel({
         <PreviewRow label="Race" value={view.selectedRace?.name ?? 'NA'} />
         <PreviewRow label="Classe" value={view.selectedClass?.name ?? 'NA'} />
         <PreviewRow label="Atouts" value={String(view.grantedAssets.length)} />
-        <PreviewRow label="Equipement" value={String(draft.equipmentIds.length)} />
+        <PreviewRow label="Équipement" value={String(draft.equipmentIds.length)} />
         {preview && (
           <PreviewRow
             label="Ressources"
@@ -748,7 +748,7 @@ function BudgetPanel({
           limit={view.attributeBudget.limit}
           value={view.attributeBudget.spent}
         />
-        <Meter label="Competences" limit={view.skillBudget.limit} value={view.skillBudget.spent} />
+        <Meter label="Compétences" limit={view.skillBudget.limit} value={view.skillBudget.spent} />
         <Meter
           label="Sorts"
           limit={view.spellBudget.requiredPoints}

--- a/apps/game/src/features/character-creation/model.ts
+++ b/apps/game/src/features/character-creation/model.ts
@@ -141,13 +141,13 @@ export interface CharacterCreationView {
 }
 
 export const CREATION_STEPS: CharacterCreationStep[] = [
-  { id: 'identity', label: 'Identite' },
+  { id: 'identity', label: 'Identité' },
   { id: 'attributes', label: 'Aptitudes' },
   { id: 'path', label: 'Voie' },
   { id: 'spells', label: 'Sorts' },
-  { id: 'skills', label: 'Competences' },
+  { id: 'skills', label: 'Compétences' },
   { id: 'assets', label: 'Atouts' },
-  { id: 'equipment', label: 'Equipement' },
+  { id: 'equipment', label: 'Équipement' },
   { id: 'story', label: 'Historique' },
   { id: 'review', label: 'Validation' }
 ];

--- a/apps/game/src/features/combat-tracker/CombatTracker.tsx
+++ b/apps/game/src/features/combat-tracker/CombatTracker.tsx
@@ -253,7 +253,7 @@ export function CombatTracker({
           <Seal>DT {view.current.cyclicDT}</Seal>
         </div>
 
-        <div className="kw-combat__metrics" aria-label="Etat du combat">
+        <div className="kw-combat__metrics" aria-label="État du combat">
           <Metric label="DT" value={view.current.cyclicDT} />
           <Metric label="Absolu" value={view.current.absoluteDT} />
           <Metric label="Acteurs" value={view.roster.length} />

--- a/apps/game/src/features/gm-cockpit/GmCockpit.tsx
+++ b/apps/game/src/features/gm-cockpit/GmCockpit.tsx
@@ -110,7 +110,7 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
     void run('rollback', async () =>
       requestPersistedRollback(state.slug, {
         actorId: 'gm',
-        reason: 'Rollback depuis cockpit MJ',
+        reason: 'Renvoi depuis cockpit MJ',
         targetSequence: effectiveRollbackSequence
       })
     );
@@ -126,9 +126,9 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
             </p>
             <h1 className="mt-2 text-3xl font-semibold text-ink">{view.title}</h1>
             <p className="mt-2 text-sm leading-6 text-ink/68">
-              {view.activeScene?.title ?? 'Aucune scene active'} ·{' '}
-              {view.activeScene?.location ?? 'Hors scene'} · {view.metrics.pendingDecisions}{' '}
-              decision(s) MJ
+              {view.activeScene?.title ?? 'Aucune scène active'} ·{' '}
+              {view.activeScene?.location ?? 'Hors scène'} · {view.metrics.pendingDecisions}{' '}
+              décision(s) MJ
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -147,13 +147,13 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
         <article className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
           <div className="flex items-center gap-2">
             <ScrollText aria-hidden="true" className="size-5 text-forest" />
-            <h2 className="text-lg font-semibold text-ink">Scene active</h2>
+            <h2 className="text-lg font-semibold text-ink">Scène active</h2>
           </div>
           <p className="mt-4 text-xl font-semibold text-ink">
-            {view.activeScene?.title ?? 'Aucune scene'}
+            {view.activeScene?.title ?? 'Aucune scène'}
           </p>
           <p className="mt-1 text-sm font-semibold text-forest">
-            {view.activeScene?.location ?? 'Hors scene'}
+            {view.activeScene?.location ?? 'Hors scène'}
           </p>
           <p className="mt-3 text-sm leading-6 text-ink/70">
             {view.activeScene?.description ?? 'Le MJ peut reprendre depuis le journal de session.'}
@@ -215,7 +215,7 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
         </article>
 
         <article className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
-          <h2 className="text-lg font-semibold text-ink">Rollback</h2>
+          <h2 className="text-lg font-semibold text-ink">Renvoi</h2>
           <label className="mt-4 block text-sm font-semibold text-ink/70" htmlFor="gm-rollback">
             Point de reprise
           </label>
@@ -238,7 +238,7 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
             type="button"
           >
             <RotateCcw aria-hidden="true" className="size-4" />
-            Rollback
+            Renvoi
           </button>
         </article>
 
@@ -293,7 +293,7 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
       <section className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
         <div className="flex items-center gap-2">
           <Swords aria-hidden="true" className="size-5 text-forest" />
-          <h2 className="text-lg font-semibold text-ink">Journal recent</h2>
+          <h2 className="text-lg font-semibold text-ink">Journal récent</h2>
         </div>
         <ol className="mt-4 grid gap-2">
           {view.recentEvents.map((event) => (

--- a/apps/game/src/features/session-dashboard/model.ts
+++ b/apps/game/src/features/session-dashboard/model.ts
@@ -41,12 +41,12 @@ const shortcuts: SessionDashboardShortcut[] = [
     label: 'Fiche'
   },
   {
-    detail: 'Ouvrir le registre DT pour resoudre la prochaine passe.',
+    detail: 'Ouvrir le registre DT pour résoudre la prochaine passe.',
     href: '/combat',
     label: 'Combat'
   },
   {
-    detail: 'Verifier les ecoles, sorts et pistes de preparation.',
+    detail: 'Vérifier les écoles, sorts et pistes de préparation.',
     href: '/grimoire',
     label: 'Grimoire'
   }
@@ -67,9 +67,9 @@ function buildNextActions(session: SessionManagerView): SessionDashboardAction[]
   if (session.decisionQueue.length === 0) {
     return [
       {
-        detail: session.activeScene?.location ?? 'Hors scene',
+        detail: session.activeScene?.location ?? 'Hors scène',
         id: 'scene-watch',
-        label: session.activeScene?.title ?? 'Ouvrir la prochaine scene',
+        label: session.activeScene?.title ?? 'Ouvrir la prochaine scène',
         tone: 'info'
       }
     ];

--- a/apps/game/src/features/session-manager/SessionManager.tsx
+++ b/apps/game/src/features/session-manager/SessionManager.tsx
@@ -207,17 +207,17 @@ export function SessionManager({ currentPlayerId, initialState }: Readonly<Sessi
           <section className="rounded-md border border-ink/10 bg-vellum/60 p-4">
             <div className="flex items-center gap-2">
               <MapPin aria-hidden="true" className="size-5 text-forest" />
-              <h2 className="text-lg font-semibold text-ink">Scene active</h2>
+              <h2 className="text-lg font-semibold text-ink">Scène active</h2>
             </div>
             <div className="mt-4">
               <p className="text-xl font-semibold text-ink">
-                {view.activeScene?.title ?? 'Aucune scene'}
+                {view.activeScene?.title ?? 'Aucune scène'}
               </p>
               <p className="mt-1 text-sm font-semibold text-forest">
-                {view.activeScene?.location ?? 'Hors scene'}
+                {view.activeScene?.location ?? 'Hors scène'}
               </p>
               <p className="mt-3 text-sm leading-6 text-ink/70">
-                {view.activeScene?.description ?? 'Scene non initialisee.'}
+                {view.activeScene?.description ?? 'Scène non initialisée.'}
               </p>
             </div>
           </section>
@@ -311,12 +311,12 @@ export function SessionManager({ currentPlayerId, initialState }: Readonly<Sessi
             <ActionButton
               disabled={busy || view.rollbackTargets.length === 0}
               icon={<RotateCcw aria-hidden="true" className="size-4" />}
-              label="Rollback"
+              label="Renvoi"
               onClick={() => {
                 void runPersistedAction('rollback', async (slug) => {
                   await requestPersistedRollback(slug, {
                     actorId: 'gm',
-                    reason: 'Correction demandee par le MJ',
+                    reason: 'Correction demandée par le MJ',
                     targetSequence: effectiveRollbackSequence
                   });
                   // On re-lit le snapshot complet : le journal doit afficher le
@@ -692,11 +692,11 @@ function threadKindLabel(kind: string): string {
   }
 
   if (kind === 'decision') {
-    return 'Decision';
+    return 'Décision';
   }
 
   if (kind === 'rollback') {
-    return 'Rollback';
+    return 'Renvoi';
   }
 
   return 'Post';

--- a/apps/game/src/features/session-manager/model.test.ts
+++ b/apps/game/src/features/session-manager/model.test.ts
@@ -71,7 +71,7 @@ describe('session manager model', () => {
     });
     expect(view.recentEvents.map((event) => event.label)).toEqual([
       'Aveline · Action joueur',
-      'MJ · Scene ouverte'
+      'MJ · Scène ouverte'
     ]);
   });
 
@@ -195,12 +195,12 @@ describe('session manager model', () => {
     const view = buildSessionManagerView(state);
 
     expect(view.recentEvents.map((event) => event.label)).toEqual([
-      'Aveline · Jet de des',
-      'Aveline · Jet de des'
+      'Aveline · Jet de dés',
+      'Aveline · Jet de dés'
     ]);
     expect(view.recentEvents.map((event) => event.detail)).toEqual([
-      '4 succes · reussite critique',
-      '0 succes · echec critique D100 73'
+      '4 succès · réussite critique',
+      '0 succès · échec critique D100 73'
     ]);
   });
 
@@ -258,7 +258,7 @@ describe('session manager model', () => {
       {
         actorName: 'Aveline',
         createdAt: '2026-04-30T10:01:00.000Z',
-        detail: 'Je force la serrure. · 1 succes',
+        detail: 'Je force la serrure. · 1 succès',
         id: 'event-roll',
         kind: 'roll',
         sequence: 2

--- a/apps/game/src/features/session-manager/model.ts
+++ b/apps/game/src/features/session-manager/model.ts
@@ -109,17 +109,17 @@ export interface SessionManagerView {
 const eventLabels: Record<SessionEventType, string> = {
   combat: 'Combat',
   combat_ended: 'Fin de combat',
-  dice_roll: 'Jet de des',
-  gm_decision_requested: 'Decision MJ demandee',
-  gm_decision_resolved: 'Decision MJ resolue',
+  dice_roll: 'Jet de dés',
+  gm_decision_requested: 'Décision MJ demandée',
+  gm_decision_resolved: 'Décision MJ résolue',
   gm_ruling: 'Arbitrage MJ',
   narration: 'Narration',
-  narrative_time_advanced: 'Temps narratif avance',
+  narrative_time_advanced: 'Temps narratif avancé',
   player_action: 'Action joueur',
-  rollback_requested: 'Rollback demande',
-  scene_opened: 'Scene ouverte',
-  spell_cast: 'Sort lance',
-  spell_dispelled: 'Sort dissipe'
+  rollback_requested: 'Renvoi demandé',
+  scene_opened: 'Scène ouverte',
+  spell_cast: 'Sort lancé',
+  spell_dispelled: 'Sort dissipé'
 };
 
 export function createSessionManagerState(
@@ -166,7 +166,7 @@ export function buildSessionManagerView(state: SessionManagerState): SessionMana
     narrativeClock: buildNarrativeClockView(state),
     playerRows: state.players.map((player) => ({
       ...player,
-      statusLabel: player.connected === false ? 'Hors ligne' : 'Connecte'
+      statusLabel: player.connected === false ? 'Hors ligne' : 'Connecté'
     })),
     recentEvents: [...state.events]
       .sort((left, right) => right.sequence - left.sequence)
@@ -181,9 +181,9 @@ export function buildSessionManagerView(state: SessionManagerState): SessionMana
       })),
     summaryMetrics: [
       { label: 'Joueurs actifs', value: metrics.activePlayers },
-      { label: 'Scenes', value: metrics.scenes },
-      { label: 'Evenements', value: metrics.events },
-      { label: 'Decisions MJ', value: metrics.pendingDecisions }
+      { label: 'Scènes', value: metrics.scenes },
+      { label: 'Événements', value: metrics.events },
+      { label: 'Décisions MJ', value: metrics.pendingDecisions }
     ],
     threadRows: buildSessionThreadRows(state)
   };
@@ -475,18 +475,18 @@ function eventDetail(event: SessionEvent): string {
 
 function diceEventDetail(event: SessionEvent): string {
   if (typeof event.payload.successes !== 'number') {
-    return 'Jet de des';
+    return 'Jet de dés';
   }
 
-  const parts = [`${event.payload.successes} succes`];
+  const parts = [`${event.payload.successes} succès`];
 
   if (event.payload.isCriticalSuccess === true) {
-    parts.push('reussite critique');
+    parts.push('réussite critique');
   }
 
   if (event.payload.isCriticalFailure === true) {
     const severity = event.payload.criticalFailureSeverity;
-    parts.push(typeof severity === 'number' ? `echec critique D100 ${severity}` : 'echec critique');
+    parts.push(typeof severity === 'number' ? `échec critique D100 ${severity}` : 'échec critique');
   }
 
   return parts.join(' · ');
@@ -494,7 +494,7 @@ function diceEventDetail(event: SessionEvent): string {
 
 function actorName(state: SessionManagerState, actorId: string | undefined): string {
   if (!actorId) {
-    return 'Systeme';
+    return 'Système';
   }
 
   return state.players.find((player) => player.id === actorId)?.name ?? actorId;

--- a/apps/game/src/lib/surface-theme.test.ts
+++ b/apps/game/src/lib/surface-theme.test.ts
@@ -63,12 +63,12 @@ describe('surface theme contract', () => {
     expect(surfaceNavItems).toContainEqual({
       href: '/bestiaire',
       label: 'Bestiaire',
-      shortLabel: 'Betes',
+      shortLabel: 'Bêtes',
       skin: 'armorial'
     });
   });
 
-  it('normalizes the persisted Jour/Veillee preference', () => {
+  it('normalizes the persisted Jour/Veillée preference', () => {
     expect(resolveThemePreference('night')).toBe('night');
     expect(resolveThemePreference('day')).toBe('day');
     expect(resolveThemePreference(undefined)).toBe('day');

--- a/apps/game/src/lib/surface-theme.ts
+++ b/apps/game/src/lib/surface-theme.ts
@@ -23,19 +23,19 @@ export type SurfaceNavItem = {
 };
 
 export const surfaceNavItems: readonly SurfaceNavItem[] = [
-  { href: '/', label: 'Dashboard', shortLabel: 'Poste', skin: 'gazette' },
+  { href: '/', label: 'Poste', shortLabel: 'Poste', skin: 'gazette' },
   { href: '/mj', label: 'Cockpit MJ', shortLabel: 'MJ', skin: 'gazette' },
   { href: '/atouts', label: 'Atouts', shortLabel: 'Atouts', skin: 'armorial' },
   { href: '/character', label: 'Personnage', shortLabel: 'Fiche', skin: 'armorial' },
-  { href: '/character/create', label: 'Creation', shortLabel: 'Creer', skin: 'armorial' },
-  { href: '/bestiaire', label: 'Bestiaire', shortLabel: 'Betes', skin: 'armorial' },
+  { href: '/character/create', label: 'Création', shortLabel: 'Créer', skin: 'armorial' },
+  { href: '/bestiaire', label: 'Bestiaire', shortLabel: 'Bêtes', skin: 'armorial' },
   { href: '/combat', label: 'Combat', shortLabel: 'DT', skin: 'registre' },
   { href: '/session', label: 'Session', shortLabel: 'Journal', skin: 'gazette' },
   { href: '/greffe', label: 'Greffe', shortLabel: 'Greffe', skin: 'archives' },
   { href: '/grimoire', label: 'Grimoire', shortLabel: 'Sorts', skin: 'grimoire' },
-  { href: '/dice', label: 'Des', shortLabel: 'D10', skin: 'tripot' },
+  { href: '/dice', label: 'Dés', shortLabel: 'D10', skin: 'tripot' },
   { href: '/rules', label: 'Archives', shortLabel: 'D1-D13', skin: 'archives' },
-  { href: '/bibliotheque', label: 'Bibliotheque', shortLabel: 'CMS', skin: 'bibliotheque' },
+  { href: '/bibliotheque', label: 'Bibliothèque', shortLabel: 'CMS', skin: 'bibliotheque' },
   { href: '/cartulaire', label: 'Cartulaire', shortLabel: 'Carte', skin: 'armorial' },
   { href: '/design-proto', label: 'Lab', shortLabel: 'Skin', skin: 'moderne' }
 ] as const;

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -37,6 +37,7 @@
   border: var(--border-hairline) solid var(--color-border-rule);
   border-radius: var(--radius-rect);
   box-shadow: var(--shadow-card) color-mix(in oklab, var(--color-text-ink) 18%, transparent);
+  min-width: 0;
   padding: 20px;
 }
 
@@ -50,9 +51,11 @@
 
 .kw-badge {
   display: inline-block;
+  max-width: 100%;
   font-family: var(--font-label);
   font-size: var(--text-label-sm);
   letter-spacing: var(--tracking-label);
+  overflow-wrap: anywhere;
   text-transform: uppercase;
   border: var(--border-hairline) solid currentColor;
   border-radius: var(--radius-rect);
@@ -125,13 +128,15 @@
 }
 .kw-statblock__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 120px), 1fr));
   gap: 8px;
+  min-width: 0;
 }
 .kw-statblock__item {
   display: flex;
   flex-direction: column;
   border: var(--border-hairline) solid var(--color-border-hairline);
+  min-width: 0;
   padding: 6px 10px;
 }
 .kw-statblock__label {

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -22,7 +22,7 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByRole('link', { name: /Session/ })).toBeVisible();
   });
 
-  test('application shell applies surface skins and persists Veillee', async ({
+  test('application shell applies surface skins and persists Veillée', async ({
     page
   }, testInfo) => {
     annotateCanonical(testInfo, 'dashboard');
@@ -42,6 +42,7 @@ test.describe('K&W player and GM application flows', () => {
       ['/grimoire', 'grimoire'],
       ['/dice', 'tripot'],
       ['/rules', 'archives'],
+      ['/greffe', 'archives'],
       ['/bibliotheque', 'bibliotheque'],
       ['/design-proto', 'moderne']
     ] as const;
@@ -52,7 +53,7 @@ test.describe('K&W player and GM application flows', () => {
     }
 
     await page.goto('/');
-    await page.getByRole('button', { name: 'Passer en mode Veillee' }).click();
+    await page.getByRole('button', { name: 'Passer en mode Veillée' }).click();
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
     await page.reload();
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
@@ -60,6 +61,28 @@ test.describe('K&W player and GM application flows', () => {
     await page.getByRole('link', { name: /^Combat/ }).click();
     await expect(page.locator('html')).toHaveAttribute('data-skin', 'registre');
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
+  });
+
+  test('mobile shell keeps core surfaces inside the viewport', async ({ page }, testInfo) => {
+    annotateCanonical(testInfo, 'dashboard');
+
+    await page.setViewportSize({ width: 390, height: 844 });
+
+    for (const route of [
+      '/character',
+      '/character/create',
+      '/atouts',
+      '/bestiaire',
+      '/cartulaire',
+      '/greffe'
+    ]) {
+      await page.goto(route);
+      const overflowX = await page.evaluate(
+        () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+      );
+
+      expect(overflowX, route + ' should not create horizontal scroll').toBeLessThanOrEqual(1);
+    }
   });
 
   test('character sheet exposes canonical attributes, nested skills and level budget', async ({
@@ -281,7 +304,7 @@ test.describe('K&W player and GM application flows', () => {
 
     await expect(page.locator('html')).toHaveAttribute('data-skin', 'gazette');
     await expect(page.getByRole('heading', { name: 'Table Cockpit' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Scene active' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Scène active' })).toBeVisible();
     await expect(page.getByText('Porte nord', { exact: true })).toBeVisible();
     await expect(page.getByText('Brumeval', { exact: true })).toBeVisible();
     await expect(page.getByText('Aveline Cockpit', { exact: true }).first()).toBeVisible();
@@ -326,7 +349,7 @@ test.describe('K&W player and GM application flows', () => {
     await increaseStepper(page, 'Perception', 4);
     await expect(page.getByText('20/20').first()).toBeVisible();
 
-    await openCreationStep(page, 'Competences');
+    await openCreationStep(page, 'Compétences');
     await increaseStepper(page, 'Arcanologie', 4);
     await increaseStepper(page, 'Epée bâtarde', 4);
     await increaseStepper(page, 'Chasse', 4);
@@ -350,7 +373,7 @@ test.describe('K&W player and GM application flows', () => {
     await increaseStepper(page, 'Bouclier', 2);
     await expect(page.getByText('4/4').first()).toBeVisible();
 
-    await openCreationStep(page, 'Competences');
+    await openCreationStep(page, 'Compétences');
     await expect(page.getByText('0/0').first()).toBeVisible();
     await expect(page.getByText('Convertis')).toBeVisible();
   });
@@ -446,7 +469,7 @@ test.describe('K&W player and GM application flows', () => {
     await page.goto(`/session?slug=${slug}`);
 
     await expect(page.getByRole('heading', { name: /Session Flow/ })).toBeVisible();
-    await expect(page.getByText('Decisions MJ')).toBeVisible();
+    await expect(page.getByText('Décisions MJ')).toBeVisible();
 
     await page.getByLabel('Message de table').fill('Aveline precise son intention.');
     await page.getByRole('button', { name: 'Publier' }).click();
@@ -463,10 +486,10 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByText('Valider la consequence narrative').first()).toBeVisible();
 
     await page.getByLabel('Approuver').click();
-    await expect(page.getByText(/Decision MJ resolue/).first()).toBeVisible();
+    await expect(page.getByText(/Décision MJ résolue/).first()).toBeVisible();
 
-    await page.getByRole('button', { name: 'Rollback' }).click();
-    await expect(page.getByText(/Rollback demande/).first()).toBeVisible();
+    await page.getByRole('button', { name: 'Renvoi' }).click();
+    await expect(page.getByText(/Renvoi demandé/).first()).toBeVisible();
   });
 });
 

--- a/tests/e2e/session-multiplayer.spec.ts
+++ b/tests/e2e/session-multiplayer.spec.ts
@@ -49,7 +49,7 @@ test('two networked players see each other journal actions live', async ({ brows
     // A player dice roll stays attached to the post and also propagates live.
     await guest.getByLabel('Message de table').fill('Je force la serrure.');
     await guest.getByRole('button', { name: 'Jeter D10' }).click();
-    await expect(host.getByText(/Je force la serrure\..*succes/).first()).toBeVisible();
+    await expect(host.getByText(/Je force la serrure\..*succès/).first()).toBeVisible();
 
     // A GM decision created from the thread is visible to the other client and survives reload.
     await host.getByLabel('Message de table').fill('Valider le bruit de la serrure');


### PR DESCRIPTION
## Summary
- align visible surface labels and French UI copy across app shell, creation, session, MJ, atouts, bestiaire, grimoire, cartulaire, dashboard, and greffe
- remove dev-facing Greffe labels and replace rollback wording with Renvoi/Cassation language
- harden mobile layout against horizontal overflow and add an E2E viewport guard for core surfaces
- update multiplayer E2E expectations after product copy moves from succes to succès

## Verification
- pnpm format:check
- pnpm vitest run apps/game/src/lib/surface-theme.test.ts apps/game/src/features/session-manager/model.test.ts apps/game/src/features/character-creation/model.test.ts apps/game/src/features/session-dashboard/model.test.ts
- pnpm exec playwright test tests/e2e/app-features.spec.ts -g application-shell-mobile-shell-character-creation-session-manager
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm canonical:check
- pnpm exec playwright test tests/e2e/app-features.spec.ts
- pnpm exec playwright test tests/e2e/session-multiplayer.spec.ts
- pnpm exec playwright test
- Chrome audit: desktop/mobile routes checked for overflow and dev-facing tokens
