### PR TITLE
test(e2e): #257 - lock UX invariants on MVP surfaces

### DIFF
--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -63,16 +63,24 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.locator('html')).toHaveAttribute('data-theme', 'night');
   });
 
-  test('mobile shell keeps core surfaces inside the viewport', async ({ page }, testInfo) => {
+  test('mobile shell keeps MVP surfaces inside the viewport', async ({ page }, testInfo) => {
     annotateCanonical(testInfo, 'dashboard');
 
     await page.setViewportSize({ width: 390, height: 844 });
 
+    // Every MVP surface (#257) must stay inside a 390px-wide phone viewport:
+    // the playable table loop (Poste, Session, Cockpit MJ, Combat) alongside the
+    // reference/character surfaces. No surface may force horizontal scroll.
     for (const route of [
+      '/',
       '/character',
       '/character/create',
+      '/session',
+      '/mj',
+      '/combat',
       '/atouts',
       '/bestiaire',
+      '/grimoire',
       '/cartulaire',
       '/greffe'
     ]) {
@@ -82,6 +90,45 @@ test.describe('K&W player and GM application flows', () => {
       );
 
       expect(overflowX, route + ' should not create horizontal scroll').toBeLessThanOrEqual(1);
+    }
+  });
+
+  test('MVP surfaces never leak internal enum tokens into visible copy', async ({
+    page
+  }, testInfo) => {
+    annotateCanonical(testInfo, 'dashboard');
+
+    // Internal snake_case identifiers (session event types, session modes, the
+    // human_gm controller role) must always be humanised before display (#257:
+    // "aucun token interne visible hors logs/audit"). snake_case never appears in
+    // legitimate French UI copy, so any occurrence in visible text is a leak.
+    const forbiddenTokens = [
+      'scene_opened',
+      'player_action',
+      'dice_roll',
+      'gm_ruling',
+      'gm_decision_requested',
+      'gm_decision_resolved',
+      'rollback_requested',
+      'narrative_time_advanced',
+      'combat_ended',
+      'spell_cast',
+      'spell_dispelled',
+      'classic_table',
+      'digital_human_gm',
+      'digital_llm_gm',
+      'digital_auto_gm',
+      'multiplayer_no_gm',
+      'human_gm'
+    ];
+
+    for (const route of ['/', '/session', '/mj', '/combat', '/character']) {
+      await page.goto(route);
+      // Visible rendered text only (innerText excludes data-* attributes / aria).
+      const visibleText = await page.evaluate(() => document.body.innerText);
+      const leaked = forbiddenTokens.filter((token) => visibleText.includes(token));
+
+      expect(leaked, route + ' leaks internal tokens: ' + leaked.join(', ')).toEqual([]);
     }
   });
 


### PR DESCRIPTION
## #257 — Invariants UX verrouillés sur les surfaces MVP

Première tranche **gated** de #257 : on encode deux des trois critères d'acceptation en **invariants E2E durables** (Playwright, dans le gate `test:e2e`), plutôt qu'en audit manuel ponctuel.

### Ce qui est verrouillé

1. **Aucun overflow horizontal mobile sur les surfaces MVP** — l'invariant existant ne couvrait que `/character`, `/character/create`, `/atouts`, `/bestiaire`, `/cartulaire`, `/greffe`. Il couvre désormais **toute la boucle jouable** : `/` (Poste), `/session`, `/mj` (Cockpit MJ), `/combat`, `/grimoire`. Viewport 390×844, `scrollWidth − clientWidth ≤ 1`.
2. **Aucun token interne visible** (#257 « hors logs/audit ») — nouvel invariant : les identifiants `snake_case` internes (types d'événements de session, modes, rôle `human_gm`) ne doivent jamais fuiter dans le texte visible (`body.innerText`) de `/`, `/session`, `/mj`, `/combat`, `/character`. Le `snake_case` n'apparaît jamais dans une copie FR légitime → toute occurrence est une fuite.

### Résultat

- **14/14 e2e verts** (13 → 14 ; le test mobile est renommé + élargi, +1 test token-leak).
- Aucune violation détectée sur l'app courante : les surfaces jouables restent dans le viewport mobile et humanisent déjà leurs enums (labels FR). L'apport est la **garde anti-régression** sur l'ensemble du parcours MVP.

### Reste de #257 (hors de cette PR)

Le 3ᵉ critère — **audit Chrome visuel documenté desktop+mobile** (densité, hiérarchie, états vides, harmonisation skins Surface/Cloud, sélecteurs natifs lourds des gros catalogues) — reste un passage manuel à mener surface par surface ; il produira des correctifs ciblés que ces invariants pourront ensuite figer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
