### PR TITLE
feat(server): add request user boundary

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -17,7 +17,7 @@ export function buildApp(options: FastifyServerOptions = {}): FastifyInstance {
 
     reply.header('access-control-allow-origin', origin);
     reply.header('access-control-allow-methods', 'GET,PUT,POST,PATCH,OPTIONS');
-    reply.header('access-control-allow-headers', 'content-type,authorization');
+    reply.header('access-control-allow-headers', 'content-type,authorization,x-kw-user-id');
 
     if (request.method === 'OPTIONS') {
       return reply.code(204).send();

--- a/apps/server/src/auth/user.ts
+++ b/apps/server/src/auth/user.ts
@@ -1,0 +1,26 @@
+import type { FastifyRequest } from 'fastify';
+
+export const DEFAULT_USER_ID = 'local-dev';
+export const USER_ID_HEADER = 'x-kw-user-id';
+
+export function resolveRequestUserId(request: FastifyRequest, fallback?: unknown): string {
+  return (
+    normalizeUserId(readHeader(request.headers[USER_ID_HEADER])) ??
+    normalizeUserId(fallback) ??
+    DEFAULT_USER_ID
+  );
+}
+
+export function normalizeUserId(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim();
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function readHeader(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}

--- a/apps/server/src/characters/finalize.ts
+++ b/apps/server/src/characters/finalize.ts
@@ -22,7 +22,7 @@ import {
   type RaceProfile,
   gainXP
 } from '@knightandwizard/rules-core';
-import { eq, sql as drizzleSql } from 'drizzle-orm';
+import { and, eq, sql as drizzleSql } from 'drizzle-orm';
 import { z } from 'zod';
 import { createDbClient, createSqlClient } from '../db/client.js';
 import { characterDrafts, characters } from '../db/schema.js';
@@ -43,6 +43,10 @@ export class CharacterNotFoundError extends Error {
 
 export interface CharacterPersistenceResult {
   character: Character;
+}
+
+export interface CharacterPersistenceScope {
+  userId?: string;
 }
 
 export interface CharacterCombatStateUpdate {
@@ -159,7 +163,10 @@ const CharacterCreationDraftSnapshotSchema: z.ZodType<CharacterCreationDraftSnap
   payload: CharacterCreationDraftPayloadSchema
 });
 
-export async function finalizeCharacterDraft(draftId: string): Promise<CharacterPersistenceResult> {
+export async function finalizeCharacterDraft(
+  draftId: string,
+  scope: CharacterPersistenceScope = {}
+): Promise<CharacterPersistenceResult> {
   const sql = createSqlClient();
   const db = createDbClient(sql);
 
@@ -167,7 +174,11 @@ export async function finalizeCharacterDraft(draftId: string): Promise<Character
     const draftRows = await db
       .select()
       .from(characterDrafts)
-      .where(eq(characterDrafts.id, draftId))
+      .where(
+        scope.userId
+          ? and(eq(characterDrafts.id, draftId), eq(characterDrafts.userId, scope.userId))
+          : eq(characterDrafts.id, draftId)
+      )
       .limit(1);
     const row = draftRows[0];
 
@@ -213,7 +224,10 @@ export async function finalizeCharacterDraft(draftId: string): Promise<Character
   }
 }
 
-export async function getPersistedCharacter(id: string): Promise<CharacterPersistenceResult> {
+export async function getPersistedCharacter(
+  id: string,
+  scope: CharacterPersistenceScope = {}
+): Promise<CharacterPersistenceResult> {
   const sql = createSqlClient();
   const db = createDbClient(sql);
 
@@ -221,7 +235,11 @@ export async function getPersistedCharacter(id: string): Promise<CharacterPersis
     const rows = await db
       .select({ character: characters.payload })
       .from(characters)
-      .where(eq(characters.id, id))
+      .where(
+        scope.userId
+          ? and(eq(characters.id, id), eq(characters.userId, scope.userId))
+          : eq(characters.id, id)
+      )
       .limit(1);
     const row = rows[0];
 
@@ -239,7 +257,8 @@ export async function getPersistedCharacter(id: string): Promise<CharacterPersis
 
 export async function updatePersistedCharacterCombatState(
   id: string,
-  input: CharacterCombatStateUpdate
+  input: CharacterCombatStateUpdate,
+  scope: CharacterPersistenceScope = {}
 ): Promise<CharacterPersistenceResult> {
   const sql = createSqlClient();
   const db = createDbClient(sql);
@@ -248,7 +267,11 @@ export async function updatePersistedCharacterCombatState(
     const rows = await db
       .select({ character: characters.payload })
       .from(characters)
-      .where(eq(characters.id, id))
+      .where(
+        scope.userId
+          ? and(eq(characters.id, id), eq(characters.userId, scope.userId))
+          : eq(characters.id, id)
+      )
       .limit(1);
     const row = rows[0];
 
@@ -285,7 +308,11 @@ export async function updatePersistedCharacterCombatState(
         payload: character,
         updatedAt: drizzleSql`now()`
       })
-      .where(eq(characters.id, id))
+      .where(
+        scope.userId
+          ? and(eq(characters.id, id), eq(characters.userId, scope.userId))
+          : eq(characters.id, id)
+      )
       .returning({ character: characters.payload });
 
     return {
@@ -298,7 +325,8 @@ export async function updatePersistedCharacterCombatState(
 
 export async function awardPersistedCharacterXp(
   id: string,
-  input: CharacterXpAwardUpdate
+  input: CharacterXpAwardUpdate,
+  scope: CharacterPersistenceScope = {}
 ): Promise<CharacterPersistenceResult> {
   const sql = createSqlClient();
   const db = createDbClient(sql);
@@ -307,7 +335,11 @@ export async function awardPersistedCharacterXp(
     const rows = await db
       .select({ character: characters.payload })
       .from(characters)
-      .where(eq(characters.id, id))
+      .where(
+        scope.userId
+          ? and(eq(characters.id, id), eq(characters.userId, scope.userId))
+          : eq(characters.id, id)
+      )
       .limit(1);
     const row = rows[0];
 
@@ -340,7 +372,11 @@ export async function awardPersistedCharacterXp(
         payload: character,
         updatedAt: drizzleSql`now()`
       })
-      .where(eq(characters.id, id))
+      .where(
+        scope.userId
+          ? and(eq(characters.id, id), eq(characters.userId, scope.userId))
+          : eq(characters.id, id)
+      )
       .returning({ character: characters.payload });
 
     return {

--- a/apps/server/src/routes/character-drafts.test.ts
+++ b/apps/server/src/routes/character-drafts.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { buildApp } from '../app.js';
 
@@ -47,6 +48,60 @@ describe('character draft routes', () => {
     });
   });
 
+  it('scopes draft persistence to the current request user', async () => {
+    const draftId = `draft-auth-${randomUUID()}`;
+    const draft = {
+      currentStep: 'identity',
+      payload: {
+        classId: 'garde',
+        name: 'Aveline Auth',
+        raceId: 'humain'
+      }
+    };
+
+    const saveResponse = await app.inject({
+      headers: { 'x-kw-user-id': 'player-aveline' },
+      method: 'PUT',
+      payload: draft,
+      url: `/character-drafts/${draftId}`
+    });
+    const ownerReadResponse = await app.inject({
+      headers: { 'x-kw-user-id': 'player-aveline' },
+      method: 'GET',
+      url: `/character-drafts/${draftId}`
+    });
+    const otherReadResponse = await app.inject({
+      headers: { 'x-kw-user-id': 'player-bastian' },
+      method: 'GET',
+      url: `/character-drafts/${draftId}`
+    });
+    const overwriteResponse = await app.inject({
+      headers: { 'x-kw-user-id': 'player-bastian' },
+      method: 'PUT',
+      payload: {
+        ...draft,
+        payload: { ...draft.payload, name: 'Bastian Intrus' }
+      },
+      url: `/character-drafts/${draftId}`
+    });
+
+    expect(saveResponse.statusCode).toBe(200);
+    expect(saveResponse.json()).toMatchObject({
+      id: draftId,
+      status: 'saved',
+      userId: 'player-aveline'
+    });
+    expect(ownerReadResponse.statusCode).toBe(200);
+    expect(ownerReadResponse.json()).toMatchObject({
+      id: draftId,
+      payload: draft.payload,
+      userId: 'player-aveline'
+    });
+    expect(otherReadResponse.statusCode).toBe(404);
+    expect(overwriteResponse.statusCode).toBe(409);
+    expect(overwriteResponse.json()).toEqual({ status: 'owner_conflict' });
+  });
+
   it('allows browser preflight requests from the game app', async () => {
     const response = await app.inject({
       headers: {
@@ -60,5 +115,6 @@ describe('character draft routes', () => {
     expect(response.statusCode).toBe(204);
     expect(response.headers['access-control-allow-origin']).toBe('http://localhost:3000');
     expect(response.headers['access-control-allow-methods']).toContain('PUT');
+    expect(response.headers['access-control-allow-headers']).toContain('x-kw-user-id');
   });
 });

--- a/apps/server/src/routes/character-drafts.ts
+++ b/apps/server/src/routes/character-drafts.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import type postgres from 'postgres';
+import { normalizeUserId, resolveRequestUserId } from '../auth/user.js';
 import { createSqlClient } from '../db/client.js';
 
 interface CharacterDraftRequestBody {
@@ -28,7 +29,7 @@ export async function registerCharacterDraftRoutes(app: FastifyInstance): Promis
       }
 
       const sql = createSqlClient();
-      const userId = typeof request.body.userId === 'string' ? request.body.userId : 'local-dev';
+      const userId = resolveRequestUserId(request, request.body.userId);
       const payload = request.body.payload as postgres.JSONValue;
 
       try {
@@ -47,9 +48,16 @@ export async function registerCharacterDraftRoutes(app: FastifyInstance): Promis
             current_step = EXCLUDED.current_step,
             payload = EXCLUDED.payload,
             updated_at = now()
+          WHERE character_drafts.user_id = EXCLUDED.user_id
           RETURNING id, user_id, current_step, payload, updated_at
         `;
         const row = rows[0];
+
+        if (!row) {
+          return reply.code(409).send({
+            status: 'owner_conflict'
+          });
+        }
 
         return {
           currentStep: row.current_step,
@@ -69,12 +77,14 @@ export async function registerCharacterDraftRoutes(app: FastifyInstance): Promis
     '/character-drafts/:id',
     async (request, reply) => {
       const sql = createSqlClient();
+      const userId = resolveRequestUserId(request);
 
       try {
         const rows = await sql<CharacterDraftRow[]>`
           SELECT id, user_id, current_step, payload, updated_at
           FROM character_drafts
           WHERE id = ${request.params.id}
+            AND user_id = ${userId}
         `;
         const row = rows[0];
 
@@ -116,6 +126,10 @@ function validateDraftBody(body: CharacterDraftRequestBody): { errors: string[];
 
   if (!isRecord(body.payload)) {
     errors.push('payload must be an object');
+  }
+
+  if (body.userId !== undefined && normalizeUserId(body.userId) === undefined) {
+    errors.push('userId must be a non-empty string');
   }
 
   return {

--- a/apps/server/src/routes/characters.test.ts
+++ b/apps/server/src/routes/characters.test.ts
@@ -48,6 +48,68 @@ describe('character routes', () => {
     });
   });
 
+  it('scopes character finalization and mutations to the current request user', async () => {
+    const draftId = `route-auth-character-${randomUUID()}`;
+
+    await app.inject({
+      headers: { 'x-kw-user-id': 'player-aveline' },
+      method: 'PUT',
+      payload: sampleDraft('Aveline Authentifiee'),
+      url: `/character-drafts/${draftId}`
+    });
+
+    const deniedFinalizeResponse = await app.inject({
+      headers: { 'x-kw-user-id': 'player-bastian' },
+      method: 'POST',
+      payload: { draftId },
+      url: '/characters/finalize'
+    });
+    const finalizeResponse = await app.inject({
+      headers: { 'x-kw-user-id': 'player-aveline' },
+      method: 'POST',
+      payload: { draftId },
+      url: '/characters/finalize'
+    });
+    const ownerReadResponse = await app.inject({
+      headers: { 'x-kw-user-id': 'player-aveline' },
+      method: 'GET',
+      url: `/characters/${draftId}`
+    });
+    const otherReadResponse = await app.inject({
+      headers: { 'x-kw-user-id': 'player-bastian' },
+      method: 'GET',
+      url: `/characters/${draftId}`
+    });
+    const otherCombatResponse = await app.inject({
+      headers: { 'x-kw-user-id': 'player-bastian' },
+      method: 'PATCH',
+      payload: { vitality: { current: 1 } },
+      url: `/characters/${draftId}/combat-state`
+    });
+    const otherXpResponse = await app.inject({
+      headers: { 'x-kw-user-id': 'player-bastian' },
+      method: 'POST',
+      payload: { amount: 1, reason: 'Intrusion' },
+      url: `/characters/${draftId}/xp-awards`
+    });
+
+    expect(deniedFinalizeResponse.statusCode).toBe(404);
+    expect(finalizeResponse.statusCode).toBe(201);
+    expect(finalizeResponse.json()).toMatchObject({
+      character: {
+        id: draftId,
+        name: 'Aveline Authentifiee',
+        userId: 'player-aveline'
+      },
+      status: 'finalized'
+    });
+    expect(ownerReadResponse.statusCode).toBe(200);
+    expect(ownerReadResponse.json().character.userId).toBe('player-aveline');
+    expect(otherReadResponse.statusCode).toBe(404);
+    expect(otherCombatResponse.statusCode).toBe(404);
+    expect(otherXpResponse.statusCode).toBe(404);
+  });
+
   it('updates persisted combat vitality and statuses for the character sheet', async () => {
     const draftId = `route-combat-character-${randomUUID()}`;
 

--- a/apps/server/src/routes/characters.ts
+++ b/apps/server/src/routes/characters.ts
@@ -9,6 +9,7 @@ import {
   type CharacterCombatStateUpdate,
   type CharacterXpAwardUpdate
 } from '../characters/finalize.js';
+import { resolveRequestUserId } from '../auth/user.js';
 
 interface FinalizeCharacterRequestBody {
   draftId?: unknown;
@@ -51,7 +52,9 @@ export async function registerCharacterRoutes(app: FastifyInstance): Promise<voi
       }
 
       try {
-        const result = await finalizeCharacterDraft(draftId);
+        const result = await finalizeCharacterDraft(draftId, {
+          userId: resolveRequestUserId(request)
+        });
 
         return reply.code(201).send({
           character: result.character,
@@ -65,7 +68,9 @@ export async function registerCharacterRoutes(app: FastifyInstance): Promise<voi
 
   app.get<{ Params: CharacterParams }>('/characters/:id', async (request, reply) => {
     try {
-      const result = await getPersistedCharacter(request.params.id);
+      const result = await getPersistedCharacter(request.params.id, {
+        userId: resolveRequestUserId(request)
+      });
 
       return {
         character: result.character,
@@ -91,7 +96,8 @@ export async function registerCharacterRoutes(app: FastifyInstance): Promise<voi
       try {
         const result = await updatePersistedCharacterCombatState(
           request.params.id,
-          validation.input
+          validation.input,
+          { userId: resolveRequestUserId(request) }
         );
 
         return {
@@ -117,7 +123,9 @@ export async function registerCharacterRoutes(app: FastifyInstance): Promise<voi
       }
 
       try {
-        const result = await awardPersistedCharacterXp(request.params.id, validation.input);
+        const result = await awardPersistedCharacterXp(request.params.id, validation.input, {
+          userId: resolveRequestUserId(request)
+        });
 
         return {
           character: result.character,

--- a/tests/e2e/backend-gm.spec.ts
+++ b/tests/e2e/backend-gm.spec.ts
@@ -19,6 +19,7 @@ test.describe('K&W backend, RAG and GM runtime flows', () => {
     const draftId = `e2e-draft-${suffix}`;
     const sessionSlug = `e2e-session-${suffix}`;
     const gmSessionId = `e2e-gm-${suffix}`;
+    const e2eUserHeaders = { 'x-kw-user-id': 'e2e' };
     const canonicalLinks = {
       characters: ['aveline'],
       objects: ['relique-brisee'],
@@ -73,13 +74,22 @@ test.describe('K&W backend, RAG and GM runtime flows', () => {
           rules: 'character creation draft persistence'
         },
         userId: 'e2e'
-      }
+      },
+      e2eUserHeaders
     );
 
-    await expectJson(request, 'GET', `/character-drafts/${draftId}`, 200, (body) => {
-      expect(body.status).toBe('found');
-      expect(asRecord(body.payload).name).toBe(canonicalE2EFixtures.actors.avelineDraftName);
-    });
+    await expectJson(
+      request,
+      'GET',
+      `/character-drafts/${draftId}`,
+      200,
+      (body) => {
+        expect(body.status).toBe('found');
+        expect(asRecord(body.payload).name).toBe(canonicalE2EFixtures.actors.avelineDraftName);
+      },
+      undefined,
+      e2eUserHeaders
+    );
 
     await expectJson(
       request,
@@ -274,11 +284,15 @@ async function expectJson(
   path: string,
   expectedStatus: number,
   assertBody: (body: JsonObject) => void,
-  data?: Record<string, unknown>
+  data?: Record<string, unknown>,
+  headers: Record<string, string> = {}
 ): Promise<JsonObject> {
   const response = await request.fetch(`${apiBaseUrl}${path}`, {
     data,
-    headers: data ? { 'content-type': 'application/json' } : undefined,
+    headers: {
+      ...(data ? { 'content-type': 'application/json' } : {}),
+      ...headers
+    },
     method
   });
   const body = asRecord(await response.json());


### PR DESCRIPTION
Summary: add a minimal request identity boundary for #170 using x-kw-user-id with local-dev fallback; scope character drafts and persisted character routes to the current request user; prevent cross-user draft overwrite; allow the header through CORS. Verification: focused RED/GREEN route tests; adjacent route tests; pnpm canonical:check; pnpm lint; pnpm format:check; pnpm typecheck; pnpm build:shared; pnpm test; pnpm validate:geojson.