### PR TITLE
feat(game): surface session change requests

### DIFF
--- a/apps/game/src/app/greffe/page.tsx
+++ b/apps/game/src/app/greffe/page.tsx
@@ -31,7 +31,11 @@ import {
   type TableColumn
 } from '@knightandwizard/ui';
 
-import { createSessionManagerState, recordSessionEvent } from '@/features/session-manager/model';
+import {
+  createSessionManagerState,
+  recordSessionEvent,
+  withSessionChangeRequests
+} from '@/features/session-manager/model';
 
 type DecisionRow = {
   assignedTo: Arbiter;
@@ -508,85 +512,100 @@ function createInitialGreffeState(): SessionState {
     }
   );
 
-  state = queueGmDecision(
-    state,
-    {
-      assignedTo: 'human_gm',
-      payload: { cause: 'passage-nord', source: 'D13 multi-arbitre' },
-      priority: 'urgent',
-      requestedBy: 'scribe-llm',
-      title: 'Trancher le droit de passage au pont nord'
-    },
-    {
-      decisionId: 'cause-001',
-      eventId: 'greffe-event-2',
-      now: '2026-04-30T10:01:00.000Z'
-    }
-  );
-
-  state = resolveGmDecision(
-    state,
-    'cause-001',
-    {
-      actorId: 'gm',
-      resolution: {
-        ruling: 'Le passage est accordé, coût narratif différé.',
-        source: 'human_gm'
+  state = withSessionChangeRequests(
+    queueGmDecision(
+      state,
+      {
+        assignedTo: 'human_gm',
+        payload: { cause: 'passage-nord', source: 'D13 multi-arbitre' },
+        priority: 'urgent',
+        requestedBy: 'scribe-llm',
+        title: 'Trancher le droit de passage au pont nord'
       },
-      status: 'approved'
-    },
-    {
-      eventId: 'greffe-event-3',
-      now: '2026-04-30T10:02:00.000Z'
-    }
+      {
+        decisionId: 'cause-001',
+        eventId: 'greffe-event-2',
+        now: '2026-04-30T10:01:00.000Z'
+      }
+    ),
+    state.changeRequests
   );
 
-  state = queueGmDecision(
-    state,
-    {
-      assignedTo: 'player',
-      payload: { cause: 'risque-consenti', source: 'consentement joueur' },
-      priority: 'high',
-      requestedBy: 'gm',
-      title: 'Confirmer le risque consenti par Aveline'
-    },
-    {
-      decisionId: 'cause-002',
-      eventId: 'greffe-event-4',
-      now: '2026-04-30T10:03:00.000Z'
-    }
+  state = withSessionChangeRequests(
+    resolveGmDecision(
+      state,
+      'cause-001',
+      {
+        actorId: 'gm',
+        resolution: {
+          ruling: 'Le passage est accordé, coût narratif différé.',
+          source: 'human_gm'
+        },
+        status: 'approved'
+      },
+      {
+        eventId: 'greffe-event-3',
+        now: '2026-04-30T10:02:00.000Z'
+      }
+    ),
+    state.changeRequests
   );
 
-  state = queueGmDecision(
-    state,
-    {
-      assignedTo: 'llm',
-      payload: { cause: 'attendus-narratifs', guardrail: 'narration_only' },
-      priority: 'normal',
-      requestedBy: 'aveline',
-      title: 'Proposer les attendus narratifs sans calcul mécanique'
-    },
-    {
-      decisionId: 'cause-003',
-      eventId: 'greffe-event-5',
-      now: '2026-04-30T10:04:00.000Z'
-    }
+  state = withSessionChangeRequests(
+    queueGmDecision(
+      state,
+      {
+        assignedTo: 'player',
+        payload: { cause: 'risque-consenti', source: 'consentement joueur' },
+        priority: 'high',
+        requestedBy: 'gm',
+        title: 'Confirmer le risque consenti par Aveline'
+      },
+      {
+        decisionId: 'cause-002',
+        eventId: 'greffe-event-4',
+        now: '2026-04-30T10:03:00.000Z'
+      }
+    ),
+    state.changeRequests
   );
 
-  state = queueGmDecision(
-    state,
-    {
-      assignedTo: 'auto',
-      payload: { cause: 'delai', guardrail: 'typed_projection_only' },
-      priority: 'low',
-      requestedBy: 'scribe-llm',
-      title: 'Appliquer le suivi automatique du délai'
-    },
-    {
-      decisionId: 'cause-004',
-      eventId: 'greffe-event-6',
-      now: '2026-04-30T10:05:00.000Z'
-    }
+  state = withSessionChangeRequests(
+    queueGmDecision(
+      state,
+      {
+        assignedTo: 'llm',
+        payload: { cause: 'attendus-narratifs', guardrail: 'narration_only' },
+        priority: 'normal',
+        requestedBy: 'aveline',
+        title: 'Proposer les attendus narratifs sans calcul mécanique'
+      },
+      {
+        decisionId: 'cause-003',
+        eventId: 'greffe-event-5',
+        now: '2026-04-30T10:04:00.000Z'
+      }
+    ),
+    state.changeRequests
+  );
+
+  state = withSessionChangeRequests(
+    queueGmDecision(
+      state,
+      {
+        assignedTo: 'auto',
+        payload: { cause: 'delai', guardrail: 'typed_projection_only' },
+        priority: 'low',
+        requestedBy: 'scribe-llm',
+        title: 'Appliquer le suivi automatique du délai'
+      },
+      {
+        decisionId: 'cause-004',
+        eventId: 'greffe-event-6',
+        now: '2026-04-30T10:05:00.000Z'
+      }
+    ),
+    state.changeRequests
   );
 
   state = recordSessionEvent(
@@ -604,17 +623,20 @@ function createInitialGreffeState(): SessionState {
     }
   );
 
-  return requestSessionRollback(
-    state,
-    {
-      actorId: 'gm',
-      reason: 'Renvoi préparatoire vers la confirmation du risque.',
-      targetSequence: 4
-    },
-    {
-      eventId: 'greffe-event-8',
-      now: '2026-04-30T10:07:00.000Z'
-    }
+  return withSessionChangeRequests(
+    requestSessionRollback(
+      state,
+      {
+        actorId: 'gm',
+        reason: 'Renvoi préparatoire vers la confirmation du risque.',
+        targetSequence: 4
+      },
+      {
+        eventId: 'greffe-event-8',
+        now: '2026-04-30T10:07:00.000Z'
+      }
+    ),
+    state.changeRequests
   );
 }
 

--- a/apps/game/src/features/gm-cockpit/GmCockpit.tsx
+++ b/apps/game/src/features/gm-cockpit/GmCockpit.tsx
@@ -2,14 +2,26 @@
 
 import Link from 'next/link';
 import { useMemo, useState } from 'react';
-import { ArrowUpRight, CheckCircle2, RotateCcw, ScrollText, Swords, Users } from 'lucide-react';
+import {
+  ArrowUpRight,
+  CheckCircle2,
+  Gavel,
+  PlusCircle,
+  RotateCcw,
+  ScrollText,
+  Swords,
+  Users,
+  XCircle
+} from 'lucide-react';
 
 import type { SessionManagerState } from '../session-manager/model';
 import {
   appendGmRulingToSession,
   awardCharacterXp,
   fetchPersistedSessionState,
-  requestPersistedRollback
+  queuePersistedChangeRequest,
+  requestPersistedRollback,
+  resolvePersistedChangeRequest
 } from '../session-manager/persistence';
 
 import { buildGmCockpitView } from './model';
@@ -22,6 +34,11 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
   const [state, setState] = useState(initialState);
   const view = useMemo(() => buildGmCockpitView(state), [state]);
   const [selectedXpTarget, setSelectedXpTarget] = useState(view.xpTargets[0]?.characterId ?? '');
+  const [changeKind, setChangeKind] = useState('predilection_target');
+  const [changeSummary, setChangeSummary] = useState('Changement a valider par le MJ.');
+  const [changeTargetId, setChangeTargetId] = useState(view.xpTargets[0]?.characterId ?? '');
+  const [changeTargetType, setChangeTargetType] = useState('character');
+  const [changeTitle, setChangeTitle] = useState('Changer une predilection');
   const [rollbackSequence, setRollbackSequence] = useState(
     view.rollbackTargets[0]?.sequence.toString() ?? ''
   );
@@ -116,6 +133,48 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
     );
   }
 
+  function submitChangeRequest() {
+    const title = changeTitle.trim();
+    const summary = changeSummary.trim();
+    const targetId = changeTargetId.trim();
+
+    if (!title || !summary) {
+      return;
+    }
+
+    void run('change-request-create', async () => {
+      await queuePersistedChangeRequest(state.slug, {
+        assignedTo: 'human_gm',
+        authority: 'human_gm',
+        changeKind,
+        payload: { source: 'gm-cockpit' },
+        priority: 'normal',
+        requestedBy: 'gm',
+        summary,
+        ...(targetId ? { targetId } : {}),
+        targetType: changeTargetType,
+        title
+      });
+      setChangeTitle('Changer une predilection');
+      setChangeSummary('Changement a valider par le MJ.');
+    });
+  }
+
+  function resolveChangeRequest(changeRequestId: string, status: 'approved' | 'rejected') {
+    void run(`change-request-${changeRequestId}-${status}`, async () => {
+      await resolvePersistedChangeRequest(state.slug, changeRequestId, {
+        actorId: 'gm',
+        resolution: {
+          ruling:
+            status === 'approved'
+              ? 'Demande approuvee depuis le cockpit MJ.'
+              : 'Demande rejetee depuis le cockpit MJ.'
+        },
+        status
+      });
+    });
+  }
+
   return (
     <main className="grid gap-5">
       <section className="rounded-md border border-ink/10 bg-white/72 p-5 shadow-sm">
@@ -128,7 +187,7 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
             <p className="mt-2 text-sm leading-6 text-ink/68">
               {view.activeScene?.title ?? 'Aucune scène active'} ·{' '}
               {view.activeScene?.location ?? 'Hors scène'} · {view.metrics.pendingDecisions}{' '}
-              décision(s) MJ
+              décision(s) MJ · {view.pendingChangeRequests.length} demande(s)
             </p>
           </div>
           <div className="flex flex-wrap gap-2">
@@ -217,6 +276,52 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
               ))
             )}
           </ol>
