### PR TITLE
fix(game): #257 add searchable catalog browsers

### DIFF
--- a/apps/game/src/app/globals.css
+++ b/apps/game/src/app/globals.css
@@ -667,9 +667,17 @@ a {
 }
 
 .kw-atouts-meter-list,
-.kw-atouts-family-list {
+.kw-atouts-family-list,
+.kw-atouts-catalog-list {
   gap: 10px;
   margin-top: 12px;
+}
+
+.kw-atouts-catalog-list {
+  display: grid;
+  max-height: 520px;
+  overflow: auto;
+  padding-right: 4px;
 }
 
 .kw-atouts-meter {
@@ -1273,14 +1281,45 @@ a {
 
 .kw-sheet__inventory-tools {
   display: grid;
-  grid-template-columns: minmax(190px, 1fr) auto;
+  grid-template-columns: minmax(210px, 0.42fr) minmax(0, 1fr);
   gap: 10px;
-  align-items: end;
+  align-items: start;
 }
 
 .kw-sheet__add-button,
 .kw-sheet__icon-button {
   white-space: nowrap;
+}
+
+.kw-sheet__equipment-results {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 8px;
+  min-width: 0;
+}
+
+.kw-sheet__equipment-option.kw-btn {
+  min-height: 58px;
+  justify-content: space-between;
+  text-align: left;
+  white-space: normal;
+}
+
+.kw-sheet__equipment-option span {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.kw-sheet__equipment-option strong,
+.kw-sheet__equipment-option small {
+  overflow-wrap: anywhere;
+}
+
+.kw-sheet__equipment-option small {
+  color: var(--color-text-muted);
+  font-family: var(--font-label);
+  font-size: var(--text-label-sm);
 }
 
 .kw-sheet__icon-button.kw-btn {
@@ -1444,6 +1483,7 @@ a {
 .kw-bestiary__species-list {
   max-height: 720px;
   overflow: auto;
+  margin-top: 12px;
   padding-right: 4px;
 }
 
@@ -1521,5 +1561,123 @@ a {
 
   .kw-bestiary {
     padding: 16px;
+  }
+}
+
+.kw-grimoire-page,
+.kw-grimoire__spell-list,
+.kw-grimoire__school-list {
+  display: grid;
+  gap: 16px;
+}
+
+.kw-grimoire-page h1,
+.kw-grimoire-page h2,
+.kw-grimoire-page h3,
+.kw-grimoire-page p {
+  margin: 0;
+}
+
+.kw-grimoire-page h1,
+.kw-grimoire-page h2,
+.kw-grimoire-page h3 {
+  color: var(--color-text-ink);
+  font-family: var(--font-display);
+  line-height: var(--leading-tight);
+}
+
+.kw-grimoire-page h1 {
+  font-size: var(--text-title-l);
+}
+
+.kw-grimoire-page h2 {
+  font-size: var(--text-title-m);
+}
+
+.kw-grimoire-page h3 {
+  font-size: var(--text-body-l);
+}
+
+.kw-grimoire-page p {
+  color: var(--color-text-muted);
+  line-height: var(--leading-normal);
+}
+
+.kw-grimoire__badge-row,
+.kw-grimoire__schools,
+.kw-grimoire__spell-meta,
+.kw-grimoire__school-card-head,
+.kw-grimoire__panel-head,
+.kw-grimoire__spell-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.kw-grimoire__badge-row {
+  margin-top: 12px;
+}
+
+.kw-grimoire__overview,
+.kw-grimoire__layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.62fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.kw-grimoire__schools {
+  align-items: center;
+}
+
+.kw-grimoire__school-button.kw-btn {
+  white-space: normal;
+}
+
+.kw-grimoire__panel-head,
+.kw-grimoire__spell-head,
+.kw-grimoire__school-card-head {
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.kw-grimoire__spell-card,
+.kw-grimoire__school-card {
+  display: grid;
+  gap: 10px;
+  border: var(--border-hairline) solid var(--color-border-hairline);
+  background: var(--color-bg-elevated);
+  padding: 12px;
+}
+
+.kw-grimoire__spell-head > div {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.kw-grimoire__spell-meta {
+  align-items: center;
+  color: var(--color-text-muted);
+  font-family: var(--font-label);
+  font-size: var(--text-label-sm);
+}
+
+@media (max-width: 900px) {
+  .kw-grimoire__overview,
+  .kw-grimoire__layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 680px) {
+  .kw-grimoire__panel-head,
+  .kw-grimoire__spell-head {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .kw-grimoire__schools .kw-btn {
+    width: 100%;
   }
 }

--- a/apps/game/src/app/grimoire/page.tsx
+++ b/apps/game/src/app/grimoire/page.tsx
@@ -1,42 +1,8 @@
-import type { CSSProperties } from 'react';
+import { GrimoireSurface } from '@/features/grimoire/GrimoireSurface';
+import { getGrimoireReadModel } from '@/features/grimoire/read-models';
 
-import { Badge, Card, Label } from '@knightandwizard/ui';
+export default async function GrimoirePage() {
+  const view = await getGrimoireReadModel();
 
-const schools = [
-  ['Abjuration', 'abjuration'],
-  ['Altération', 'alteration'],
-  ['Blanche', 'blanche'],
-  ['Divination', 'divination'],
-  ['Enchantement', 'enchantement'],
-  ['Élémentaire', 'elementaire'],
-  ['Illusion', 'illusion'],
-  ['Invocation', 'invocation'],
-  ['Naturelle', 'naturelle'],
-  ['Noire', 'noire'],
-  ['Nécromancie', 'necromancie']
-] as const;
-
-export default function GrimoirePage() {
-  return (
-    <div className="kw-surface-page">
-      <Card>
-        <Label>Grimoire</Label>
-        <h1>Onze écoles, une roue peu charitable.</h1>
-        <Badge tone="info">Skin grimoire</Badge>
-      </Card>
-
-      <section className="kw-surface-grid" aria-label="Écoles de magie">
-        {schools.map(([label, token]) => (
-          <div className="kw-swatch-row" key={token}>
-            <span
-              aria-hidden="true"
-              className="kw-swatch"
-              style={{ '--swatch-color': 'var(--school-' + token + ')' } as CSSProperties}
-            />
-            <span>{label}</span>
-          </div>
-        ))}
-      </section>
-    </div>
-  );
+  return <GrimoireSurface view={view} />;
 }

--- a/apps/game/src/features/atouts/AtoutsCompanionSurface.tsx
+++ b/apps/game/src/features/atouts/AtoutsCompanionSurface.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState, type CSSProperties } from 'react';
+import { useMemo, useState, type CSSProperties } from 'react';
 
-import { Badge, Button, Card, Label, Seal, StatBlock } from '@knightandwizard/ui';
+import { Badge, Button, Card, Field, Label, Seal, StatBlock } from '@knightandwizard/ui';
 import type { BadgeTone } from '@knightandwizard/ui';
 
 import type {
@@ -22,6 +22,11 @@ const COMPANION_IDENTITY = {
 
 export function AtoutsCompanionSurface({ view }: Readonly<{ view: AtoutsCompanionView }>) {
   const [night, setNight] = useState(false);
+  const [atoutSearch, setAtoutSearch] = useState('');
+  const filteredAtouts = useMemo(
+    () => filterAtouts(view.browseAtouts, atoutSearch, 12),
+    [atoutSearch, view.browseAtouts]
+  );
 
   const catalogStats = [
     { label: 'Atouts', value: formatNumber(view.stats.atoutTotal) },
@@ -75,6 +80,31 @@ export function AtoutsCompanionSurface({ view }: Readonly<{ view: AtoutsCompanio
 
         <div className="kw-atouts-layout">
           <section className="kw-atouts-stack" aria-label="Atouts suivis">
+            <Card>
+              <div className="kw-atouts-section-head">
+                <div>
+                  <Label>Répertoire</Label>
+                  <h2>Recherche d&apos;atouts</h2>
+                </div>
+                <Badge tone="info">{formatNumber(view.browseAtouts.length)} actifs</Badge>
+              </div>
+              <Field
+                id="atouts-search"
+                label="Rechercher"
+                onChange={(event) => setAtoutSearch(event.target.value)}
+                placeholder="Adrénaline, ambidextrie, race..."
+                type="search"
+                value={atoutSearch}
+              />
+              <div className="kw-atouts-catalog-list" aria-label="Atouts filtrés">
+                {filteredAtouts.length > 0 ? (
+                  filteredAtouts.map((atout) => <AtoutEntry atout={atout} key={atout.id} />)
+                ) : (
+                  <p>Aucun atout trouvé.</p>
+                )}
+              </div>
+            </Card>
+
             <Card>
               <div className="kw-atouts-section-head">
                 <div>
@@ -180,6 +210,19 @@ function BreakdownMeter({ item }: Readonly<{ item: BreakdownItem }>) {
   );
 }
 
+function filterAtouts(atouts: AtoutSummary[], query: string, limit: number): AtoutSummary[] {
+  const normalizedQuery = normalizeSearchText(query);
+  const source = normalizedQuery
+    ? atouts.filter((atout) =>
+        normalizeSearchText(`${atout.name} ${atout.effect} ${scopeLabel(atout.scope)}`).includes(
+          normalizedQuery
+        )
+      )
+    : atouts;
+
+  return source.slice(0, limit);
+}
+
 function activationTone(activation: AtoutActivation): BadgeTone {
   if (activation === 'ephemere') return 'warn';
   if (activation === 'permanent') return 'success';
@@ -239,4 +282,12 @@ function formatAtoutValue(value: number | null): string {
 
 function formatNumber(value: number): string {
   return new Intl.NumberFormat('fr-FR').format(value);
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .trim();
 }

--- a/apps/game/src/features/atouts/read-models.test.ts
+++ b/apps/game/src/features/atouts/read-models.test.ts
@@ -70,6 +70,7 @@ describe('buildAtoutsCompanionView', () => {
       skillTotal: 2
     });
     expect(view.highlightAtouts.map((atout) => atout.id)).toEqual(['ambidextrie', 'adrenaline']);
+    expect(view.browseAtouts.map((atout) => atout.id)).toEqual(['adrenaline', 'ambidextrie']);
     expect(view.skillFamilies).toEqual([
       { family: 'combat', label: 'Combat', total: 1 },
       { family: 'survie', label: 'Survie', total: 1 }

--- a/apps/game/src/features/atouts/read-models.ts
+++ b/apps/game/src/features/atouts/read-models.ts
@@ -57,6 +57,7 @@ export type AtoutScope = 'classe' | 'neutre' | 'orientation' | 'race' | 'niveau'
 
 export interface AtoutsCompanionView {
   activationBreakdown: BreakdownItem[];
+  browseAtouts: AtoutSummary[];
   focusSkills: SkillSummary[];
   highlightAtouts: AtoutSummary[];
   skillFamilies: SkillFamilySummary[];
@@ -131,6 +132,9 @@ export function buildAtoutsCompanionView({
 
   return {
     activationBreakdown: buildBreakdown(atoutEntries, (atout) => atout.activation),
+    browseAtouts: atoutEntries
+      .filter((atout) => atout.status === 'active')
+      .sort((left, right) => left.name.localeCompare(right.name, 'fr')),
     focusSkills: selectPreferred(skillEntries, FOCUS_SKILL_IDS, 6),
     highlightAtouts: selectPreferred(
       atoutEntries.filter((atout) => atout.status === 'active'),
@@ -139,8 +143,8 @@ export function buildAtoutsCompanionView({
     ),
     skillFamilies: buildSkillFamilies(skillEntries),
     sourceLabels: {
-      atouts: atouts.metadata?.source ?? 'atouts.yaml',
-      skills: skills.metadata?.source ?? 'competences.yaml'
+      atouts: humanizeSourceLabel(atouts.metadata?.source, 'Atouts'),
+      skills: humanizeSourceLabel(skills.metadata?.source, 'Compétences')
     },
     scopeBreakdown: buildBreakdown(atoutEntries, (atout) => atout.scope),
     stats: {
@@ -275,4 +279,12 @@ function labelCatalogKey(key: string): string {
   };
 
   return labels[key] ?? key;
+}
+
+function humanizeSourceLabel(source: string | undefined, fallback: string): string {
+  if (!source) return fallback;
+  if (source.includes('/atouts/')) return 'Atouts web';
+  if (source.includes('competences')) return 'Compétences';
+
+  return fallback;
 }

--- a/apps/game/src/features/bestiaire/BestiaireSurface.tsx
+++ b/apps/game/src/features/bestiaire/BestiaireSurface.tsx
@@ -2,7 +2,16 @@
 
 import { useMemo, useState } from 'react';
 
-import { Badge, Button, Card, Label, Seal, StatBlock, type BadgeTone } from '@knightandwizard/ui';
+import {
+  Badge,
+  Button,
+  Card,
+  Field,
+  Label,
+  Seal,
+  StatBlock,
+  type BadgeTone
+} from '@knightandwizard/ui';
 
 import type { BestiaryEntryView, BestiarySurfaceView } from './model';
 
@@ -13,10 +22,19 @@ interface BestiaireSurfaceProps {
 export function BestiaireSurface({ view }: Readonly<BestiaireSurfaceProps>) {
   const [night, setNight] = useState(false);
   const [selectedId, setSelectedId] = useState(view.entries[0]?.id ?? '');
+  const [search, setSearch] = useState('');
+
+  const filteredEntries = useMemo(
+    () => filterBestiaryEntries(view.entries, search),
+    [search, view.entries]
+  );
 
   const selected = useMemo(
-    () => view.entries.find((entry) => entry.id === selectedId) ?? view.entries[0],
-    [selectedId, view.entries]
+    () =>
+      filteredEntries.find((entry) => entry.id === selectedId) ??
+      filteredEntries[0] ??
+      view.entries[0],
+    [filteredEntries, selectedId, view.entries]
   );
 
   return (
@@ -50,7 +68,7 @@ export function BestiaireSurface({ view }: Readonly<BestiaireSurfaceProps>) {
               <Badge tone="neutral">API catalogues</Badge>
               {view.sourceFiles.map((source) => (
                 <Badge key={source.path} tone="neutral">
-                  {source.path}
+                  {source.label}
                 </Badge>
               ))}
             </div>
@@ -76,7 +94,7 @@ export function BestiaireSurface({ view }: Readonly<BestiaireSurfaceProps>) {
             <div className="kw-bestiary__category-grid">
               {view.categorySummaries.map((summary) => (
                 <div className="kw-bestiary__category-row" key={summary.category}>
-                  <span>{summary.category}</span>
+                  <span>{summary.label}</span>
                   <Badge tone="neutral">{summary.count}</Badge>
                 </div>
               ))}
@@ -89,24 +107,36 @@ export function BestiaireSurface({ view }: Readonly<BestiaireSurfaceProps>) {
             <div className="kw-bestiary__panel-head">
               <div>
                 <Label>Index des especes</Label>
-                <h2>{view.metrics.activeEntries} fiches actives</h2>
+                <h2>{filteredEntries.length} fiches affichées</h2>
               </div>
             </div>
+            <Field
+              id="bestiaire-search"
+              label="Rechercher"
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Humain, griffon, race jouable..."
+              type="search"
+              value={search}
+            />
             <div className="kw-bestiary__species-list" aria-label="Fiches du bestiaire">
-              {view.entries.map((entry) => (
-                <Button
-                  aria-pressed={entry.id === selected?.id}
-                  className="kw-bestiary__species-button"
-                  key={entry.id}
-                  onClick={() => setSelectedId(entry.id)}
-                  variant={entry.id === selected?.id ? 'primary' : 'secondary'}
-                >
-                  <span className="kw-bestiary__species-name">{entry.name}</span>
-                  <span className="kw-bestiary__species-meta">
-                    {entry.category} · {entry.playableLabel}
-                  </span>
-                </Button>
-              ))}
+              {filteredEntries.length > 0 ? (
+                filteredEntries.map((entry) => (
+                  <Button
+                    aria-pressed={entry.id === selected?.id}
+                    className="kw-bestiary__species-button"
+                    key={entry.id}
+                    onClick={() => setSelectedId(entry.id)}
+                    variant={entry.id === selected?.id ? 'primary' : 'secondary'}
+                  >
+                    <span className="kw-bestiary__species-name">{entry.name}</span>
+                    <span className="kw-bestiary__species-meta">
+                      {entry.categoryLabel} · {entry.playableLabel}
+                    </span>
+                  </Button>
+                ))
+              ) : (
+                <p className="kw-bestiary__muted">Aucune fiche trouvée.</p>
+              )}
             </div>
           </Card>
 
@@ -146,7 +176,7 @@ function BestiaryDetail({ entry }: Readonly<{ entry: BestiaryEntryView | undefin
         <StatBlock
           title="Morphologie"
           items={[
-            { label: 'Categorie', value: entry.category },
+            { label: 'Categorie', value: entry.categoryLabel },
             { label: 'Taille', value: entry.sizeLabel },
             { label: 'Esperance', value: entry.lifeExpectancyLabel },
             { label: 'Langage', value: entry.languageLabel }
@@ -198,6 +228,28 @@ function TraitList({ label, values }: Readonly<{ label: string; values: string[]
   );
 }
 
+function filterBestiaryEntries(entries: BestiaryEntryView[], query: string): BestiaryEntryView[] {
+  const normalizedQuery = normalizeSearchText(query);
+
+  if (!normalizedQuery) return entries;
+
+  return entries.filter((entry) =>
+    normalizeSearchText(
+      `${entry.name} ${entry.sourceName} ${entry.categoryLabel} ${entry.playableLabel} ${
+        entry.lore ?? ''
+      }`
+    ).includes(normalizedQuery)
+  );
+}
+
 function playableTone(entry: BestiaryEntryView): BadgeTone {
   return entry.playable ? 'success' : 'info';
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .trim();
 }

--- a/apps/game/src/features/bestiaire/model.test.ts
+++ b/apps/game/src/features/bestiaire/model.test.ts
@@ -42,6 +42,7 @@ describe('bestiaire surface view model', () => {
     expect(view.entries.map((entry) => entry.name)).toEqual(['Humain', 'Griffon']);
     expect(view.entries[0]).toMatchObject({
       category: 'humanoid',
+      categoryLabel: 'Humanoïdes',
       languageLabel: 'Langage articule',
       lifeExpectancyLabel: '75 ans',
       playableLabel: 'Race jouable',
@@ -52,12 +53,18 @@ describe('bestiaire surface view model', () => {
       playableLabel: 'Creature MJ'
     });
     expect(view.categorySummaries).toEqual([
-      { category: 'beast', count: 1 },
-      { category: 'humanoid', count: 1 }
+      { category: 'beast', count: 1, label: 'Bêtes' },
+      { category: 'humanoid', count: 1, label: 'Humanoïdes' }
     ]);
-    expect(view.sourceFiles.map((source) => source.path)).toEqual([
-      'data/legacy/web-scraped/documents/bestiaire/index.md',
-      'data/legacy/paper/regles-papier/extracted/listes/bestiaire.md'
+    expect(view.sourceFiles).toEqual([
+      {
+        label: 'Bestiaire web',
+        path: 'data/legacy/web-scraped/documents/bestiaire/index.md'
+      },
+      {
+        label: 'Bestiaire papier',
+        path: 'data/legacy/paper/regles-papier/extracted/listes/bestiaire.md'
+      }
     ]);
   });
 

--- a/apps/game/src/features/bestiaire/model.ts
+++ b/apps/game/src/features/bestiaire/model.ts
@@ -51,6 +51,7 @@ export interface BestiarySurfaceView {
 export interface BestiaryEntryView {
   attributeMaxItems: Array<{ label: string; value: number }>;
   category: string;
+  categoryLabel: string;
   habitat: string[];
   id: string;
   innateAtouts: string[];
@@ -80,10 +81,12 @@ export interface BestiaryMetrics {
 
 export interface CategorySummary {
   category: string;
+  label: string;
   count: number;
 }
 
 export interface SourceFileView {
+  label: string;
   path: string;
 }
 
@@ -128,7 +131,7 @@ export function buildBestiarySurfaceView(catalog: BestiaryCatalogDocument): Best
       playableEntries
     },
     sourceFiles: (catalog.metadata?.source_files ?? []).flatMap((source) =>
-      source.path ? [{ path: source.path }] : []
+      source.path ? [{ label: humanizeSourcePath(source.path), path: source.path }] : []
     )
   };
 }
@@ -144,6 +147,7 @@ function toEntryView(creature: BestiaryCatalogCreature): BestiaryEntryView {
       value: creature.attribute_max[key]
     })),
     category: creature.category,
+    categoryLabel: labelCreatureCategory(creature.category),
     habitat: creature.habitat ?? [],
     id: creature.id,
     innateAtouts: creature.innate_atouts ?? [],
@@ -173,8 +177,26 @@ function toCategorySummaries(entries: BestiaryEntryView[]): CategorySummary[] {
   }
 
   return [...counts.entries()]
-    .map(([category, count]) => ({ category, count }))
-    .sort((left, right) => left.category.localeCompare(right.category, 'fr'));
+    .map(([category, count]) => ({ category, count, label: labelCreatureCategory(category) }))
+    .sort((left, right) => left.label.localeCompare(right.label, 'fr'));
+}
+
+function labelCreatureCategory(category: string): string {
+  const labels: Record<string, string> = {
+    beast: 'Bêtes',
+    humanoid: 'Humanoïdes',
+    spirit: 'Esprits',
+    undead: 'Morts-vivants'
+  };
+
+  return labels[category] ?? category;
+}
+
+function humanizeSourcePath(path: string): string {
+  if (path.includes('/paper/')) return 'Bestiaire papier';
+  if (path.includes('/web-scraped/')) return 'Bestiaire web';
+
+  return 'Source bestiaire';
 }
 
 function cleanCreatureName(name: string): string {

--- a/apps/game/src/features/character-sheet/CharacterSheet.tsx
+++ b/apps/game/src/features/character-sheet/CharacterSheet.tsx
@@ -13,7 +13,6 @@ import {
   Label,
   ProgressBar,
   Seal,
-  SelectField,
   StatBlock,
   Tabs,
   Toast,
@@ -82,9 +81,6 @@ export function CharacterSheet({
   const [lastRoll, setLastRoll] = useState<AttributeRollResult | null>(null);
   const [equipmentSearch, setEquipmentSearch] = useState('');
   const [rollHistory, setRollHistory] = useState<AttributeRollResult[]>([]);
-  const [selectedEquipmentId, setSelectedEquipmentId] = useState<string>(
-    () => equipmentCatalog[0]?.id ?? ''
-  );
 
   function addEquipment(equipmentId: string) {
     const option = equipmentCatalog.find((entry) => entry.id === equipmentId);
@@ -117,12 +113,9 @@ export function CharacterSheet({
   const combatStatuses = combatStatusesFromMetadata(character.metadata.combat);
   const showGrimoire = shouldShowGrimoire(character, spells);
   const filteredEquipmentCatalog = useMemo(
-    () => filterEquipmentCatalog(equipmentCatalog, equipmentSearch),
+    () => filterEquipmentCatalog(equipmentCatalog, equipmentSearch, 8),
     [equipmentCatalog, equipmentSearch]
   );
-  const selectedEquipment =
-    filteredEquipmentCatalog.find((entry) => entry.id === selectedEquipmentId) ??
-    filteredEquipmentCatalog[0];
 
   function roll(attribute: AttributeKey) {
     const result = rollAttributeCheck(
@@ -360,34 +353,37 @@ export function CharacterSheet({
                 <Field
                   id="equipment-search"
                   label="Recherche"
+                  hint={`${filteredEquipmentCatalog.length} proposition${
+                    filteredEquipmentCatalog.length > 1 ? 's' : ''
+                  } affichée${filteredEquipmentCatalog.length > 1 ? 's' : ''}`}
                   onChange={(event) => setEquipmentSearch(event.target.value)}
                   placeholder="Épée, potion, bouclier..."
                   type="search"
                   value={equipmentSearch}
                 />
-                <SelectField
-                  id="equipment-picker"
-                  label="Équipement"
-                  onChange={(event) => setSelectedEquipmentId(event.target.value)}
-                  options={
-                    filteredEquipmentCatalog.length > 0
-                      ? filteredEquipmentCatalog.map((option) => ({
-                          label: option.name,
-                          value: option.id
-                        }))
-                      : [{ disabled: true, label: 'Aucun résultat', value: '' }]
-                  }
-                  value={selectedEquipment?.id ?? ''}
-                />
-                <Button
-                  className="kw-sheet__add-button"
-                  disabled={!selectedEquipment}
-                  onClick={() => selectedEquipment && addEquipment(selectedEquipment.id)}
-                  type="button"
-                >
-                  <PackagePlus aria-hidden="true" className="kw-sheet__button-icon" />
-                  Ajouter
-                </Button>
+                <div className="kw-sheet__equipment-results" aria-label="Équipements trouvés">
+                  {filteredEquipmentCatalog.length > 0 ? (
+                    filteredEquipmentCatalog.map((option) => (
+                      <Button
+                        className="kw-sheet__equipment-option"
+                        key={option.id}
+                        onClick={() => addEquipment(option.id)}
+                        type="button"
+                        variant="secondary"
+                      >
+                        <span>
+                          <strong>{option.name}</strong>
+                          <small>
+                            {inventoryCategoryLabel(option.category)} · {option.weightKg ?? 0} kg
+                          </small>
+                        </span>
+                        <PackagePlus aria-hidden="true" className="kw-sheet__button-icon" />
+                      </Button>
+                    ))
+                  ) : (
+                    <p className="kw-sheet__muted">Aucun équipement trouvé.</p>
+                  )}
+                </div>
               </div>
             ) : undefined
           }

--- a/apps/game/src/features/grimoire/GrimoireSurface.tsx
+++ b/apps/game/src/features/grimoire/GrimoireSurface.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useMemo, useState, type CSSProperties } from 'react';
+
+import { Badge, Button, Card, Field, Label, StatBlock } from '@knightandwizard/ui';
+
+import type { GrimoireReadModel, GrimoireSpellView } from './read-models';
+
+export function GrimoireSurface({ view }: Readonly<{ view: GrimoireReadModel }>) {
+  const [query, setQuery] = useState('');
+  const [schoolId, setSchoolId] = useState<string>('all');
+  const filteredSpells = useMemo(
+    () => filterSpells(view.spells, query, schoolId, 18),
+    [query, schoolId, view.spells]
+  );
+  const selectedSchool =
+    schoolId === 'all' ? undefined : view.schoolSummaries.find((school) => school.id === schoolId);
+
+  return (
+    <div className="kw-grimoire-page">
+      <Card>
+        <Label>Grimoire</Label>
+        <h1>Grand Grimoire</h1>
+        <p>
+          Index consultable des sorts canoniques, classés par école et reliés au lexique quand une
+          définition papier existe.
+        </p>
+        <div className="kw-grimoire__badge-row">
+          <Badge tone="info">Skin grimoire</Badge>
+          {view.sourceLabels.map((source) => (
+            <Badge key={source} tone="neutral">
+              {source}
+            </Badge>
+          ))}
+        </div>
+      </Card>
+
+      <div className="kw-grimoire__overview">
+        <Card>
+          <StatBlock
+            title="Index magique"
+            items={[
+              { label: 'Sorts', value: view.metrics.spells },
+              { label: 'Écoles', value: view.metrics.schools },
+              { label: 'Liés au lexique', value: view.metrics.lexiqueLinkedSpells }
+            ]}
+          />
+        </Card>
+        <Card>
+          <Label>Filtrer</Label>
+          <Field
+            id="grimoire-search"
+            label="Recherche"
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Barrière, énergie, illusion..."
+            type="search"
+            value={query}
+          />
+        </Card>
+      </div>
+
+      <section className="kw-grimoire__schools" aria-label="Écoles de magie">
+        <Button
+          aria-pressed={schoolId === 'all'}
+          onClick={() => setSchoolId('all')}
+          variant={schoolId === 'all' ? 'primary' : 'secondary'}
+        >
+          Toutes les écoles
+        </Button>
+        {view.schoolSummaries.map((school) => (
+          <Button
+            aria-pressed={schoolId === school.id}
+            className="kw-grimoire__school-button"
+            key={school.id}
+            onClick={() => setSchoolId(school.id)}
+            variant={schoolId === school.id ? 'primary' : 'secondary'}
+          >
+            <span
+              aria-hidden="true"
+              className="kw-swatch"
+              style={
+                {
+                  '--swatch-color': `var(--school-${schoolTokenId(school.id)}, var(--color-accent))`
+                } as CSSProperties
+              }
+            />
+            <span>{school.name}</span>
+            <Badge tone="neutral">{school.spellCount}</Badge>
+          </Button>
+        ))}
+      </section>
+
+      <div className="kw-grimoire__layout">
+        <Card>
+          <div className="kw-grimoire__panel-head">
+            <div>
+              <Label>Résultats</Label>
+              <h2>{filteredSpells.length} sorts affichés</h2>
+            </div>
+            {selectedSchool ? <Badge tone="info">{selectedSchool.name}</Badge> : null}
+          </div>
+          <div className="kw-grimoire__spell-list" aria-label="Sorts filtrés">
+            {filteredSpells.length > 0 ? (
+              filteredSpells.map((spell) => <SpellCard key={spell.id} spell={spell} />)
+            ) : (
+              <p>Aucun sort trouvé.</p>
+            )}
+          </div>
+        </Card>
+
+        <Card>
+          <Label>Écoles</Label>
+          <div className="kw-grimoire__school-list">
+            {view.schoolSummaries.map((school) => (
+              <article className="kw-grimoire__school-card" key={school.id}>
+                <div className="kw-grimoire__school-card-head">
+                  <strong>{school.name}</strong>
+                  <Badge tone="neutral">{school.color}</Badge>
+                </div>
+                <p>{school.domain}</p>
+              </article>
+            ))}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function SpellCard({ spell }: Readonly<{ spell: GrimoireSpellView }>) {
+  return (
+    <article className="kw-grimoire__spell-card">
+      <div className="kw-grimoire__spell-head">
+        <div>
+          <h3>{spell.name}</h3>
+          <p>{spell.effect}</p>
+        </div>
+        <Badge tone={spell.isLexiqueLinked ? 'success' : 'neutral'}>
+          {spell.isLexiqueLinked ? 'Lexique relié' : 'Notice courte'}
+        </Badge>
+      </div>
+      <div className="kw-grimoire__spell-meta">
+        <Badge tone="info">{spell.schoolName}</Badge>
+        <span>Énergie {formatNullableNumber(spell.energy)}</span>
+        <span>Incantation {formatNullableNumber(spell.incantationTime)} DT</span>
+        <span>Difficulté {formatNullableNumber(spell.difficulty)}</span>
+      </div>
+    </article>
+  );
+}
+
+function filterSpells(
+  spells: GrimoireSpellView[],
+  query: string,
+  schoolId: string,
+  limit: number
+): GrimoireSpellView[] {
+  const normalizedQuery = normalizeSearchText(query);
+
+  return spells
+    .filter((spell) => schoolId === 'all' || spell.schoolId === schoolId)
+    .filter((spell) => {
+      if (!normalizedQuery) return true;
+
+      return normalizeSearchText(`${spell.name} ${spell.effect} ${spell.schoolName}`).includes(
+        normalizedQuery
+      );
+    })
+    .slice(0, limit);
+}
+
+function formatNullableNumber(value: number | null): string {
+  return value === null ? 'non renseignée' : new Intl.NumberFormat('fr-FR').format(value);
+}
+
+function normalizeSearchText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLowerCase()
+    .trim();
+}
+
+function schoolTokenId(schoolId: string): string {
+  const tokenIds: Record<string, string> = {
+    'magie-blanche': 'blanche',
+    'magie-naturelle': 'naturelle',
+    'magie-noire': 'noire'
+  };
+
+  return tokenIds[schoolId] ?? schoolId;
+}

--- a/apps/game/src/features/grimoire/read-models.test.ts
+++ b/apps/game/src/features/grimoire/read-models.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/catalogs', () => ({ getCatalogDocument: vi.fn() }));
+
+import { buildGrimoireReadModel } from './read-models.js';
+
+describe('buildGrimoireReadModel', () => {
+  it('builds a searchable spell index from spells and magic schools', () => {
+    const view = buildGrimoireReadModel({
+      schools: {
+        metadata: { source: 'data/legacy/web-scraped/documents/grimoire/index.md' },
+        schools: [
+          {
+            color: 'jaune',
+            domain: 'Anti-magie',
+            id: 'abjuration',
+            name: 'Abjuration',
+            status: 'active'
+          },
+          {
+            color: 'rouge',
+            domain: 'Transformation',
+            id: 'alteration',
+            name: 'Altération',
+            status: 'active'
+          }
+        ]
+      },
+      spells: {
+        metadata: { source: 'data/legacy/web-scraped/documents/grimoire/index.md' },
+        spells: [
+          {
+            difficulty: 5,
+            effect: "Augmente l'énergie d'un sort",
+            energy: 6,
+            id: 'augmentation-energetique',
+            incantation_time: 4,
+            name: 'Augmentation énergétique',
+            prose_refs: [{ catalog: 'lexique' }],
+            school_id: 'abjuration',
+            status: 'active',
+            value: 12
+          },
+          {
+            effect: 'Archive',
+            id: 'archive',
+            name: 'Archive',
+            school_id: 'alteration',
+            status: 'raw_reference_only'
+          }
+        ]
+      }
+    });
+
+    expect(view.metrics).toEqual({
+      lexiqueLinkedSpells: 1,
+      schools: 2,
+      spells: 1
+    });
+    expect(view.schoolSummaries).toEqual([
+      {
+        color: 'jaune',
+        domain: 'Anti-magie',
+        id: 'abjuration',
+        name: 'Abjuration',
+        spellCount: 1
+      },
+      {
+        color: 'rouge',
+        domain: 'Transformation',
+        id: 'alteration',
+        name: 'Altération',
+        spellCount: 0
+      }
+    ]);
+    expect(view.spells[0]).toMatchObject({
+      id: 'augmentation-energetique',
+      isLexiqueLinked: true,
+      schoolName: 'Abjuration'
+    });
+    expect(view.sourceLabels).toEqual(['Grand Grimoire web']);
+  });
+});

--- a/apps/game/src/features/grimoire/read-models.ts
+++ b/apps/game/src/features/grimoire/read-models.ts
@@ -1,0 +1,173 @@
+import { getCatalogDocument } from '@/lib/catalogs';
+
+export interface SpellsCatalogDocument {
+  metadata?: {
+    source?: string;
+    total_entries?: number;
+  };
+  spells?: SpellCatalogEntry[];
+}
+
+export interface SpellCatalogEntry {
+  difficulty?: number;
+  effect?: string;
+  energy?: number;
+  id?: string;
+  incantation_time?: number;
+  name?: string;
+  prose_refs?: unknown[];
+  school_id?: string;
+  status?: string;
+  value?: number;
+}
+
+export interface MagicSchoolsCatalogDocument {
+  metadata?: {
+    source?: string;
+    total_entries?: number;
+  };
+  schools?: MagicSchoolCatalogEntry[];
+}
+
+export interface MagicSchoolCatalogEntry {
+  color?: string;
+  domain?: string;
+  id?: string;
+  name?: string;
+  specialist_class_id?: string;
+  status?: string;
+}
+
+export interface GrimoireReadModel {
+  metrics: {
+    lexiqueLinkedSpells: number;
+    schools: number;
+    spells: number;
+  };
+  schoolSummaries: GrimoireSchoolSummary[];
+  sourceLabels: string[];
+  spells: GrimoireSpellView[];
+}
+
+export interface GrimoireSchoolSummary {
+  color: string;
+  domain: string;
+  id: string;
+  name: string;
+  spellCount: number;
+}
+
+export interface GrimoireSpellView {
+  difficulty: number | null;
+  effect: string;
+  energy: number | null;
+  id: string;
+  incantationTime: number | null;
+  isLexiqueLinked: boolean;
+  name: string;
+  schoolId: string;
+  schoolName: string;
+  value: number | null;
+}
+
+export async function getGrimoireReadModel(): Promise<GrimoireReadModel> {
+  const [spells, schools] = await Promise.all([
+    getCatalogDocument<SpellsCatalogDocument>('spells.yaml'),
+    getCatalogDocument<MagicSchoolsCatalogDocument>('magic-schools.yaml')
+  ]);
+
+  return buildGrimoireReadModel({ schools, spells });
+}
+
+export function buildGrimoireReadModel({
+  schools,
+  spells
+}: {
+  schools: MagicSchoolsCatalogDocument;
+  spells: SpellsCatalogDocument;
+}): GrimoireReadModel {
+  const schoolEntries = (schools.schools ?? []).filter(isDisplayableSchool);
+  const schoolById = new Map(schoolEntries.map((school) => [school.id, school]));
+  const spellEntries = (spells.spells ?? [])
+    .filter(isDisplayableSpell)
+    .map((spell) => toSpellView(spell, schoolById))
+    .sort((left, right) => left.name.localeCompare(right.name, 'fr'));
+  const spellCounts = countSpellsBySchool(spellEntries);
+
+  return {
+    metrics: {
+      lexiqueLinkedSpells: spellEntries.filter((spell) => spell.isLexiqueLinked).length,
+      schools: schoolEntries.length,
+      spells: spellEntries.length
+    },
+    schoolSummaries: schoolEntries.map((school) => ({
+      color: school.color ?? 'inconnue',
+      domain: school.domain ?? 'Domaine non renseigné',
+      id: school.id,
+      name: school.name,
+      spellCount: spellCounts.get(school.id) ?? 0
+    })),
+    sourceLabels: [
+      ...new Set([
+        humanizeSourceLabel(spells.metadata?.source, 'Sorts web'),
+        humanizeSourceLabel(schools.metadata?.source, 'Écoles de magie')
+      ])
+    ],
+    spells: spellEntries
+  };
+}
+
+function isDisplayableSchool(
+  entry: MagicSchoolCatalogEntry
+): entry is RequiredNameAndId<MagicSchoolCatalogEntry> {
+  return entry.status === 'active' && Boolean(entry.id && entry.name);
+}
+
+function isDisplayableSpell(
+  entry: SpellCatalogEntry
+): entry is RequiredNameAndId<SpellCatalogEntry> {
+  return entry.status === 'active' && Boolean(entry.id && entry.name);
+}
+
+type RequiredNameAndId<Entry extends { id?: string; name?: string }> = Entry & {
+  id: string;
+  name: string;
+};
+
+function toSpellView(
+  spell: RequiredNameAndId<SpellCatalogEntry>,
+  schoolById: Map<string, RequiredNameAndId<MagicSchoolCatalogEntry>>
+): GrimoireSpellView {
+  const schoolId = spell.school_id ?? 'unknown';
+  const school = schoolById.get(schoolId);
+
+  return {
+    difficulty: typeof spell.difficulty === 'number' ? spell.difficulty : null,
+    effect: spell.effect ?? 'Effet non renseigné',
+    energy: typeof spell.energy === 'number' ? spell.energy : null,
+    id: spell.id,
+    incantationTime: typeof spell.incantation_time === 'number' ? spell.incantation_time : null,
+    isLexiqueLinked: Array.isArray(spell.prose_refs) && spell.prose_refs.length > 0,
+    name: spell.name,
+    schoolId,
+    schoolName: school?.name ?? 'École inconnue',
+    value: typeof spell.value === 'number' ? spell.value : null
+  };
+}
+
+function countSpellsBySchool(spells: GrimoireSpellView[]): Map<string, number> {
+  const counts = new Map<string, number>();
+
+  for (const spell of spells) {
+    counts.set(spell.schoolId, (counts.get(spell.schoolId) ?? 0) + 1);
+  }
+
+  return counts;
+}
+
+function humanizeSourceLabel(source: string | undefined, fallback: string): string {
+  if (!source) return fallback;
+  if (source.includes('/grimoire/')) return 'Grand Grimoire web';
+
+  return fallback;
+}

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -187,14 +187,51 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByRole('heading', { name: 'Audit complet' })).toBeVisible();
 
     await page.getByRole('tab', { name: 'Complet' }).click();
-    const equipmentPicker = page.locator('#equipment-picker');
-    await expect(equipmentPicker).toBeVisible();
-    expect(await equipmentPicker.locator('option').count()).toBeGreaterThan(0);
-    await equipmentPicker.selectOption({ index: 0 });
-    await page.getByRole('button', { name: 'Ajouter' }).click();
+    await expect(page.locator('#equipment-picker')).toHaveCount(0);
+    await page.locator('#equipment-search').fill('Potion de Soin');
+    await page
+      .getByLabel('Équipements trouvés')
+      .getByRole('button', { name: /Potion de Soin/ })
+      .click();
     await expect(
       page.locator('p.kw-sheet__muted').filter({ hasText: /Charge .* kg/ })
     ).toBeVisible();
+  });
+
+  test('catalog browsers use searchable results instead of heavy native selects', async ({
+    page
+  }, testInfo) => {
+    annotateCanonical(testInfo, 'dashboard');
+
+    await page.goto('/character');
+    await page.getByRole('tab', { name: 'Complet' }).click();
+    await expect(page.locator('select')).toHaveCount(0);
+    await page.locator('#equipment-search').fill('Potion de Soin');
+    await expect(
+      page.getByLabel('Équipements trouvés').getByRole('button', { name: /Potion de Soin/ })
+    ).toBeVisible();
+
+    await page.goto('/atouts');
+    await expect(page.locator('select')).toHaveCount(0);
+    await page.locator('#atouts-search').fill('Accoutumance');
+    await expect(
+      page
+        .getByLabel('Atouts filtrés')
+        .getByRole('heading', { name: 'Accoutumance à la douleur' })
+        .first()
+    ).toBeVisible();
+
+    await page.goto('/bestiaire');
+    await expect(page.locator('select')).toHaveCount(0);
+    await page.locator('#bestiaire-search').fill('Centaure');
+    await expect(page.getByRole('button', { name: /Centaure Humanoïdes/ })).toBeVisible();
+
+    await page.goto('/grimoire');
+    await expect(page.locator('select')).toHaveCount(0);
+    await page.locator('#grimoire-search').fill('Augmentation énergétique');
+    await expect(page.getByRole('heading', { name: 'Augmentation énergétique' })).toBeVisible();
+    await page.getByRole('button', { name: /Abjuration/ }).click();
+    await expect(page.getByText('Grand Grimoire web')).toBeVisible();
   });
 
   test('character sheet can render an API-backed saved draft', async ({ page }, testInfo) => {


### PR DESCRIPTION
## Summary
- replace the character sheet heavy native equipment select with searchable result buttons
- add searchable catalog browsers for Atouts and Bestiaire, with humanised Bestiaire category/source labels
- turn Grimoire into an API-backed searchable spell index using `spells.yaml` + `magic-schools.yaml`
- extend E2E coverage for the no-native-select/search UX invariant

## Verification
- `pnpm exec vitest run apps/game/src/features/atouts/read-models.test.ts apps/game/src/features/bestiaire/model.test.ts apps/game/src/features/grimoire/read-models.test.ts apps/game/src/features/character-sheet/model.test.ts`
- `pnpm --filter @knightandwizard/game typecheck`
- `pnpm devlab:up && pnpm devlab:test`
- `pnpm test:e2e -- --grep "character sheet exposes|catalog browsers"` prepared DB/catalogs/knowledge; arg forwarding failed before Playwright, then reran direct Playwright below
- `pnpm exec playwright test tests/e2e/app-features.spec.ts --grep "character sheet exposes|catalog browsers"`
- Browser audit on `/character`, `/atouts`, `/bestiaire`, `/grimoire`: desktop + 390px mobile, 0 selects, 1 searchbox each, 0 horizontal overflow, no forbidden internal tokens detected
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test`
- `API_BASE_URL=http://127.0.0.1:3102 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:3102 pnpm build:game`
- `pnpm canonical:check`
