### PR TITLE
fix(rules-core): gate MJ-validated effects

### DIFF
--- a/packages/rules-core/src/effects.test.ts
+++ b/packages/rules-core/src/effects.test.ts
@@ -5,6 +5,7 @@ import {
   computeEffectiveModifiers,
   createEffectUseLedger,
   effectiveAttribute,
+  getEffectMjValidationStatus,
   getEffectUseStatus,
   recordEffectUse,
   resetEffectUseLedgerForDay,
@@ -239,6 +240,72 @@ describe('effect modifier engine', () => {
     expect(
       getEffectUseStatus(limited, used, { characterId: 'aveline', day: 'jour-2' }).allowed
     ).toBe(true);
+  });
+
+  it('gates MJ-validated activity effects unless their source ref is approved', () => {
+    const guarded = effect({
+      target: 'difficulty',
+      scope: 'attaque',
+      op: 'sub',
+      value: 5,
+      activation: 'active',
+      duration: 'ephemeral',
+      condition: {
+        aptitude: 'perception',
+        directness: 'direct_only',
+        intent: 'sauvegarder',
+        target_disposition: 'enemy',
+        target_tag: 'magicien'
+      },
+      requires_mj_validation: true
+    });
+
+    expect(getEffectMjValidationStatus(guarded)).toEqual({
+      required: true,
+      satisfied: false,
+      sourceRef: 'fixture:effect'
+    });
+
+    const unvalidated = computeEffectiveModifiers([guarded], {
+      activations: ['active'],
+      aptitude: 'perception',
+      directness: 'direct_only',
+      intent: 'sauvegarder',
+      target_disposition: 'enemy',
+      target_tag: ['magicien']
+    });
+    expect(unvalidated.difficulty).toEqual({});
+
+    const validated = computeEffectiveModifiers([guarded], {
+      activations: ['active'],
+      aptitude: 'perception',
+      directness: 'direct_only',
+      intent: 'sauvegarder',
+      target_disposition: 'enemy',
+      target_tag: ['magicien'],
+      validatedEffectRefs: ['fixture:effect']
+    });
+    expect(validated.difficulty.attaque.sub).toBe(5);
+  });
+
+  it('lets tables disable the global MJ validation gate explicitly', () => {
+    const guarded = effect({
+      target: 'pool',
+      op: 'add',
+      value: 1,
+      requires_mj_validation: true
+    });
+
+    expect(getEffectMjValidationStatus(guarded, { requireMjValidation: false })).toMatchObject({
+      required: false,
+      satisfied: true
+    });
+
+    const modifiers = computeEffectiveModifiers([guarded], {
+      requireMjValidation: false
+    });
+
+    expect(modifiers.pool.__global__.add).toBe(1);
   });
 });
 

--- a/packages/rules-core/src/effects.ts
+++ b/packages/rules-core/src/effects.ts
@@ -50,7 +50,9 @@ export type EffectApplicationContext = EffectConditionContext &
     characterId?: string;
     currentDay?: string;
     dailyUses?: EffectUseLedger;
+    requireMjValidation?: boolean;
     statusRegistry?: CompositeStatusRegistry;
+    validatedEffectRefs?: readonly string[];
   };
 
 export interface EffectModifierApplication {
@@ -121,6 +123,12 @@ export interface RecordEffectUseResult {
   ledger: EffectUseLedger;
   recorded: boolean;
   status: EffectUseStatus;
+}
+
+export interface EffectMjValidationStatus {
+  required: boolean;
+  satisfied: boolean;
+  sourceRef: string;
 }
 
 export function createEffectUseLedger(day: string): EffectUseLedger {
@@ -216,6 +224,30 @@ export function recordEffectUse(
     ledger: nextLedger,
     recorded: true,
     status: getEffectUseStatus(effect, nextLedger, { ...options, day })
+  };
+}
+
+export function getEffectMjValidationStatus(
+  effect: EffectModel,
+  ctx: Pick<EffectApplicationContext, 'requireMjValidation' | 'validatedEffectRefs'> = {}
+): EffectMjValidationStatus {
+  const parsed = parseEffectModel(effect);
+  const required = parsed.spec.requires_mj_validation === true && ctx.requireMjValidation !== false;
+
+  if (!required) {
+    return {
+      required: false,
+      satisfied: true,
+      sourceRef: parsed.source.ref
+    };
+  }
+
+  const satisfied = ctx.validatedEffectRefs?.includes(parsed.source.ref) ?? false;
+
+  return {
+    required,
+    satisfied,
+    sourceRef: parsed.source.ref
   };
 }
 
@@ -322,8 +354,13 @@ function isEffectActive(effect: EffectModel, ctx: EffectApplicationContext): boo
     matchesCondition(spec.condition, ctx) &&
     isActivationActive(spec.activation, ctx) &&
     isDurationActive(spec.duration, ctx) &&
+    isMjValidationSatisfied(effect, ctx) &&
     isDailyUseAvailable(effect, ctx)
   );
+}
+
+function isMjValidationSatisfied(effect: EffectModel, ctx: EffectApplicationContext): boolean {
+  return getEffectMjValidationStatus(effect, ctx).satisfied;
 }
 
 function isDailyUseAvailable(effect: EffectModel, ctx: EffectApplicationContext): boolean {


### PR DESCRIPTION
## Summary\n- gate EffectModel applications marked requires_mj_validation until their source ref is validated\n- add an explicit requireMjValidation:false override for loose table modes\n- cover activity dimensions with aptitude, target, intent, and directness conditions\n\nCloses #139\n\n## Verification\n- pnpm exec vitest run packages/rules-core/src/effects.test.ts packages/rules-core/src/effect-model.test.ts\n- pnpm --filter @knightandwizard/rules-core typecheck\n- pnpm lint\n- pnpm format:check\n- pnpm typecheck\n- pnpm test\n- pnpm canonical:check