+          <div className="mt-5 border-t border-ink/10 pt-4">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.14em] text-ink/55">
+              Demandes de changement
+            </h3>
+            <ol className="mt-3 grid gap-2">
+              {view.pendingChangeRequests.length === 0 ? (
+                <li className="rounded-md bg-forest/8 px-3 py-2 text-sm font-semibold text-forest">
+                  Aucune demande ouverte.
+                </li>
+              ) : (
+                view.pendingChangeRequests.map((request) => (
+                  <li className="rounded-md bg-paper px-3 py-2" key={request.id}>
+                    <span className="block text-sm font-semibold text-ink">{request.title}</span>
+                    <span className="block text-xs font-medium text-ink/55">
+                      {request.requestedBy}
+                      {' -> '}
+                      {request.authority} · {request.targetLabel}
+                    </span>
+                    <span className="mt-1 block text-xs leading-5 text-ink/65">
+                      {request.summary}
+                    </span>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      <button
+                        className="inline-flex items-center gap-1 rounded-md bg-forest px-2 py-1 text-xs font-semibold text-white disabled:opacity-50"
+                        disabled={pendingAction !== null}
+                        onClick={() => resolveChangeRequest(request.id, 'approved')}
+                        type="button"
+                      >
+                        <CheckCircle2 aria-hidden="true" className="size-3.5" />
+                        Approuver
+                      </button>
+                      <button
+                        className="inline-flex items-center gap-1 rounded-md bg-wine px-2 py-1 text-xs font-semibold text-white disabled:opacity-50"
+                        disabled={pendingAction !== null}
+                        onClick={() => resolveChangeRequest(request.id, 'rejected')}
+                        type="button"
+                      >
+                        <XCircle aria-hidden="true" className="size-3.5" />
+                        Rejeter
+                      </button>
+                    </div>
+                  </li>
+                ))
+              )}
+            </ol>
+          </div>
         </article>
 
         <article className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
