### PR TITLE
feat(rules-core): activate granted composite statuses

### DIFF
--- a/packages/rules-core/src/status-effects.test.ts
+++ b/packages/rules-core/src/status-effects.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { computeEffectiveModifiers, effectiveAttribute } from './effects.js';
+import { parseEffectModel } from './effect-model.js';
 import {
+  activateGrantedStatuses,
   canActivate,
+  collectActivatedStatusGrants,
   COMPOSITE_STATUS_REGISTRY,
   defineCompositeStatusRegistry,
   expandActiveStatuses,
@@ -124,5 +127,74 @@ describe('composite status effects', () => {
     expect(canActivate('mj_imposed', 'gm_only', registry)).toBe(true);
     expect(canActivate('player_toggle', 'gm_only', registry)).toBe(false);
     expect(canActivate('player_toggle', 'missing_status', registry)).toBe(false);
+  });
+
+  it('turns granted status effects into active composite statuses for allowed sources', () => {
+    const grant = parseEffectModel({
+      source: {
+        prose: 'Accorde la folie furieuse.',
+        ref: 'fixture:status:fou-furieux'
+      },
+      spec: {
+        target: 'status',
+        scope: 'fou_furieux',
+        op: 'grant',
+        value: 1,
+        activation: 'active',
+        duration: 'ephemeral'
+      },
+      fidelity: 'covered'
+    });
+
+    const modifiers = computeEffectiveModifiers([grant], { activations: ['active'] });
+    const grants = collectActivatedStatusGrants(modifiers, 'player_toggle');
+
+    expect(grants).toEqual([
+      {
+        activationSource: 'player_toggle',
+        entry: { id: 'fou_furieux' },
+        id: 'fou_furieux',
+        sourceRef: 'fixture:status:fou-furieux'
+      }
+    ]);
+    expect(
+      expandActiveStatuses(activateGrantedStatuses(modifiers, 'player_toggle'), undefined, {
+        elapsedDT: 24,
+        level: 1
+      })
+    ).toHaveLength(4);
+  });
+
+  it('filters granted statuses by their activation source contract', () => {
+    const registry = defineCompositeStatusRegistry({
+      gm_only: {
+        activationSources: ['mj_imposed'],
+        effects: [
+          {
+            target: 'pool',
+            op: 'add',
+            value: 1,
+            activation: 'passive',
+            duration: 'permanent'
+          }
+        ]
+      }
+    });
+    const grant = parseEffectModel({
+      source: { prose: 'Le MJ impose un etat.', ref: 'fixture:status:gm-only' },
+      spec: {
+        target: 'status',
+        scope: 'gm_only',
+        op: 'grant',
+        value: 1,
+        activation: 'active',
+        duration: 'ephemeral'
+      },
+      fidelity: 'covered'
+    });
+    const modifiers = computeEffectiveModifiers([grant], { activations: ['active'] });
+
+    expect(activateGrantedStatuses(modifiers, 'player_toggle', registry)).toEqual([]);
+    expect(activateGrantedStatuses(modifiers, 'mj_imposed', registry)).toEqual([{ id: 'gm_only' }]);
   });
 });

--- a/packages/rules-core/src/status-effects.ts
+++ b/packages/rules-core/src/status-effects.ts
@@ -3,6 +3,7 @@ import {
   parseEffectModel,
   type EffectDuration,
   type EffectModel,
+  type EffectOperation,
   type EffectSpec,
   type EffectValueContext
 } from './effect-model.js';
@@ -32,6 +33,27 @@ export type ActiveStatusEntry =
 export type StatusExpansionContext = EffectValueContext & {
   elapsedDT?: number;
 };
+
+export interface StatusGrantApplicationView {
+  op: EffectOperation;
+  sourceRef: string;
+}
+
+export interface StatusGrantBucketView {
+  applications: readonly StatusGrantApplicationView[];
+  scope?: string;
+}
+
+export interface StatusGrantModifiersView {
+  status: Readonly<Record<string, StatusGrantBucketView>>;
+}
+
+export interface ActivatedStatusGrant {
+  activationSource: ActivationSource;
+  entry: ActiveStatusEntry;
+  id: string;
+  sourceRef: string;
+}
 
 export const COMPOSITE_STATUS_REGISTRY = defineCompositeStatusRegistry({
   fou_furieux: {
@@ -114,6 +136,47 @@ export function expandActiveStatuses(
   }
 
   return expanded;
+}
+
+export function collectActivatedStatusGrants(
+  modifiers: StatusGrantModifiersView,
+  source: ActivationSource,
+  registry: CompositeStatusRegistry = COMPOSITE_STATUS_REGISTRY
+): ActivatedStatusGrant[] {
+  const grants: ActivatedStatusGrant[] = [];
+  const seen = new Set<string>();
+
+  for (const bucket of Object.values(modifiers.status)) {
+    const statusId = bucket.scope;
+
+    if (statusId === undefined || !canActivate(source, statusId, registry)) {
+      continue;
+    }
+
+    for (const application of bucket.applications) {
+      if (application.op !== 'grant' || seen.has(statusId)) {
+        continue;
+      }
+
+      grants.push({
+        activationSource: source,
+        entry: { id: statusId },
+        id: statusId,
+        sourceRef: application.sourceRef
+      });
+      seen.add(statusId);
+    }
+  }
+
+  return grants;
+}
+
+export function activateGrantedStatuses(
+  modifiers: StatusGrantModifiersView,
+  source: ActivationSource,
+  registry: CompositeStatusRegistry = COMPOSITE_STATUS_REGISTRY
+): ActiveStatusEntry[] {
+  return collectActivatedStatusGrants(modifiers, source, registry).map((grant) => grant.entry);
 }
 
 export function canActivate(


### PR DESCRIPTION
## Summary\n- add helpers to collect status:grant applications into active composite statuses\n- enforce each status activation source contract (player_toggle, mj_validated, mj_imposed)\n- cover fou_furieux grant -> active status expansion and GM-only source filtering\n\nCloses #141\n\n## Verification\n- pnpm exec vitest run packages/rules-core/src/status-effects.test.ts packages/rules-core/src/effects.test.ts\n- pnpm --filter @knightandwizard/rules-core typecheck\n- pnpm format:check\n- pnpm lint\n- pnpm typecheck\n- pnpm test\n- pnpm canonical:check