### PR TITLE
feat(rules-core): codify conflict arbitration

### DIFF
--- a/apps/game/src/app/greffe/page.tsx
+++ b/apps/game/src/app/greffe/page.tsx
@@ -5,13 +5,16 @@ import { useMemo, useState, type CSSProperties, type ReactNode } from 'react';
 
 import {
   ARBITER_PRECEDENCE,
+  buildConflictResolutionPlan,
   getPendingDecisions,
   hasArbiterAuthorityOver,
+  nextConflictResolutionStep,
   queueGmDecision,
   requestSessionRollback,
   resolveGmDecision,
   revertSessionToSequence,
   type Arbiter,
+  type ConflictResolutionActor,
   type SessionDecision,
   type SessionDecisionStatus,
   type SessionEvent,
@@ -52,6 +55,21 @@ type AuthorityRow = {
   label: string;
   rank: number;
   overrides: string;
+};
+
+type ConflictStepRow = {
+  actor: string;
+  auditRequired: boolean;
+  id: string;
+  label: string;
+  rank: number;
+};
+
+type ConflictRecourseRow = {
+  auditRequired: boolean;
+  consensusRequired: boolean;
+  id: string;
+  label: string;
 };
 
 const surfaceStyle: CSSProperties = {
@@ -229,6 +247,29 @@ export default function GreffePage() {
   const nextDecision = useMemo(() => selectNextDecisionByAuthority(state), [state]);
   const decisionRows = useMemo(() => state.decisions.map(toDecisionRow), [state]);
   const authorityRows = useMemo(() => buildAuthorityRows(), []);
+  const conflictPlan = useMemo(() => buildConflictResolutionPlan('rule_interpretation'), []);
+  const conflictRows = useMemo<ConflictStepRow[]>(
+    () =>
+      conflictPlan.steps.map((step, index) => ({
+        actor: conflictActorLabel(step.actor),
+        auditRequired: step.auditRequired,
+        id: step.id,
+        label: step.label,
+        rank: index + 1
+      })),
+    [conflictPlan]
+  );
+  const recourseRows = useMemo<ConflictRecourseRow[]>(
+    () =>
+      conflictPlan.recourses.map((recourse) => ({
+        auditRequired: recourse.auditRequired,
+        consensusRequired: recourse.consensusRequired,
+        id: recourse.id,
+        label: recourse.label
+      })),
+    [conflictPlan]
+  );
+  const activeConflictStep = nextConflictResolutionStep(['discussion_among_table']);
   const recentEvents = useMemo(() => [...state.events].slice(-8).reverse(), [state.events]);
   const rollbackTargets = useMemo(
     () =>
@@ -374,6 +415,49 @@ export default function GreffePage() {
                 />
               </div>
             ))}
+          </div>
+        </Card>
+
+        <Card>
+          <div style={heroStyle}>
+            <div style={stackStyle}>
+              <Label>R-13.12</Label>
+              <h2 style={panelTitleStyle}>Arbitrage des conflits</h2>
+              <p style={subtitleStyle}>{conflictPlan.description}</p>
+            </div>
+            <Seal>
+              <Scale aria-hidden="true" style={iconStyle} /> Litige
+            </Seal>
+          </div>
+
+          <div style={stackStyle}>
+            {conflictRows.map((row) => (
+              <div key={row.id} style={eventRowStyle}>
+                <Badge tone={row.auditRequired ? 'warn' : 'neutral'}>#{row.rank}</Badge>
+                <span style={stackStyle}>
+                  <strong>{row.label}</strong>
+                  <span style={mutedStyle}>
+                    {row.actor} · {row.auditRequired ? 'audit requis' : 'discussion libre'}
+                  </span>
+                </span>
+              </div>
+            ))}
+          </div>
+
+          <div style={{ ...stackStyle, marginTop: 12 }}>
+            <span style={mutedStyle}>
+              Suite après discussion :{' '}
+              {activeConflictStep
+                ? `${activeConflictStep.label} · ${conflictActorLabel(activeConflictStep.actor)}`
+                : 'clôturé'}
+            </span>
+            <div style={inlineStackStyle}>
+              {recourseRows.map((row) => (
+                <Badge key={row.id} tone={row.consensusRequired ? 'info' : 'neutral'}>
+                  {row.label}
+                </Badge>
+              ))}
+            </div>
           </div>
         </Card>
 
@@ -705,6 +789,12 @@ function actorIdForArbiter(arbiter: Arbiter): string {
 
 function actorLabel(actorId: string): string {
   return actorNames[actorId] ?? actorId;
+}
+
+function conflictActorLabel(actor: ConflictResolutionActor): string {
+  if (actor === 'admin') return 'Admin';
+  if (actor === 'table') return 'Table';
+  return roleLabels[actor];
 }
 
 function statusLabel(status: SessionDecisionStatus): string {

--- a/packages/rules-core/src/arbiter.test.ts
+++ b/packages/rules-core/src/arbiter.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { ARBITER_PRECEDENCE, compareArbiterAuthority, hasArbiterAuthorityOver } from './arbiter.js';
+import {
+  ARBITER_PRECEDENCE,
+  CONFLICT_RECOURSES,
+  CONFLICT_RESOLUTION_HIERARCHY,
+  buildConflictResolutionPlan,
+  compareArbiterAuthority,
+  hasArbiterAuthorityOver,
+  nextConflictResolutionStep
+} from './arbiter.js';
 
 describe('arbiter authority hierarchy', () => {
   it('keeps the canonical K&W authority order from D13', () => {
@@ -23,5 +31,46 @@ describe('arbiter authority hierarchy', () => {
 
   it('rejects an unknown arbiter value defensively', () => {
     expect(() => compareArbiterAuthority('ghost' as never, 'auto')).toThrow('Unknown arbiter');
+  });
+
+  it('keeps the canonical R-13.12 conflict escalation order', () => {
+    expect(CONFLICT_RESOLUTION_HIERARCHY.map((step) => step.id)).toEqual([
+      'discussion_among_table',
+      'gm_ruling',
+      'rule_lookup',
+      'dice_arbitration',
+      'session_pause_for_admin_intervention'
+    ]);
+  });
+
+  it('builds an auditable conflict resolution plan for a known conflict type', () => {
+    expect(buildConflictResolutionPlan('dice_roll_dispute')).toMatchObject({
+      conflictType: 'dice_roll_dispute',
+      description: 'Jet contesté, erreur de lancer ou soupçon de triche',
+      recourses: CONFLICT_RECOURSES,
+      steps: [
+        { actor: 'table', id: 'discussion_among_table' },
+        { actor: 'human_gm', id: 'gm_ruling' },
+        { actor: 'auto', id: 'rule_lookup' },
+        { actor: 'auto', id: 'dice_arbitration' },
+        { actor: 'admin', id: 'session_pause_for_admin_intervention' }
+      ]
+    });
+  });
+
+  it('selects the next unresolved escalation step', () => {
+    expect(nextConflictResolutionStep(['discussion_among_table', 'gm_ruling'])).toMatchObject({
+      actor: 'auto',
+      id: 'rule_lookup'
+    });
+    expect(nextConflictResolutionStep(CONFLICT_RESOLUTION_HIERARCHY.map((step) => step.id))).toBe(
+      undefined
+    );
+  });
+
+  it('rejects an unknown conflict type defensively', () => {
+    expect(() => buildConflictResolutionPlan('lost_item' as never)).toThrow(
+      'Unknown conflict type'
+    );
   });
 });

--- a/packages/rules-core/src/arbiter.ts
+++ b/packages/rules-core/src/arbiter.ts
@@ -2,6 +2,87 @@ export const ARBITER_PRECEDENCE = ['human_gm', 'player', 'llm', 'auto'] as const
 
 export type Arbiter = (typeof ARBITER_PRECEDENCE)[number];
 
+export const CONFLICT_TYPES = [
+  'rule_interpretation',
+  'dice_roll_dispute',
+  'controller_decision_dispute',
+  'inter_player_pj_conflict'
+] as const;
+
+export const CONFLICT_RESOLUTION_HIERARCHY = [
+  {
+    actor: 'table',
+    auditRequired: false,
+    id: 'discussion_among_table',
+    label: 'Discussion de table'
+  },
+  {
+    actor: 'human_gm',
+    auditRequired: true,
+    id: 'gm_ruling',
+    label: 'Décision MJ'
+  },
+  {
+    actor: 'auto',
+    auditRequired: true,
+    id: 'rule_lookup',
+    label: 'Consultation règles'
+  },
+  {
+    actor: 'auto',
+    auditRequired: true,
+    id: 'dice_arbitration',
+    label: 'Arbitrage par les dés'
+  },
+  {
+    actor: 'admin',
+    auditRequired: true,
+    id: 'session_pause_for_admin_intervention',
+    label: 'Pause et intervention admin'
+  }
+] as const;
+
+export const CONFLICT_RECOURSES = [
+  {
+    auditRequired: true,
+    consensusRequired: false,
+    id: 're_roll_dice',
+    label: 'Relancer le jet'
+  },
+  {
+    auditRequired: true,
+    consensusRequired: true,
+    id: 'retcon_event',
+    label: 'Retcon audité'
+  },
+  {
+    auditRequired: true,
+    consensusRequired: false,
+    id: 'escalate_to_admin',
+    label: 'Escalade admin'
+  }
+] as const;
+
+export type ConflictType = (typeof CONFLICT_TYPES)[number];
+export type ConflictResolutionActor = Arbiter | 'admin' | 'table';
+export type ConflictResolutionStep = (typeof CONFLICT_RESOLUTION_HIERARCHY)[number];
+export type ConflictResolutionStepId = ConflictResolutionStep['id'];
+export type ConflictRecourse = (typeof CONFLICT_RECOURSES)[number];
+
+export interface ConflictResolutionPlan {
+  conflictType: ConflictType;
+  description: string;
+  recourses: readonly ConflictRecourse[];
+  steps: readonly ConflictResolutionStep[];
+}
+
+const CONFLICT_DESCRIPTIONS: Record<ConflictType, string> = {
+  controller_decision_dispute: 'Décision de contrôleur contestée par un joueur ou le MJ',
+  dice_roll_dispute: 'Jet contesté, erreur de lancer ou soupçon de triche',
+  inter_player_pj_conflict: 'Conflit PJ/PJ ou désaccord de table',
+  rule_interpretation: 'Interprétation de règle contestée entre joueur et MJ'
+};
+
 const AUTHORITY_SCORE = new Map<Arbiter, number>(
   ARBITER_PRECEDENCE.map((arbiter, index) => [arbiter, ARBITER_PRECEDENCE.length - index])
 );
@@ -12,6 +93,29 @@ export function compareArbiterAuthority(left: Arbiter, right: Arbiter): number {
 
 export function hasArbiterAuthorityOver(left: Arbiter, right: Arbiter): boolean {
   return compareArbiterAuthority(left, right) > 0;
+}
+
+export function buildConflictResolutionPlan(conflictType: ConflictType): ConflictResolutionPlan {
+  const description = CONFLICT_DESCRIPTIONS[conflictType];
+
+  if (description === undefined) {
+    throw new Error(`Unknown conflict type: ${conflictType}`);
+  }
+
+  return {
+    conflictType,
+    description,
+    recourses: CONFLICT_RECOURSES,
+    steps: CONFLICT_RESOLUTION_HIERARCHY
+  };
+}
+
+export function nextConflictResolutionStep(
+  completedSteps: readonly ConflictResolutionStepId[]
+): ConflictResolutionStep | undefined {
+  const completed = new Set(completedSteps);
+
+  return CONFLICT_RESOLUTION_HIERARCHY.find((step) => !completed.has(step.id));
 }
 
 function authorityScore(arbiter: Arbiter): number {


### PR DESCRIPTION
## Summary
- codify R-13.12 conflict types, escalation hierarchy and recourses in rules-core
- expose the rule lookup / dice / admin escalation plan in the Greffe surface
- cover unknown conflict types and next-step selection in tests

## Verification
- pnpm test -- packages/rules-core/src/arbiter.test.ts
- pnpm typecheck
- pnpm format:check
- pnpm validate

Refs #166
