### PR TITLE
feat(game): #257 - humanise system actor ids in session journal

### DIFF
--- a/apps/game/src/features/session-dashboard/model.test.ts
+++ b/apps/game/src/features/session-dashboard/model.test.ts
@@ -52,7 +52,7 @@ describe('session dashboard model', () => {
     });
     expect(view.nextActions).toEqual([
       {
-        detail: 'llm -> MJ humain',
+        detail: 'LLM -> MJ humain',
         id: 'decision-1',
         label: 'Valider la reaction du guetteur',
         tone: 'warn'

--- a/apps/game/src/features/session-manager/model.test.ts
+++ b/apps/game/src/features/session-manager/model.test.ts
@@ -160,6 +160,8 @@ describe('session manager model', () => {
       {
         id: 'decision-live',
         priority: 'high',
+        // The 'llm' actor is not a session player: it must be humanised, not raw.
+        requestedBy: 'LLM',
         title: 'Valider la consequence narrative'
       }
     ]);

--- a/apps/game/src/features/session-manager/model.ts
+++ b/apps/game/src/features/session-manager/model.ts
@@ -496,12 +496,23 @@ function diceEventDetail(event: SessionEvent): string {
   return parts.join(' · ');
 }
 
+// System actor ids that are not session players; humanised so the journal /
+// decision queue never shows a raw identifier (#257).
+const systemActorLabels: Record<string, string> = {
+  auto: 'Auto',
+  gm: 'MJ',
+  llm: 'LLM',
+  system: 'Système'
+};
+
 function actorName(state: SessionManagerState, actorId: string | undefined): string {
   if (!actorId) {
     return 'Système';
   }
 
-  return state.players.find((player) => player.id === actorId)?.name ?? actorId;
+  const player = state.players.find((candidate) => candidate.id === actorId);
+
+  return player?.name ?? systemActorLabels[actorId] ?? actorId;
 }
 
 function roleLabel(role: SessionPlayer['role']): string {


### PR DESCRIPTION
Audit #257 (langage technique residuel) : les acteurs systeme non-joueurs (llm, gm, auto) s affichaient en identifiant brut dans la File MJ / le journal de session (ex. requestedBy llm minuscule). actorName humanise desormais les ids systeme connus (llm -> LLM, gm -> MJ, auto -> Auto, system -> Systeme) tout en gardant la priorite au nom du joueur quand l id correspond a un participant. Test : decisionQueue requestedBy llm -> LLM. typecheck + lint OK ; e2e couvert par le gate.