### PR TITLE
feat(game): #257 - humanise decision priority labels

### DIFF
--- a/apps/game/src/features/gm-cockpit/GmCockpit.tsx
+++ b/apps/game/src/features/gm-cockpit/GmCockpit.tsx
@@ -211,7 +211,7 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
                   <span className="block text-xs font-medium text-ink/55">
                     {decision.requestedBy}
                     {' -> '}
-                    {decision.assignedTo} · {decision.priority}
+                    {decision.assignedTo} · {decision.priorityLabel}
                   </span>
                 </li>
               ))

--- a/apps/game/src/features/gm-cockpit/model.test.ts
+++ b/apps/game/src/features/gm-cockpit/model.test.ts
@@ -67,6 +67,7 @@ describe('GM cockpit model', () => {
         assignedTo: 'MJ humain',
         id: 'decision-1',
         priority: 'high',
+        priorityLabel: 'Haute',
         requestedBy: 'Aveline',
         title: 'Valider le bruit de la serrure'
       }

--- a/apps/game/src/features/gm-cockpit/model.ts
+++ b/apps/game/src/features/gm-cockpit/model.ts
@@ -19,6 +19,7 @@ export interface GmCockpitDecision {
   assignedTo: string;
   id: string;
   priority: string;
+  priorityLabel: string;
   requestedBy: string;
   title: string;
 }
@@ -78,6 +79,7 @@ export function buildGmCockpitView(state: SessionManagerState): GmCockpitView {
       assignedTo: decision.assignedTo,
       id: decision.id,
       priority: decision.priority,
+      priorityLabel: decision.priorityLabel,
       requestedBy: decision.requestedBy,
       title: decision.title
     })),

--- a/apps/game/src/features/session-manager/SessionManager.tsx
+++ b/apps/game/src/features/session-manager/SessionManager.tsx
@@ -521,7 +521,7 @@ export function SessionManager({ currentPlayerId, initialState }: Readonly<Sessi
                       priorityClasses[decision.priority]
                     ].join(' ')}
                   >
-                    {decision.priority}
+                    {decision.priorityLabel}
                   </span>
                 </li>
               ))

--- a/apps/game/src/features/session-manager/model.test.ts
+++ b/apps/game/src/features/session-manager/model.test.ts
@@ -453,6 +453,8 @@ describe('applyLiveSessionEvent', () => {
     expect(view.decisionQueue).toMatchObject([
       {
         id: 'decision-live',
+        priority: 'high',
+        priorityLabel: 'Haute',
         title: 'Valider la consequence narrative'
       }
     ]);

--- a/apps/game/src/features/session-manager/model.ts
+++ b/apps/game/src/features/session-manager/model.ts
@@ -64,7 +64,10 @@ export interface SessionDecisionRow {
   assignedTo: string;
   createdAt: string;
   id: string;
+  /** Raw priority enum — kept for styling/sorting; never shown to users directly. */
   priority: SessionDecision['priority'];
+  /** Humanised priority shown in the UI (#257: no raw enum in visible copy). */
+  priorityLabel: string;
   requestedBy: string;
   title: string;
 }
@@ -159,6 +162,7 @@ export function buildSessionManagerView(state: SessionManagerState): SessionMana
       createdAt: decision.createdAt,
       id: decision.id,
       priority: decision.priority,
+      priorityLabel: priorityLabel(decision.priority),
       requestedBy: actorName(state, decision.requestedBy),
       title: decision.title
     })),
@@ -514,4 +518,15 @@ function roleLabel(role: SessionPlayer['role']): string {
   }
 
   return 'Joueur';
+}
+
+const priorityLabels: Record<SessionDecision['priority'], string> = {
+  high: 'Haute',
+  low: 'Basse',
+  normal: 'Normale',
+  urgent: 'Urgente'
+};
+
+function priorityLabel(priority: SessionDecision['priority']): string {
+  return priorityLabels[priority];
 }


### PR DESCRIPTION
Audit #257 (langage technique residuel) : la file de decisions MJ affichait l enum brut de priorite (low/normal/high/urgent) sur la surface Session (File MJ) et le Cockpit MJ. Humanise en libelles FR (Basse/Normale/Haute/Urgente) via SessionDecisionRow.priorityLabel, en gardant l enum brut priority pour la classe CSS du badge et le tri. Tests model session + cockpit verts ; typecheck + build:game OK.