@@ -293,6 +398,82 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
             </button>
           </div>
         </article>
+      </section>
+
+      <section className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
+        <div className="flex items-center gap-2">
+          <Gavel aria-hidden="true" className="size-5 text-wine" />
+          <h2 className="text-lg font-semibold text-ink">Nouvelle demande</h2>
+        </div>
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          <label className="block text-sm font-semibold text-ink/70" htmlFor="gm-change-title">
+            Minute
+            <input
+              className="mt-2 w-full rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-semibold text-ink"
+              id="gm-change-title"
+              onChange={(event) => setChangeTitle(event.target.value)}
+              value={changeTitle}
+            />
+          </label>
+          <label className="block text-sm font-semibold text-ink/70" htmlFor="gm-change-kind">
+            Type
+            <select
+              className="mt-2 w-full rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-semibold text-ink"
+              id="gm-change-kind"
+              onChange={(event) => setChangeKind(event.target.value)}
+              value={changeKind}
+            >
+              <option value="predilection_target">Prédilection</option>
+              <option value="feat_target">Cible d&apos;atout</option>
+              <option value="class_reclassification">Reclassement</option>
+              <option value="scene_state">État de scène</option>
+            </select>
+          </label>
+          <label className="block text-sm font-semibold text-ink/70" htmlFor="gm-change-target">
+            Cible
+            <select
+              className="mt-2 w-full rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-semibold text-ink"
+              id="gm-change-target"
+              onChange={(event) => setChangeTargetType(event.target.value)}
+              value={changeTargetType}
+            >
+              <option value="character">Personnage</option>
+              <option value="session">Session</option>
+              <option value="scene">Scène</option>
+              <option value="catalog_entry">Entrée canonique</option>
+            </select>
+          </label>
+          <label className="block text-sm font-semibold text-ink/70" htmlFor="gm-change-target-id">
+            Identifiant
+            <input
+              className="mt-2 w-full rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-semibold text-ink"
+              id="gm-change-target-id"
+              onChange={(event) => setChangeTargetId(event.target.value)}
+              value={changeTargetId}
+            />
+          </label>
+          <label
+            className="block text-sm font-semibold text-ink/70 md:col-span-2"
+            htmlFor="gm-change-summary"
+          >
+            Résumé
+            <textarea
+              className="mt-2 min-h-24 w-full rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-semibold text-ink"
+              id="gm-change-summary"
+              onChange={(event) => setChangeSummary(event.target.value)}
+              value={changeSummary}
+            />
+          </label>
+        </div>
+        <button
+          className="mt-4 inline-flex items-center gap-2 rounded-md bg-ink px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+          disabled={pendingAction !== null || !changeTitle.trim() || !changeSummary.trim()}
+          onClick={submitChangeRequest}
+          type="button"
+        >
+          <PlusCircle aria-hidden="true" className="size-4" />
+          Inscrire
+        </button>
       </section>
 
       <section className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">

--- a/apps/game/src/features/gm-cockpit/model.test.ts
+++ b/apps/game/src/features/gm-cockpit/model.test.ts
@@ -19,6 +19,25 @@ describe('GM cockpit model', () => {
           title: 'Valider le bruit de la serrure'
         }
       ],
