### PR TITLE
feat(rules-core): apply effect-granted combat statuses

### DIFF
--- a/packages/rules-core/src/combat.test.ts
+++ b/packages/rules-core/src/combat.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   addCombatant,
   applyDamage,
+  applyEffectGrantedStatuses,
   applyStatus,
   createCombatState,
   declareSpellCast,
@@ -161,6 +162,45 @@ describe('combat vitality and statuses', () => {
     ).timeline[0];
 
     expect(stunned.statuses).toEqual([{ id: 'stunned', durationDT: 5, appliedAtDT: 4 }]);
+  });
+
+  it('applies combat statuses granted by active effects through the activation source', () => {
+    const state = addCombatant(createCombatState(4), {
+      ...combatant({ id: 'berserker' }),
+      activeEffects: [statusGrantEffect('fou_furieux')]
+    });
+
+    const activated = applyEffectGrantedStatuses(state, 'berserker', 'player_toggle', {
+      activations: ['active']
+    });
+    const duplicated = applyEffectGrantedStatuses(activated, 'berserker', 'player_toggle', {
+      activations: ['active']
+    });
+
+    expect(activated.timeline[0].statuses).toEqual([{ id: 'fou_furieux', appliedAtDT: 4 }]);
+    expect(activated.log.at(-1)).toMatchObject({
+      type: 'status_applied',
+      targetId: 'berserker',
+      status: { id: 'fou_furieux', appliedAtDT: 4 }
+    });
+    expect(duplicated.timeline[0].statuses).toEqual([{ id: 'fou_furieux', appliedAtDT: 4 }]);
+    expect(duplicated.log).toHaveLength(activated.log.length);
+  });
+
+  it('does not apply effect-granted combat statuses from a disallowed source', () => {
+    const state = addCombatant(createCombatState(4), {
+      ...combatant({ id: 'berserker' }),
+      activeEffects: [statusGrantEffect('fou_furieux')]
+    });
+
+    const inactive = applyEffectGrantedStatuses(state, 'berserker', 'player_toggle');
+    const missing = applyEffectGrantedStatuses(state, 'berserker', 'player_toggle', {
+      activations: ['active'],
+      statusRegistry: {}
+    });
+
+    expect(inactive.timeline[0].statuses).toEqual([]);
+    expect(missing.timeline[0].statuses).toEqual([]);
   });
 
   it('resolves the legacy endurance roll before applying damage', () => {
@@ -709,6 +749,21 @@ function factorEffect(op: 'add' | 'sub', value: number): EffectModel {
   return parseEffectModel({
     source: { prose: 'Fixture speed-factor effect.', ref: 'fixture:factor' },
     spec: { target: 'factor', op, value, activation: 'passive', duration: 'permanent' },
+    fidelity: 'covered'
+  });
+}
+
+function statusGrantEffect(statusId: string): EffectModel {
+  return parseEffectModel({
+    source: { prose: `Fixture status grant ${statusId}.`, ref: `fixture:status:${statusId}` },
+    spec: {
+      target: 'status',
+      scope: statusId,
+      op: 'grant',
+      value: 1,
+      activation: 'active',
+      duration: 'ephemeral'
+    },
     fidelity: 'covered'
   });
 }

--- a/packages/rules-core/src/combat.ts
+++ b/packages/rules-core/src/combat.ts
@@ -17,12 +17,22 @@ import {
   type EffectValueContext,
   evaluateValue
 } from './effect-model.js';
-import { applyEffectiveModifiers, computeEffectiveModifiers, effectiveValue } from './effects.js';
+import {
+  applyEffectiveModifiers,
+  computeEffectiveModifiers,
+  effectiveValue,
+  type EffectApplicationContext
+} from './effects.js';
 import {
   resolveSpellResistance,
   type SpellResistanceResult,
   type TargetResistanceProfile
 } from './resistance.js';
+import {
+  activateGrantedStatuses,
+  type ActivationSource,
+  type ActiveStatusEntry
+} from './status-effects.js';
 
 export const COMBAT_ROUND_LENGTH_DT = DEFAULT_RULES_CONFIG.combat.roundLengthDT;
 
@@ -480,6 +490,59 @@ export function applyStatus(
           status: nextTarget.statuses.find((candidate) => candidate.id === status.id)
         }
       ]
+    },
+    nextTarget
+  );
+}
+
+export function applyEffectGrantedStatuses(
+  state: CombatState,
+  targetId: string,
+  source: ActivationSource,
+  ctx: EffectApplicationContext = {}
+): CombatState {
+  const target = findCombatant(state, targetId);
+  const activeEffects = target.activeEffects ?? [];
+
+  if (activeEffects.length === 0) {
+    return state;
+  }
+
+  const modifiers = computeEffectiveModifiers(activeEffects, ctx);
+  const grantedStatuses = activateGrantedStatuses(modifiers, source, ctx.statusRegistry);
+
+  if (grantedStatuses.length === 0) {
+    return state;
+  }
+
+  let nextTarget = target;
+  const events: CombatEvent[] = [];
+
+  for (const grantedStatus of grantedStatuses) {
+    const status = combatStatusFromActiveStatus(grantedStatus, state.currentDT, ctx);
+    const beforeCount = nextTarget.statuses.length;
+    nextTarget = withStatus(nextTarget, status, state.currentDT);
+
+    if (nextTarget.statuses.length === beforeCount) {
+      continue;
+    }
+
+    events.push({
+      type: 'status_applied',
+      atDT: state.currentDT,
+      targetId,
+      status: nextTarget.statuses.find((candidate) => candidate.id === status.id)
+    });
+  }
+
+  if (events.length === 0) {
+    return state;
+  }
+
+  return replaceCombatant(
+    {
+      ...state,
+      log: [...state.log, ...events]
     },
     nextTarget
   );
@@ -1077,6 +1140,43 @@ function withStatus(combatant: Combatant, status: CombatStatus, currentDT: numbe
       }
     ]
   };
