### PR TITLE
feat(server): persist character active spells

### DIFF
--- a/apps/server/drizzle/0008_character_active_spells.sql
+++ b/apps/server/drizzle/0008_character_active_spells.sql
@@ -1,0 +1,27 @@
+CREATE TABLE IF NOT EXISTS character_active_spells (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES game_sessions (id) ON DELETE CASCADE,
+  character_id text NOT NULL REFERENCES characters (id) ON DELETE CASCADE,
+  active_spell_id text NOT NULL,
+  spell_id text,
+  source_caster_id text,
+  cast_at_sequence integer NOT NULL,
+  cast_at_narrative_seconds double precision NOT NULL DEFAULT 0,
+  duration_amount double precision NOT NULL DEFAULT 0,
+  duration_unit text NOT NULL CHECK (duration_unit IN ('DT', 'minute', 'hour', 'day', 'permanent')),
+  successes_count integer,
+  expires_at_narrative_seconds double precision,
+  expires_at_combat_dt integer,
+  last_renewed_at timestamptz,
+  dispelled_at_sequence integer,
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'dispelled', 'expired')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS character_active_spells_session_character_spell_idx
+  ON character_active_spells (session_id, character_id, active_spell_id);
+CREATE INDEX IF NOT EXISTS character_active_spells_character_status_idx
+  ON character_active_spells (character_id, status);
+CREATE INDEX IF NOT EXISTS character_active_spells_session_idx
+  ON character_active_spells (session_id);

--- a/apps/server/src/characters/finalize.ts
+++ b/apps/server/src/characters/finalize.ts
@@ -45,6 +45,22 @@ export interface CharacterPersistenceResult {
   character: Character;
 }
 
+export interface CharacterActiveSpellReadModel {
+  activeSpellId: string;
+  castAtNarrativeSeconds: number;
+  castAtSequence: number;
+  characterId: string;
+  durationAmount: number;
+  durationUnit: string;
+  expiresAtCombatDt?: number;
+  expiresAtNarrativeSeconds?: number;
+  sourceCasterId?: string;
+  spellId?: string;
+  status: string;
+  successesCount?: number;
+  sessionSlug: string;
+}
+
 export interface CharacterPersistenceScope {
   userId?: string;
 }