+      changeRequests: [
+        {
+          assignedTo: 'human_gm',
+          authority: 'human_gm',
+          changeKind: 'predilection_target',
+          createdAt: '2026-05-29T08:02:00.000Z',
+          id: 'change-1',
+          payload: { source: 'character-sheet' },
+          priority: 'high',
+          requestedBy: 'player-aveline',
+          scope: 'game_state',
+          status: 'pending',
+          summary: 'Aveline veut remplacer son arme de predilection.',
+          targetId: 'pc-aveline',
+          targetType: 'character',
+          title: 'Changer la predilection',
+          updatedAt: '2026-05-29T08:02:00.000Z'
+        }
+      ],
       events: [
         {
           actorId: 'gm',
@@ -70,6 +89,22 @@ describe('GM cockpit model', () => {
         priorityLabel: 'Haute',
         requestedBy: 'Aveline',
         title: 'Valider le bruit de la serrure'
+      }
+    ]);
+    expect(view.pendingChangeRequests).toEqual([
+      {
+        assignedTo: 'MJ humain',
+        authority: 'MJ humain',
+        changeKind: 'predilection_target',
+        id: 'change-1',
+        priority: 'high',
+        priorityLabel: 'Haute',
+        requestedBy: 'Aveline',
+        status: 'pending',
+        statusLabel: 'En attente',
+        summary: 'Aveline veut remplacer son arme de predilection.',
+        targetLabel: 'character · pc-aveline',
+        title: 'Changer la predilection'
       }
     ]);
     expect(view.primaryCombatHref).toBe('/combat?slug=brumeval&characterId=pc-aveline');

--- a/apps/game/src/features/gm-cockpit/model.ts
+++ b/apps/game/src/features/gm-cockpit/model.ts
@@ -24,6 +24,21 @@ export interface GmCockpitDecision {
   title: string;
 }
 
+export interface GmCockpitChangeRequest {
+  assignedTo: string;
+  authority: string;
+  changeKind: string;
+  id: string;
+  priority: string;
+  priorityLabel: string;
+  requestedBy: string;
+  status: string;
+  statusLabel: string;
+  summary: string;
+  targetLabel: string;
+  title: string;
+}
+
 export interface GmCockpitRollbackTarget {
   label: string;
   sequence: number;
@@ -39,6 +54,7 @@ export interface GmCockpitView {
   activeScene?: SessionScene;
   metrics: SessionManagerView['metrics'];
   participants: GmCockpitParticipant[];
+  pendingChangeRequests: GmCockpitChangeRequest[];
   pendingDecisions: GmCockpitDecision[];
   primaryCombatHref: string;
   recentEvents: SessionManagerView['recentEvents'];
@@ -82,6 +98,20 @@ export function buildGmCockpitView(state: SessionManagerState): GmCockpitView {
       priorityLabel: decision.priorityLabel,
       requestedBy: decision.requestedBy,
       title: decision.title
+    })),
+    pendingChangeRequests: session.changeRequestQueue.map((request) => ({
+      assignedTo: request.assignedTo,
+      authority: request.authority,
+      changeKind: request.changeKind,
+      id: request.id,
+      priority: request.priority,
+      priorityLabel: request.priorityLabel,
+      requestedBy: request.requestedBy,
+      status: request.status,
+      statusLabel: request.statusLabel,
+      summary: request.summary,
+      targetLabel: request.targetLabel,
+      title: request.title
     })),
     primaryCombatHref: primaryCharacterId
       ? `/combat?slug=${encodeURIComponent(state.slug)}&characterId=${encodeURIComponent(primaryCharacterId)}`

--- a/apps/game/src/features/session-manager/model.ts
+++ b/apps/game/src/features/session-manager/model.ts
@@ -9,8 +9,10 @@ import {
   spellExpiresAt,
   type ActiveSpell,
   type AppendSessionEventInput,
+  type SessionControllerRole,
   type SessionAuditEntry,
   type SessionDecision,
+  type SessionDecisionPriority,
   type SessionDecisionStatus,
   type SessionEvent,
   type SessionEventType,
@@ -20,10 +22,42 @@ import {
   type SessionState
 } from '@knightandwizard/rules-core';
 
-export type SessionManagerState = SessionState;
+export type SessionChangeRequestScope = 'canon' | 'game_state';
+export type SessionChangeRequestStatus =
+  | 'applied'
+  | 'approved'
+  | 'pending'
+  | 'rejected'
+  | 'superseded';
+
+export interface SessionChangeRequest {
+  assignedTo: SessionControllerRole;
+  authority: SessionControllerRole;
+  changeKind: string;
+  createdAt: string;
+  id: string;
+  payload: Record<string, unknown>;
+  priority: SessionDecisionPriority;
+  requestedBy: string;
+  resolution?: Record<string, unknown>;
+  resolvedAt?: string;
+  resolvedBy?: string;
+  scope: SessionChangeRequestScope;
+  status: SessionChangeRequestStatus;
+  summary: string;
+  targetId?: string;
+  targetType: string;
+  title: string;
+  updatedAt?: string;
+}
+
+export interface SessionManagerState extends SessionState {
+  changeRequests: SessionChangeRequest[];
+}
 
 export interface CreateSessionManagerStateInput {
   audit?: SessionAuditEntry[];
+  changeRequests?: SessionChangeRequest[];
   createdAt?: string;
   decisions?: SessionDecision[];
   events?: SessionEvent[];
@@ -72,6 +106,21 @@ export interface SessionDecisionRow {
   title: string;
 }
 
+export interface SessionChangeRequestRow {
+  assignedTo: string;
+  authority: string;
+  changeKind: string;
+  id: string;
+  priority: SessionChangeRequest['priority'];
+  priorityLabel: string;
+  requestedBy: string;
+  status: SessionChangeRequest['status'];
+  statusLabel: string;
+  summary: string;
+  targetLabel: string;
+  title: string;
+}
+
 export interface RollbackTargetRow {
   label: string;
   sequence: number;
@@ -94,6 +143,7 @@ export interface NarrativeClockView {
 
 export interface SessionManagerView {
   activeScene?: SessionScene;
+  changeRequestQueue: SessionChangeRequestRow[];
   decisionQueue: SessionDecisionRow[];
   metrics: {
     activePlayers: number;
@@ -130,21 +180,24 @@ const eventLabels: Record<SessionEventType, string> = {
 export function createSessionManagerState(
   input: CreateSessionManagerStateInput = {}
 ): SessionManagerState {
-  return createSessionState({
-    audit: input.audit,
-    createdAt: input.createdAt,
-    decisions: input.decisions,
-    events: input.events,
-    id: input.id ?? 'session-empty',
-    metadata: input.metadata ?? {},
-    mode: input.mode ?? 'digital_human_gm',
-    players: input.players ?? [],
-    scenes: input.scenes ?? [],
-    slug: input.slug ?? 'session-empty',
-    status: input.status ?? 'planned',
-    title: input.title ?? 'Session',
-    updatedAt: input.updatedAt
-  });
+  return withSessionChangeRequests(
+    createSessionState({
+      audit: input.audit,
+      createdAt: input.createdAt,
+      decisions: input.decisions,
+      events: input.events,
+      id: input.id ?? 'session-empty',
+      metadata: input.metadata ?? {},
+      mode: input.mode ?? 'digital_human_gm',
+      players: input.players ?? [],
+      scenes: input.scenes ?? [],
+      slug: input.slug ?? 'session-empty',
+      status: input.status ?? 'planned',
+      title: input.title ?? 'Session',
+      updatedAt: input.updatedAt
+    }),
+    input.changeRequests ?? []
+  );
 }
 
 export function buildSessionManagerView(state: SessionManagerState): SessionManagerView {
@@ -159,6 +212,9 @@ export function buildSessionManagerView(state: SessionManagerState): SessionMana
 
   return {
     activeScene: getActiveScene(state),
+    changeRequestQueue: state.changeRequests
+      .filter((request) => request.status === 'pending')
+      .map((request) => toChangeRequestRow(state, request)),
     decisionQueue: pendingDecisions.map((decision) => ({
       assignedTo: roleLabel(decision.assignedTo),
       createdAt: decision.createdAt,
@@ -200,7 +256,7 @@ export function recordSessionEvent(
   input: AppendSessionEventInput,
   options?: SessionMutationOptions
 ): SessionManagerState {
-  return appendSessionEvent(state, input, options);
+  return withSessionChangeRequests(appendSessionEvent(state, input, options), state.changeRequests);
 }
 
 export function submitGmDecisionRequest(
@@ -208,16 +264,19 @@ export function submitGmDecisionRequest(
   title: string,
   options?: SessionMutationOptions
 ): SessionManagerState {
-  return queueGmDecision(
-    state,
-    {
-      assignedTo: 'human_gm',
-      payload: { source: 'session-manager' },
-      priority: 'high',
-      requestedBy: 'llm',
-      title
-    },
-    options
+  return withSessionChangeRequests(
+    queueGmDecision(
+      state,
+      {
+        assignedTo: 'human_gm',
+        payload: { source: 'session-manager' },
+        priority: 'high',
+        requestedBy: 'llm',
+        title
+      },
+      options
+    ),
+    state.changeRequests
   );
 }
 
@@ -233,15 +292,18 @@ export function resolveNextPendingDecision(
     return state;
   }
 
-  return resolveGmDecision(
-    state,
-    nextDecision.id,
-    {
-      actorId: 'gm',
-      resolution,
-      status
-    },
-    options
+  return withSessionChangeRequests(
+    resolveGmDecision(
+      state,
+      nextDecision.id,
+      {
+        actorId: 'gm',
+        resolution,
+        status
+      },
+      options
+    ),
+    state.changeRequests
   );
 }
 
@@ -251,14 +313,17 @@ export function requestRollbackFromEvent(
   reason: string,
   options?: SessionMutationOptions
 ): SessionManagerState {
-  return requestSessionRollback(
-    state,
-    {
-      actorId: 'gm',
-      reason,
-      targetSequence
-    },
-    options
+  return withSessionChangeRequests(
+    requestSessionRollback(
+      state,
+      {
+        actorId: 'gm',
+        reason,
+        targetSequence
+      },
+      options
+    ),
+    state.changeRequests
   );
 }
 
@@ -290,7 +355,7 @@ export function applyLiveSessionEvent(
 
     return {
       kind: 'applied',
-      state: { ...projected, events, scenes }
+      state: withSessionChangeRequests({ ...projected, events, scenes }, state.changeRequests)
     };
   }
 
@@ -319,6 +384,16 @@ function toActiveSpellRow(spell: ActiveSpell, nowSeconds: number): ActiveSpellRo
       ? 'Permanent (dissipation requise)'
       : `Expire dans ${formatDuration(Math.max(0, expiresAt - nowSeconds))}`,
     target: spell.targetId
+  };
+}
+
+export function withSessionChangeRequests(
+  state: SessionState,
+  changeRequests: SessionChangeRequest[]
+): SessionManagerState {
+  return {
+    ...state,
+    changeRequests: [...changeRequests]
   };
 }
 
@@ -375,6 +450,28 @@ function toEventRow(state: SessionManagerState, event: SessionEvent): SessionEve
     label,
     sequence: event.sequence,
     tone: eventTone(event.type)
+  };
+}
+
+function toChangeRequestRow(
+  state: SessionManagerState,
+  request: SessionChangeRequest
+): SessionChangeRequestRow {
+  return {
+    assignedTo: roleLabel(request.assignedTo),
+    authority: roleLabel(request.authority),
+    changeKind: request.changeKind,
+    id: request.id,
+    priority: request.priority,
+    priorityLabel: priorityLabel(request.priority),
+    requestedBy: actorName(state, request.requestedBy),
+    status: request.status,
+    statusLabel: changeRequestStatusLabel(request.status),
+    summary: request.summary,
+    targetLabel: request.targetId
+      ? `${request.targetType} · ${request.targetId}`
+      : request.targetType,
+    title: request.title
   };
 }
 
@@ -552,4 +649,16 @@ const priorityLabels: Record<SessionDecision['priority'], string> = {
 
 function priorityLabel(priority: SessionDecision['priority']): string {
   return priorityLabels[priority];
+}
+
+const changeRequestStatusLabels: Record<SessionChangeRequestStatus, string> = {
+  applied: 'Appliquée',
+  approved: 'Approuvée',
+  pending: 'En attente',
+  rejected: 'Rejetée',
+  superseded: 'Remplacée'
+};
+
+function changeRequestStatusLabel(status: SessionChangeRequestStatus): string {
+  return changeRequestStatusLabels[status];
 }

--- a/apps/game/src/features/session-manager/persistence.test.ts
+++ b/apps/game/src/features/session-manager/persistence.test.ts
@@ -6,8 +6,10 @@ import {
   appendGmRulingToSession,
   appendThreadPostToSession,
   awardCharacterXp,
+  queuePersistedChangeRequest,
   queuePersistedGmDecision,
   requestPersistedRollback,
+  resolvePersistedChangeRequest,
   resolvePersistedGmDecision,
   syncCharacterCombatState
 } from './persistence.js';
@@ -262,6 +264,67 @@ describe('session manager persistence', () => {
           actorId: 'gm',
           reason: 'Correction demandee par le MJ',
           targetSequence: 2
+        }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST'
+      }
+    );
+  });
+
+  it('persists session change requests through the governance routes', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://browser-api.test';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(okJson({ changeRequest: { id: 'change-1' }, status: 'created' }))
+      .mockResolvedValueOnce(okJson({ changeRequest: { id: 'change-1' }, status: 'resolved' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await queuePersistedChangeRequest('brumeval', {
+      assignedTo: 'human_gm',
+      authority: 'human_gm',
+      changeKind: 'predilection_target',
+      payload: { source: 'cockpit' },
+      priority: 'high',
+      requestedBy: 'gm',
+      summary: 'Aveline veut changer sa cible de predilection.',
+      targetId: 'pc-aveline',
+      targetType: 'character',
+      title: 'Changer la predilection'
+    });
+    await resolvePersistedChangeRequest('brumeval', 'change-1', {
+      actorId: 'gm',
+      resolution: { ruling: 'Accorde pour la prochaine scene.' },
+      status: 'approved'
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'http://browser-api.test/sessions/brumeval/change-requests',
+      {
+        body: JSON.stringify({
+          assignedTo: 'human_gm',
+          authority: 'human_gm',
+          changeKind: 'predilection_target',
+          payload: { source: 'cockpit' },
+          priority: 'high',
+          requestedBy: 'gm',
+          summary: 'Aveline veut changer sa cible de predilection.',
+          targetId: 'pc-aveline',
+          targetType: 'character',
+          title: 'Changer la predilection'
+        }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST'
+      }
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'http://browser-api.test/sessions/brumeval/change-requests/change-1/resolve',
+      {
+        body: JSON.stringify({
+          actorId: 'gm',
+          resolution: { ruling: 'Accorde pour la prochaine scene.' },
+          status: 'approved'
         }),
         headers: { 'content-type': 'application/json' },
         method: 'POST'

--- a/apps/game/src/features/session-manager/persistence.ts
+++ b/apps/game/src/features/session-manager/persistence.ts
@@ -14,7 +14,7 @@ import {
   toSessionManagerState,
   type PersistedSessionSnapshot
 } from './session-api';
-import type { SessionManagerState } from './model';
+import type { SessionChangeRequestStatus, SessionManagerState } from './model';
 
 export interface AppendResolvedEventInput {
   actorId: string;
@@ -40,10 +40,29 @@ export interface QueuePersistedGmDecisionInput {
   title: string;
 }
 
+export interface QueuePersistedChangeRequestInput {
+  assignedTo?: SessionControllerRole;
+  authority?: SessionControllerRole;
+  changeKind: string;
+  payload?: Record<string, unknown>;
+  priority?: SessionDecisionPriority;
+  requestedBy: string;
+  summary: string;
+  targetId?: string;
+  targetType: string;
+  title: string;
+}
+
 export interface ResolvePersistedGmDecisionInput {
   actorId: string;
   resolution?: Record<string, unknown>;
   status: Exclude<SessionDecisionStatus, 'pending'>;
+}
+
+export interface ResolvePersistedChangeRequestInput {
+  actorId: string;
+  resolution?: Record<string, unknown>;
+  status: Exclude<SessionChangeRequestStatus, 'pending'>;
 }
 
 export interface RequestPersistedRollbackInput {
@@ -185,6 +204,13 @@ export async function queuePersistedGmDecision(
   await postSessionJson(slug, `/sessions/${encodeURIComponent(slug)}/decisions`, input);
 }
 
+export async function queuePersistedChangeRequest(
+  slug: string,
+  input: QueuePersistedChangeRequestInput
+): Promise<void> {
+  await postSessionJson(slug, `/sessions/${encodeURIComponent(slug)}/change-requests`, input);
+}
+
 export async function resolvePersistedGmDecision(
   slug: string,
   decisionId: string,
@@ -193,6 +219,18 @@ export async function resolvePersistedGmDecision(
   await postSessionJson(
     slug,
     `/sessions/${encodeURIComponent(slug)}/decisions/${encodeURIComponent(decisionId)}/resolve`,
+    input
+  );
+}
+
+export async function resolvePersistedChangeRequest(
+  slug: string,
+  changeRequestId: string,
+  input: ResolvePersistedChangeRequestInput
+): Promise<void> {
+  await postSessionJson(
+    slug,
+    `/sessions/${encodeURIComponent(slug)}/change-requests/${encodeURIComponent(changeRequestId)}/resolve`,
     input
   );
 }

--- a/apps/game/src/features/session-manager/read-models.test.ts
+++ b/apps/game/src/features/session-manager/read-models.test.ts
@@ -39,7 +39,26 @@ describe('session manager read models', () => {
           status: 'active',
           title: 'Brumeval',
           updatedAt: '2026-05-26T10:01:00.000Z'
-        }
+        },
+        changeRequests: [
+          {
+            assignedTo: 'human_gm',
+            authority: 'human_gm',
+            changeKind: 'predilection_target',
+            createdAt: '2026-05-26T10:02:00.000Z',
+            id: 'change-1',
+            payload: {},
+            priority: 'normal',
+            requestedBy: 'player-aveline',
+            scope: 'game_state',
+            status: 'pending',
+            summary: 'Changement de cible de predilection.',
+            targetId: 'pc-aveline',
+            targetType: 'character',
+            title: 'Changer la predilection',
+            updatedAt: '2026-05-26T10:02:00.000Z'
+          }
+        ]
       })
     );
     vi.stubGlobal('fetch', fetchMock);
@@ -51,6 +70,9 @@ describe('session manager read models', () => {
     });
     expect(readModel.initialState.events.map((event) => event.type)).toEqual(['scene_opened']);
     expect(readModel.initialState.players).toEqual([{ id: 'gm', name: 'MJ', role: 'human_gm' }]);
+    expect(readModel.initialState.changeRequests.map((request) => request.title)).toEqual([
+      'Changer la predilection'
+    ]);
   });
 
   it('creates an empty durable session when the requested slug does not exist', async () => {

--- a/apps/game/src/features/session-manager/session-api.ts
+++ b/apps/game/src/features/session-manager/session-api.ts
@@ -1,5 +1,7 @@
 import type {
+  SessionControllerRole,
   SessionDecision,
+  SessionDecisionPriority,
   SessionEvent,
   SessionMode,
   SessionPlayer,
@@ -8,11 +10,18 @@ import type {
   SessionStatus
 } from '@knightandwizard/rules-core';
 
-import { createSessionManagerState, type SessionManagerState } from './model';
+import {
+  createSessionManagerState,
+  type SessionChangeRequest,
+  type SessionChangeRequestScope,
+  type SessionChangeRequestStatus,
+  type SessionManagerState
+} from './model';
 
 export const DEFAULT_SESSION_SLUG = 'brumeval';
 
 export interface PersistedSessionSnapshot {
+  changeRequests?: unknown[];
   createdAt?: string;
   decisions?: SessionDecision[];
   events?: Array<SessionEvent | PersistedSessionEvent>;
@@ -54,6 +63,8 @@ export function createPersistedSessionPayload(slug: string): CreatePersistedSess
 }
 
 export function toSessionManagerState(snapshot: PersistedSessionSnapshot): SessionManagerState {
+  const changeRequests = toSessionChangeRequests(snapshot.changeRequests);
+
   if (snapshot.state) {
     // Le "Journal canonique" est le log d'evenements immuable. Apres un rollback,
     // le serveur renvoie une projection revertie dans `state` (evenements tronques),
@@ -65,13 +76,14 @@ export function toSessionManagerState(snapshot: PersistedSessionSnapshot): Sessi
       : undefined;
 
     if (fullEvents && fullEvents.length > snapshot.state.events.length) {
-      return { ...snapshot.state, events: fullEvents };
+      return { ...snapshot.state, changeRequests, events: fullEvents };
     }
 
-    return snapshot.state;
+    return { ...snapshot.state, changeRequests };
   }
 
   return createSessionManagerState({
+    changeRequests,
     createdAt: snapshot.createdAt,
     decisions: snapshot.decisions ?? [],
     events: (snapshot.events ?? []).map(toSessionEvent),
@@ -145,6 +157,58 @@ function isSessionScene(value: unknown): value is SessionScene {
     typeof value.location === 'string' &&
     typeof value.title === 'string' &&
     (value.status === 'active' || value.status === 'closed' || value.status === 'draft')
+  );
+}
+
+function toSessionChangeRequests(value: unknown): SessionChangeRequest[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(isSessionChangeRequest).map((request) => ({ ...request }));
+}
+
+function isSessionChangeRequest(value: unknown): value is SessionChangeRequest {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.id === 'string' &&
+    isChangeRequestScope(value.scope) &&
+    typeof value.targetType === 'string' &&
+    typeof value.changeKind === 'string' &&
+    typeof value.title === 'string' &&
+    typeof value.summary === 'string' &&
+    typeof value.requestedBy === 'string' &&
+    isControllerRole(value.assignedTo) &&
+    isControllerRole(value.authority) &&
+    isDecisionPriority(value.priority) &&
+    isChangeRequestStatus(value.status) &&
+    isRecord(value.payload) &&
+    typeof value.createdAt === 'string'
+  );
+}
+
+function isControllerRole(value: unknown): value is SessionControllerRole {
+  return value === 'auto' || value === 'human_gm' || value === 'llm' || value === 'player';
+}
+
+function isDecisionPriority(value: unknown): value is SessionDecisionPriority {
+  return value === 'high' || value === 'low' || value === 'normal' || value === 'urgent';
+}
+
+function isChangeRequestScope(value: unknown): value is SessionChangeRequestScope {
+  return value === 'canon' || value === 'game_state';
+}
+
+function isChangeRequestStatus(value: unknown): value is SessionChangeRequestStatus {
+  return (
+    value === 'applied' ||
+    value === 'approved' ||
+    value === 'pending' ||
+    value === 'rejected' ||
+    value === 'superseded'
   );
 }
 

--- a/apps/server/src/routes/sessions.test.ts
+++ b/apps/server/src/routes/sessions.test.ts
@@ -443,6 +443,13 @@ describe('session routes', () => {
         status: 'approved'
       }
     ]);
+    expect(readResponse.json().changeRequests).toMatchObject([
+      {
+        id: changeRequest.id,
+        status: 'approved',
+        title: 'Changer la predilection d Aveline'
+      }
+    ]);
     expect(
       readResponse.json().events.map((event: { eventType: string }) => event.eventType)
     ).toEqual(['change_request_submitted', 'change_request_resolved']);

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -311,8 +311,16 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
       `;
       const playerRows = await selectSessionPlayers(sql, session.id);
       const sceneRows = await selectSessionScenes(sql, session.id);
+      const changeRequestRows = await selectSessionChangeRequests(sql, session.id);
 
-      return toSessionResponse(session, eventRows, decisionRows, playerRows, sceneRows);
+      return toSessionResponse(
+        session,
+        eventRows,
+        decisionRows,
+        playerRows,
+        sceneRows,
+        changeRequestRows
+      );
     } finally {
       await sql.end({ timeout: 5 });
     }
@@ -421,6 +429,7 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
 
           return {
             capability,
+            changeRequests: await selectSessionChangeRequests(tx, session.id),
             decisions: decisionRows,
             events: eventRows,
             player: persistedPlayer,
@@ -451,7 +460,8 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
             result.events,
             result.decisions,
             result.players,
-            result.scenes
+            result.scenes,
+            result.changeRequests
           ),
           status: 'joined'
         };
@@ -2499,7 +2509,8 @@ function toSessionResponse(
   events: SessionEventRow[],
   decisions: SessionDecisionRow[],
   playerRows: SessionPlayerRow[] = [],
-  sceneRows: SessionSceneRow[] = []
+  sceneRows: SessionSceneRow[] = [],
+  changeRequestRows: ChangeRequestRow[] = []
 ) {
   const rawState = buildSessionState(session, events, decisions, playerRows, sceneRows);
   const state = rawState.events.some((event) => event.type === 'rollback_requested')
@@ -2507,6 +2518,7 @@ function toSessionResponse(
     : rawState;
 
   return {
+    changeRequests: changeRequestRows.map(toChangeRequestResponse),
     createdAt: serializeDate(session.created_at),
     decisions: decisions.map(toDecisionResponse),
     events: events.map(toEventResponse),


### PR DESCRIPTION
## Summary
- include session change requests in persisted session snapshots
- carry change_requests through the game read model and GM cockpit projection
- add cockpit UI to create, list, approve and reject session change requests
- keep Greffe demo state compatible with the enriched session manager state

## Verification
- pnpm test -- apps/game/src/features/gm-cockpit/model.test.ts apps/game/src/features/session-manager/persistence.test.ts apps/game/src/features/session-manager/read-models.test.ts apps/server/src/routes/sessions.test.ts
- browser check: http://127.0.0.1:3000/mj showed persisted change request queue and approve/reject actions
- pnpm validate

Refs #166