### PR TITLE
feat(rules-core): #142 track effect daily uses

### DIFF
--- a/packages/rules-core/src/effect-renderer.test.ts
+++ b/packages/rules-core/src/effect-renderer.test.ts
@@ -114,6 +114,20 @@ describe('renderEffect', () => {
     expect(renderEffect(model)).toBe('Inflige niveau + 1 dégâts supplémentaires');
   });
 
+  it('renders daily use limits', () => {
+    const model = effectModel({
+      target: 'difficulty',
+      op: 'sub',
+      value: 5,
+      condition: { competence: 'danse' },
+      activation: 'active',
+      duration: 'ephemeral',
+      uses_per_day: 2
+    });
+
+    expect(renderEffect(model)).toBe('Réduit la difficulté de 5 avec la compétence danse (2/jour)');
+  });
+
   it('renders activity condition dimensions', () => {
     const model = effectModel({
       target: 'pool',

--- a/packages/rules-core/src/effect-renderer.ts
+++ b/packages/rules-core/src/effect-renderer.ts
@@ -211,8 +211,9 @@ const EFFECT_RENDER_TEMPLATES: Partial<Record<RenderTemplateKey, (spec: EffectSp
 export function renderEffect(model: EffectModel): string {
   const baseRender = renderEffectSpec(model.spec);
   const conditionRender = renderConditionSuffix(model.spec.condition);
+  const usageRender = renderDailyUseSuffix(model.spec.uses_per_day);
 
-  return `${baseRender}${conditionRender}`;
+  return `${baseRender}${conditionRender}${usageRender}`;
 }
 
 /**
@@ -241,6 +242,10 @@ function renderFallback(spec: EffectSpec): string {
   const scope = spec.scope === undefined ? '' : ` (${renderScope(spec.scope)})`;
 
   return `Applique ${spec.op} ${renderValue(spec.value)} sur ${TARGET_LABELS[spec.target]}${scope}`;
+}
+
+function renderDailyUseSuffix(usesPerDay: number | undefined): string {
+  return usesPerDay === undefined ? '' : ` (${usesPerDay}/jour)`;
 }
 
 function renderValue(value: EffectValue): string {

--- a/packages/rules-core/src/effects.test.ts
+++ b/packages/rules-core/src/effects.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
 import { parseEffectModel, type EffectModel, type EffectSpec } from './effect-model.js';
-import { computeEffectiveModifiers, effectiveAttribute } from './effects.js';
+import {
+  computeEffectiveModifiers,
+  createEffectUseLedger,
+  effectiveAttribute,
+  getEffectUseStatus,
+  recordEffectUse,
+  resetEffectUseLedgerForDay,
+  resetEffectUseLedgerForRest
+} from './effects.js';
 
 describe('effect modifier engine', () => {
   it('accumulates active additive modifiers by target and scope', () => {
@@ -163,6 +171,74 @@ describe('effect modifier engine', () => {
     });
 
     expect(modifiers.pool.musique.add).toBe(1);
+  });
+
+  it('tracks uses-per-day limits by character and gates exhausted active effects', () => {
+    const limited = effect({
+      target: 'difficulty',
+      op: 'sub',
+      value: 5,
+      activation: 'active',
+      duration: 'ephemeral',
+      uses_per_day: 1
+    });
+    const ledger = createEffectUseLedger('jour-1');
+
+    expect(getEffectUseStatus(limited, ledger, { characterId: 'aveline' })).toMatchObject({
+      allowed: true,
+      limit: 1,
+      remaining: 1,
+      used: 0
+    });
+
+    const firstUse = recordEffectUse(limited, ledger, { characterId: 'aveline' });
+    expect(firstUse.recorded).toBe(true);
+    expect(firstUse.status).toMatchObject({
+      allowed: false,
+      remaining: 0,
+      used: 1
+    });
+
+    const exhausted = computeEffectiveModifiers([limited], {
+      activations: ['active'],
+      characterId: 'aveline',
+      currentDay: 'jour-1',
+      dailyUses: firstUse.ledger
+    });
+    expect(exhausted.difficulty).toEqual({});
+
+    const otherCharacter = computeEffectiveModifiers([limited], {
+      activations: ['active'],
+      characterId: 'bastian',
+      currentDay: 'jour-1',
+      dailyUses: firstUse.ledger
+    });
+    expect(otherCharacter.difficulty.__global__.sub).toBe(5);
+  });
+
+  it('resets uses-per-day ledgers on rest and new days', () => {
+    const limited = effect({
+      target: 'pool',
+      op: 'add',
+      value: 2,
+      activation: 'active',
+      duration: 'ephemeral',
+      uses_per_day: 1
+    });
+    const used = recordEffectUse(limited, createEffectUseLedger('jour-1'), {
+      characterId: 'aveline'
+    }).ledger;
+
+    expect(getEffectUseStatus(limited, used, { characterId: 'aveline' }).allowed).toBe(false);
+
+    const afterRest = resetEffectUseLedgerForRest(used, 'aveline');
+    expect(getEffectUseStatus(limited, afterRest, { characterId: 'aveline' }).allowed).toBe(true);
+
+    const nextDay = resetEffectUseLedgerForDay('jour-2');
+    expect(getEffectUseStatus(limited, nextDay, { characterId: 'aveline' }).allowed).toBe(true);
+    expect(
+      getEffectUseStatus(limited, used, { characterId: 'aveline', day: 'jour-2' }).allowed
+    ).toBe(true);
   });
 });
 

--- a/packages/rules-core/src/effects.ts
+++ b/packages/rules-core/src/effects.ts
@@ -7,7 +7,6 @@ import {
   type EffectDuration,
   type EffectModel,
   type EffectOperation,
-  type EffectSpec,
   type EffectTarget,
   type EffectValueContext
 } from './effect-model.js';
@@ -48,6 +47,9 @@ export type EffectApplicationContext = EffectConditionContext &
     includeEphemeral?: boolean;
     predilection?: PredilectionSlots;
     activeStatuses?: readonly ActiveStatusEntry[];
+    characterId?: string;
+    currentDay?: string;
+    dailyUses?: EffectUseLedger;
     statusRegistry?: CompositeStatusRegistry;
   };
 
@@ -96,6 +98,127 @@ export interface EffectiveValueOptions {
   minimum?: number;
 }
 
+export interface EffectUseLedger {
+  day: string;
+  byCharacter: Record<string, Record<string, number>>;
+}
+
+export interface EffectUseOptions {
+  characterId: string;
+  day?: string;
+  effectKey?: string;
+}
+
+export interface EffectUseStatus {
+  allowed: boolean;
+  limited: boolean;
+  limit: number | null;
+  remaining: number | null;
+  used: number;
+}
+
+export interface RecordEffectUseResult {
+  ledger: EffectUseLedger;
+  recorded: boolean;
+  status: EffectUseStatus;
+}
+
+export function createEffectUseLedger(day: string): EffectUseLedger {
+  return { byCharacter: {}, day };
+}
+
+export function resetEffectUseLedgerForDay(day: string): EffectUseLedger {
+  return createEffectUseLedger(day);
+}
+
+export function resetEffectUseLedgerForRest(
+  ledger: EffectUseLedger,
+  characterId: string
+): EffectUseLedger {
+  const remainingCharacters = { ...ledger.byCharacter };
+  delete remainingCharacters[characterId];
+
+  return {
+    ...ledger,
+    byCharacter: remainingCharacters
+  };
+}
+
+export function effectUseKey(effect: EffectModel, overrideKey?: string): string {
+  return overrideKey ?? effect.source.ref;
+}
+
+export function getEffectUseStatus(
+  effect: EffectModel,
+  ledger: EffectUseLedger,
+  options: EffectUseOptions
+): EffectUseStatus {
+  const limit = effect.spec.uses_per_day ?? null;
+
+  if (limit === null) {
+    return {
+      allowed: true,
+      limited: false,
+      limit,
+      remaining: null,
+      used: 0
+    };
+  }
+
+  const day = options.day ?? ledger.day;
+  const used =
+    day === ledger.day
+      ? (ledger.byCharacter[options.characterId]?.[effectUseKey(effect, options.effectKey)] ?? 0)
+      : 0;
+  const remaining = Math.max(0, limit - used);
+
+  return {
+    allowed: used < limit,
+    limited: true,
+    limit,
+    remaining,
+    used
+  };
+}
+
+export function recordEffectUse(
+  effect: EffectModel,
+  ledger: EffectUseLedger,
+  options: EffectUseOptions
+): RecordEffectUseResult {
+  const day = options.day ?? ledger.day;
+  const normalizedLedger = ledger.day === day ? ledger : createEffectUseLedger(day);
+  const currentStatus = getEffectUseStatus(effect, normalizedLedger, { ...options, day });
+
+  if (!currentStatus.limited || !currentStatus.allowed) {
+    return {
+      ledger: normalizedLedger,
+      recorded: false,
+      status: currentStatus
+    };
+  }
+
+  const effectKey = effectUseKey(effect, options.effectKey);
+  const currentCharacterUses = normalizedLedger.byCharacter[options.characterId] ?? {};
+  const nextUsed = (currentCharacterUses[effectKey] ?? 0) + 1;
+  const nextLedger = {
+    ...normalizedLedger,
+    byCharacter: {
+      ...normalizedLedger.byCharacter,
+      [options.characterId]: {
+        ...currentCharacterUses,
+        [effectKey]: nextUsed
+      }
+    }
+  };
+
+  return {
+    ledger: nextLedger,
+    recorded: true,
+    status: getEffectUseStatus(effect, nextLedger, { ...options, day })
+  };
+}
+
 export function computeEffectiveModifiers(
   activeEffects: EffectModel[],
   ctx: EffectApplicationContext
@@ -107,7 +230,7 @@ export function computeEffectiveModifiers(
   for (const activeEffect of effects) {
     const effect = parseEffectModel(activeEffect);
 
-    if (!isEffectActive(effect.spec, ctx)) {
+    if (!isEffectActive(effect, ctx)) {
       continue;
     }
 
@@ -192,12 +315,30 @@ function createEmptyModifiers(): EffectiveModifiers {
   };
 }
 
-function isEffectActive(spec: EffectSpec, ctx: EffectApplicationContext): boolean {
+function isEffectActive(effect: EffectModel, ctx: EffectApplicationContext): boolean {
+  const { spec } = effect;
+
   return (
     matchesCondition(spec.condition, ctx) &&
     isActivationActive(spec.activation, ctx) &&
-    isDurationActive(spec.duration, ctx)
+    isDurationActive(spec.duration, ctx) &&
+    isDailyUseAvailable(effect, ctx)
   );
+}
+
+function isDailyUseAvailable(effect: EffectModel, ctx: EffectApplicationContext): boolean {
+  if (effect.spec.uses_per_day === undefined) {
+    return true;
+  }
+
+  if (ctx.dailyUses === undefined || ctx.characterId === undefined) {
+    return true;
+  }
+
+  return getEffectUseStatus(effect, ctx.dailyUses, {
+    characterId: ctx.characterId,
+    day: ctx.currentDay
+  }).allowed;
 }
 
 function isActivationActive(activation: EffectActivation, ctx: EffectApplicationContext): boolean {


### PR DESCRIPTION
## Summary
- complete the existing `uses_per_day` EffectModel schema support with a per-character daily usage ledger
- add day and rest reset helpers for effect usage counters
- let `computeEffectiveModifiers` optionally gate exhausted limited active effects when usage context is supplied
- render limited effects with a readable `N/jour` suffix

## Verification
- `pnpm exec vitest run packages/rules-core/src/effects.test.ts packages/rules-core/src/effect-renderer.test.ts packages/rules-core/src/effect-model.test.ts`
- `pnpm --filter @knightandwizard/rules-core typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test`
- `pnpm canonical:check`
- `pnpm build:shared`