@@ -71,6 +87,22 @@ interface CharacterCreationCatalog {
   equipment: Array<{ id: string; name: string }>;
   orientations: CharacterOrientationProfile[];
   races: RaceProfile[];
+}
+
+interface CharacterActiveSpellRow {
+  active_spell_id: string;
+  cast_at_narrative_seconds: number | string;
+  cast_at_sequence: number;
+  character_id: string;
+  duration_amount: number | string;
+  duration_unit: string;
+  expires_at_combat_dt: null | number;
+  expires_at_narrative_seconds: null | number | string;
+  session_slug: string;
+  source_caster_id: null | string;
+  spell_id: null | string;
+  status: string;
+  successes_count: null | number;
 }
 
 interface CharacterCreationDraftSnapshot {
@@ -250,6 +282,56 @@ export async function getPersistedCharacter(
     return {
       character: row.character
     };
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+export async function listPersistedCharacterActiveSpells(
+  id: string,
+  scope: CharacterPersistenceScope = {}
+): Promise<CharacterActiveSpellReadModel[]> {
+  const sql = createSqlClient();
+  const db = createDbClient(sql);
+
+  try {
+    const characterRows = await db
+      .select({ id: characters.id })
+      .from(characters)
+      .where(
+        scope.userId
+          ? and(eq(characters.id, id), eq(characters.userId, scope.userId))
+          : eq(characters.id, id)
+      )
+      .limit(1);
+
+    if (characterRows.length === 0) {
+      throw new CharacterNotFoundError(id);
+    }
+
+    const spellRows = await sql<CharacterActiveSpellRow[]>`
+      SELECT
+        cas.character_id,
+        cas.active_spell_id,
+        cas.spell_id,
+        cas.source_caster_id,
+        cas.cast_at_sequence,
+        cas.cast_at_narrative_seconds,
+        cas.duration_amount,
+        cas.duration_unit,
+        cas.successes_count,
+        cas.expires_at_narrative_seconds,
+        cas.expires_at_combat_dt,
+        cas.status,
+        gs.slug AS session_slug
+      FROM character_active_spells cas
+      JOIN game_sessions gs ON gs.id = cas.session_id
+      WHERE cas.character_id = ${id}
+        AND cas.status = 'active'
+      ORDER BY cas.cast_at_sequence ASC, cas.created_at ASC
+    `;
+
+    return spellRows.map(toCharacterActiveSpellReadModel);
   } finally {
     await sql.end({ timeout: 5 });
   }
@@ -539,6 +621,28 @@ function requireSelection<T>(value: T | undefined, label: string): T {
   }
 
   return value;
+}
+
+function toCharacterActiveSpellReadModel(
+  row: CharacterActiveSpellRow
+): CharacterActiveSpellReadModel {
+  return {
+    activeSpellId: row.active_spell_id,
+    castAtNarrativeSeconds: Number(row.cast_at_narrative_seconds),
+    castAtSequence: row.cast_at_sequence,
+    characterId: row.character_id,
+    durationAmount: Number(row.duration_amount),
+    durationUnit: row.duration_unit,
+    ...(row.expires_at_combat_dt !== null ? { expiresAtCombatDt: row.expires_at_combat_dt } : {}),
+    ...(row.expires_at_narrative_seconds !== null
+      ? { expiresAtNarrativeSeconds: Number(row.expires_at_narrative_seconds) }
+      : {}),
+    ...(row.source_caster_id !== null ? { sourceCasterId: row.source_caster_id } : {}),
+    ...(row.spell_id !== null ? { spellId: row.spell_id } : {}),
+    status: row.status,
+    ...(row.successes_count !== null ? { successesCount: row.successes_count } : {}),
+    sessionSlug: row.session_slug
+  };
 }
 
 function cleanName(name: string): string {

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -2,6 +2,7 @@ import { sql } from 'drizzle-orm';
 import {
   boolean,
   customType,
+  doublePrecision,
   index,
   integer,
   jsonb,
@@ -34,6 +35,7 @@ export const REQUIRED_APP_TABLES = [
   'catalog_documents',
   'character_drafts',
   'characters',
+  'character_active_spells',
   'game_sessions',
   'session_players',
   'session_scenes',
@@ -120,6 +122,46 @@ export const gameSessions = pgTable(
   (table) => ({
     slugIdx: uniqueIndex('game_sessions_slug_idx').on(table.slug),
     statusIdx: index('game_sessions_status_idx').on(table.status)
+  })
+);
+
+export const characterActiveSpells = pgTable(
+  'character_active_spells',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    sessionId: uuid('session_id')
+      .notNull()
+      .references(() => gameSessions.id, { onDelete: 'cascade' }),
+    characterId: text('character_id')
+      .notNull()
+      .references(() => characters.id, { onDelete: 'cascade' }),
+    activeSpellId: text('active_spell_id').notNull(),
+    spellId: text('spell_id'),
+    sourceCasterId: text('source_caster_id'),
+    castAtSequence: integer('cast_at_sequence').notNull(),
+    castAtNarrativeSeconds: doublePrecision('cast_at_narrative_seconds').notNull().default(0),
+    durationAmount: doublePrecision('duration_amount').notNull().default(0),
+    durationUnit: text('duration_unit').notNull(),
+    successesCount: integer('successes_count'),
+    expiresAtNarrativeSeconds: doublePrecision('expires_at_narrative_seconds'),
+    expiresAtCombatDt: integer('expires_at_combat_dt'),
+    lastRenewedAt: timestamp('last_renewed_at', { withTimezone: true }),
+    dispelledAtSequence: integer('dispelled_at_sequence'),
+    status: text('status').notNull().default('active'),
+    createdAt: now(),
+    updatedAt: updatedNow()
+  },
+  (table) => ({
+    characterStatusIdx: index('character_active_spells_character_status_idx').on(
+      table.characterId,
+      table.status
+    ),
+    sessionCharacterSpellIdx: uniqueIndex('character_active_spells_session_character_spell_idx').on(
+      table.sessionId,
+      table.characterId,
+      table.activeSpellId
+    ),
+    sessionIdx: index('character_active_spells_session_idx').on(table.sessionId)
   })
 );
 

--- a/apps/server/src/routes/characters.ts
+++ b/apps/server/src/routes/characters.ts
@@ -5,6 +5,7 @@ import {
   awardPersistedCharacterXp,
   finalizeCharacterDraft,
   getPersistedCharacter,
+  listPersistedCharacterActiveSpells,
   updatePersistedCharacterCombatState,
   type CharacterCombatStateUpdate,
   type CharacterXpAwardUpdate
@@ -35,6 +36,7 @@ interface CharacterParams {
 
 export async function registerCharacterRoutes(app: FastifyInstance): Promise<void> {
   app.options('/characters/finalize', async (_request, reply) => reply.code(204).send());
+  app.options('/characters/:id/active-spells', async (_request, reply) => reply.code(204).send());
   app.options('/characters/:id/combat-state', async (_request, reply) => reply.code(204).send());
   app.options('/characters/:id/xp-awards', async (_request, reply) => reply.code(204).send());
   app.options('/characters/:id', async (_request, reply) => reply.code(204).send());
@@ -65,6 +67,21 @@ export async function registerCharacterRoutes(app: FastifyInstance): Promise<voi
       }
     }
   );
+
+  app.get<{ Params: CharacterParams }>('/characters/:id/active-spells', async (request, reply) => {
+    try {
+      const activeSpells = await listPersistedCharacterActiveSpells(request.params.id, {
+        userId: resolveRequestUserId(request)
+      });
+
+      return {
+        activeSpells,
+        status: 'found'
+      };
+    } catch (error) {
+      return sendCharacterRouteError(error, reply);
+    }
+  });
 
   app.get<{ Params: CharacterParams }>('/characters/:id', async (request, reply) => {
     try {

--- a/apps/server/src/routes/sessions.test.ts
+++ b/apps/server/src/routes/sessions.test.ts
@@ -666,6 +666,152 @@ describe('session routes', () => {
     expect(expiredState.activeSpells).toEqual([]);
   });
 
+  it('persists active spell instances per target character from session events (R-8.20)', async () => {
+    const slug = `character-spell-session-${randomUUID()}`;
+    const characterId = `active-spell-target-${randomUUID()}`;
+
+    await app.inject({
+      method: 'PUT',
+      payload: sampleCharacterDraft('Aveline Protegee'),
+      url: `/character-drafts/${characterId}`
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { draftId: characterId },
+      url: '/characters/finalize'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { mode: 'digital_human_gm', slug, title: 'Character Spell API' },
+      url: '/sessions'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { actorId: 'gm', eventType: 'narrative_time_advanced', payload: { hours: 1 } },
+      url: `/sessions/${slug}/events`
+    });
+    const castResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        eventType: 'spell_cast',
+        payload: {
+          activeSpellId: 'spell-aura-character',
+          durationAmount: 10,
+          durationUnit: 'minute',
+          spellId: 'aura-de-courage',
+          successesCount: 3,
+          targetId: characterId
+        }
+      },
+      url: `/sessions/${slug}/events`
+    });
+    const activeResponse = await app.inject({
+      method: 'GET',
+      url: `/characters/${characterId}/active-spells`
+    });
+
+    expect(castResponse.statusCode).toBe(201);
+    expect(activeResponse.statusCode).toBe(200);
+    expect(activeResponse.json()).toEqual({
+      activeSpells: [
+        {
+          activeSpellId: 'spell-aura-character',
+          castAtNarrativeSeconds: 3_600,
+          castAtSequence: 2,
+          characterId,
+          durationAmount: 10,
+          durationUnit: 'minute',
+          expiresAtNarrativeSeconds: 4_200,
+          sourceCasterId: 'gm',
+          spellId: 'aura-de-courage',
+          status: 'active',
+          successesCount: 3,
+          sessionSlug: slug
+        }
+      ],
+      status: 'found'
+    });
+
+    await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        eventType: 'spell_dispelled',
+        payload: { activeSpellId: 'spell-aura-character', targetId: characterId }
+      },
+      url: `/sessions/${slug}/events`
+    });
+    const afterDispelResponse = await app.inject({
+      method: 'GET',
+      url: `/characters/${characterId}/active-spells`
+    });
+
+    expect(afterDispelResponse.statusCode).toBe(200);
+    expect(afterDispelResponse.json()).toEqual({
+      activeSpells: [],
+      status: 'found'
+    });
+  });
+
+  it('expires persisted character active spells when narrative time passes their duration', async () => {
+    const slug = `character-spell-expiry-${randomUUID()}`;
+    const characterId = `active-spell-expiry-target-${randomUUID()}`;
+
+    await app.inject({
+      method: 'PUT',
+      payload: sampleCharacterDraft('Aveline Chronometree'),
+      url: `/character-drafts/${characterId}`
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { draftId: characterId },
+      url: '/characters/finalize'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { mode: 'digital_human_gm', slug, title: 'Character Spell Expiry API' },
+      url: '/sessions'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        eventType: 'spell_cast',
+        payload: {
+          activeSpellId: 'spell-short-character',
+          durationAmount: 1,
+          durationUnit: 'minute',
+          spellId: 'aura-breve',
+          targetId: characterId
+        }
+      },
+      url: `/sessions/${slug}/events`
+    });
+
+    const activeResponse = await app.inject({
+      method: 'GET',
+      url: `/characters/${characterId}/active-spells`
+    });
+    expect(activeResponse.json().activeSpells).toHaveLength(1);
+
+    await app.inject({
+      method: 'POST',
+      payload: { actorId: 'gm', eventType: 'narrative_time_advanced', payload: { minutes: 1 } },
+      url: `/sessions/${slug}/events`
+    });
+    const expiredResponse = await app.inject({
+      method: 'GET',
+      url: `/characters/${characterId}/active-spells`
+    });
+
+    expect(expiredResponse.statusCode).toBe(200);
+    expect(expiredResponse.json()).toEqual({
+      activeSpells: [],
+      status: 'found'
+    });
+  });
+
   it('rejects invalid session payloads', async () => {
     const response = await app.inject({
       method: 'POST',

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -11,9 +11,12 @@ import {
   SESSION_DECISION_STATUSES,
   SESSION_MODES,
   SESSION_STATUSES,
+  SPELL_DURATION_UNITS,
   createSessionState,
+  durationToSeconds,
   projectSessionStateFromJournal,
-  revertSessionToSequence
+  revertSessionToSequence,
+  type SpellDurationUnit
 } from '@knightandwizard/rules-core';
 import type postgres from 'postgres';
 import { createSqlClient } from '../db/client.js';
@@ -103,6 +106,7 @@ interface SessionEntityLinks {
 const validModes = new Set<string>(SESSION_MODES);
 const validStatuses = new Set<string>(SESSION_STATUSES);
 const validPriorities = new Set<string>(SESSION_DECISION_PRIORITIES);
+const validSpellDurationUnits = new Set<string>(SPELL_DURATION_UNITS);
 // A decision cannot be *resolved* into the 'pending' state.
 const validDecisionStatuses = new Set<string>(
   SESSION_DECISION_STATUSES.filter((status) => status !== 'pending')
@@ -591,6 +595,18 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
             WHERE session_id = ${session.id}
           `;
           const sequence = sequenceRows[0]!.next_sequence;
+          const needsPriorEventRows =
+            eventType === 'spell_cast' ||
+            eventType === 'narrative_time_advanced' ||
+            eventType === 'combat_ended';
+          const priorEventRows = needsPriorEventRows
+            ? await tx<SessionEventRow[]>`
+                  SELECT id, session_id, sequence, event_type, actor_id, payload, created_at
+                  FROM session_events
+                  WHERE session_id = ${session.id}
+                  ORDER BY sequence ASC
+                `
+            : [];
           const eventRows = await tx<SessionEventRow[]>`
             INSERT INTO session_events (session_id, sequence, event_type, actor_id, payload)
             VALUES (
@@ -602,6 +618,7 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
             )
             RETURNING id, session_id, sequence, event_type, actor_id, payload, created_at
           `;
+          const event = eventRows[0]!;
 
           await tx`
             INSERT INTO audit_events (actor_id, action, entity_type, entity_id, payload)
@@ -609,7 +626,7 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
               ${actorId},
               'session.event.appended',
               'session_event',
-              ${eventRows[0]!.id},
+              ${event.id},
               ${tx.json(
                 attachLinks(
                   {
@@ -622,13 +639,14 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
               )}::jsonb
             )
           `;
+          await persistCharacterActiveSpellEvent(tx, session, event, priorEventRows);
           await tx`
             UPDATE game_sessions
             SET updated_at = now()
             WHERE id = ${session.id}
           `;
 
-          return { event: eventRows[0]!, status: 'created' as const };
+          return { event, status: 'created' as const };
         });
 
         if (result.status === 'not_found') {
@@ -1196,6 +1214,18 @@ interface SessionDecisionRow {
   updated_at: Date | string;
 }
 
+interface CharacterActiveSpellCast {
+  activeSpellId: string;
+  characterId: string;
+  durationAmount: number;
+  durationUnit: SpellDurationUnit;
+  expiresAtCombatDt: null | number;
+  expiresAtNarrativeSeconds: null | number;
+  sourceCasterId: null | string;
+  spellId: null | string;
+  successesCount: null | number;
+}
+
 function validateCreateSessionBody(body: CreateSessionRequestBody): ValidationResult {
   const errors: string[] = [];
 
@@ -1542,6 +1572,24 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+function readNonEmptyString(value: unknown): string | undefined {
+  return isNonEmptyString(value) ? value.trim() : undefined;
+}
+
+function readSpellDurationUnit(value: unknown): SpellDurationUnit | undefined {
+  return typeof value === 'string' && validSpellDurationUnits.has(value)
+    ? (value as SpellDurationUnit)
+    : undefined;
+}
+
+function readNonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function readNonNegativeInteger(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
 function splitSessionMetadata(metadata: Record<string, unknown>): {
   metadata: Record<string, unknown>;
   players: SessionPlayer[] | undefined;
@@ -1706,6 +1754,182 @@ async function upsertSessionSceneRow(
   `;
 
   return rows[0]!;
+}
+
+async function persistCharacterActiveSpellEvent(
+  sql: SessionSql,
+  session: SessionRow,
+  event: SessionEventRow,
+  priorEventRows: SessionEventRow[]
+): Promise<void> {
+  if (event.event_type === 'spell_cast') {
+    const stateBeforeCast = buildSessionState(session, priorEventRows, []);
+    const cast = readCharacterActiveSpellCast(event, stateBeforeCast.narrativeSeconds);
+
+    if (cast === undefined) {
+      return;
+    }
+
+    await expireCharacterActiveSpells(sql, session.id, stateBeforeCast.narrativeSeconds);
+    const characterRows = await sql<{ id: string }[]>`
+      SELECT id
+      FROM characters
+      WHERE id = ${cast.characterId}
+    `;
+
+    if (characterRows.length === 0) {
+      return;
+    }
+
+    await sql`
+      INSERT INTO character_active_spells (
+        session_id,
+        character_id,
+        active_spell_id,
+        spell_id,
+        source_caster_id,
+        cast_at_sequence,
+        cast_at_narrative_seconds,
+        duration_amount,
+        duration_unit,
+        successes_count,
+        expires_at_narrative_seconds,
+        expires_at_combat_dt,
+        status,
+        dispelled_at_sequence,
+        updated_at
+      )
+      VALUES (
+        ${session.id},
+        ${cast.characterId},
+        ${cast.activeSpellId},
+        ${cast.spellId},
+        ${cast.sourceCasterId},
+        ${event.sequence},
+        ${stateBeforeCast.narrativeSeconds},
+        ${cast.durationAmount},
+        ${cast.durationUnit},
+        ${cast.successesCount},
+        ${cast.expiresAtNarrativeSeconds},
+        ${cast.expiresAtCombatDt},
+        'active',
+        null,
+        now()
+      )
+      ON CONFLICT (session_id, character_id, active_spell_id)
+      DO UPDATE SET
+        spell_id = EXCLUDED.spell_id,
+        source_caster_id = EXCLUDED.source_caster_id,
+        cast_at_sequence = EXCLUDED.cast_at_sequence,
+        cast_at_narrative_seconds = EXCLUDED.cast_at_narrative_seconds,
+        duration_amount = EXCLUDED.duration_amount,
+        duration_unit = EXCLUDED.duration_unit,
+        successes_count = EXCLUDED.successes_count,
+        expires_at_narrative_seconds = EXCLUDED.expires_at_narrative_seconds,
+        expires_at_combat_dt = EXCLUDED.expires_at_combat_dt,
+        status = 'active',
+        dispelled_at_sequence = null,
+        updated_at = now()
+    `;
+    return;
+  }
+
+  if (event.event_type === 'narrative_time_advanced' || event.event_type === 'combat_ended') {
+    const stateAfterAdvance = buildSessionState(session, [...priorEventRows, event], []);
+
+    await expireCharacterActiveSpells(sql, session.id, stateAfterAdvance.narrativeSeconds);
+    return;
+  }
+
+  if (event.event_type !== 'spell_dispelled') {
+    return;
+  }
+
+  const activeSpellId =
+    readNonEmptyString(event.payload.activeSpellId) ?? readNonEmptyString(event.payload.id);
+
+  if (activeSpellId === undefined) {
+    return;
+  }
+
+  const targetId = readNonEmptyString(event.payload.targetId);
+
+  if (targetId !== undefined) {
+    await sql`
+      UPDATE character_active_spells
+      SET
+        status = 'dispelled',
+        dispelled_at_sequence = ${event.sequence},
+        updated_at = now()
+      WHERE session_id = ${session.id}
+        AND character_id = ${targetId}
+        AND active_spell_id = ${activeSpellId}
+        AND status = 'active'
+    `;
+    return;
+  }
+
+  await sql`
+    UPDATE character_active_spells
+    SET
+      status = 'dispelled',
+      dispelled_at_sequence = ${event.sequence},
+      updated_at = now()
+    WHERE session_id = ${session.id}
+      AND active_spell_id = ${activeSpellId}
+      AND status = 'active'
+  `;
+}
+
+function readCharacterActiveSpellCast(
+  event: SessionEventRow,
+  castAtNarrativeSeconds: number
+): CharacterActiveSpellCast | undefined {
+  const targetId = readNonEmptyString(event.payload.targetId);
+  const durationUnit = readSpellDurationUnit(event.payload.durationUnit);
+
+  if (targetId === undefined || durationUnit === undefined) {
+    return undefined;
+  }
+
+  const durationAmount = readNonNegativeNumber(event.payload.durationAmount) ?? 0;
+  const durationSeconds = durationToSeconds(durationAmount, durationUnit);
+
+  return {
+    activeSpellId:
+      readNonEmptyString(event.payload.activeSpellId) ??
+      readNonEmptyString(event.payload.id) ??
+      `spell-${event.sequence}`,
+    characterId: targetId,
+    durationAmount,
+    durationUnit,
+    expiresAtCombatDt: durationUnit === 'DT' ? Math.floor(durationAmount) : null,
+    expiresAtNarrativeSeconds:
+      durationSeconds === null ? null : castAtNarrativeSeconds + durationSeconds,
+    sourceCasterId: event.actor_id,
+    spellId: readNonEmptyString(event.payload.spellId) ?? null,
+    successesCount:
+      readNonNegativeInteger(event.payload.successesCount) ??
+      readNonNegativeInteger(event.payload.successes_count) ??
+      null
+  };
+}
+
+async function expireCharacterActiveSpells(
+  sql: SessionSql,
+  sessionId: string,
+  narrativeSeconds: number
+): Promise<void> {
+  await sql`
+    UPDATE character_active_spells
+    SET
+      status = 'expired',
+      updated_at = now()
+    WHERE session_id = ${sessionId}
+      AND status = 'active'
+      AND expires_at_narrative_seconds IS NOT NULL
+      AND expires_at_narrative_seconds <= ${narrativeSeconds}
+  `;
 }
 
 function buildJoinHref(slug: string, playerId: string, capability: string): string {


### PR DESCRIPTION
## Summary
- add character_active_spells as the persistent per-character read model for R-8.20 active spells
- project spell_cast, spell_dispelled, narrative_time_advanced, and combat_ended session events into active/dispelled/expired spell rows
- expose GET /characters/:id/active-spells with request-user scoping

## Verification
- pnpm validate

Refs #188