+}
+
+function combatStatusFromActiveStatus(
+  activeStatus: ActiveStatusEntry,
+  currentDT: number,
+  ctx: EffectValueContext
+): CombatStatus {
+  const durationDT = durationDTFromActiveStatus(activeStatus, ctx);
+
+  return {
+    id: activeStatusId(activeStatus),
+    ...(durationDT === undefined ? {} : { durationDT }),
+    appliedAtDT: currentDT
+  };
+}
+
+function activeStatusId(activeStatus: ActiveStatusEntry): string {
+  return typeof activeStatus === 'string'
+    ? activeStatus
+    : (activeStatus.id ?? activeStatus.statusId);
+}
+
+function durationDTFromActiveStatus(
+  activeStatus: ActiveStatusEntry,
+  ctx: EffectValueContext
+): number | undefined {
+  if (typeof activeStatus === 'string' || activeStatus.duration === undefined) {
+    return undefined;
+  }
+
+  const { duration } = activeStatus;
+
+  if (typeof duration !== 'object' || !('dt' in duration)) {
+    return undefined;
+  }
+
+  return typeof duration.dt === 'number' ? duration.dt : evaluateValue(duration.dt, ctx);
 }
 
 function replaceCombatant(state: CombatState, combatant: Combatant): CombatState {


### PR DESCRIPTION
## Summary\n- add applyEffectGrantedStatuses to materialize target:status/op:grant effects into CombatStatus entries\n- enforce activation-source filtering through the composite status registry\n- journal status_applied events and avoid duplicate combat statuses\n\nCloses #126\n\n## Verification\n- pnpm exec vitest run packages/rules-core/src/combat.test.ts packages/rules-core/src/status-effects.test.ts packages/rules-core/src/effects.test.ts\n- pnpm exec prettier --write packages/rules-core/src/combat.ts packages/rules-core/src/combat.test.ts && pnpm format:check\n- pnpm --filter @knightandwizard/rules-core typecheck\n- pnpm lint\n- pnpm test\n- pnpm canonical:check\n- pnpm typecheck