### PR TITLE
feat(canonical): classify lore RAG sources

### DIFF
--- a/docs/canonical/canonical-matrix.yaml
+++ b/docs/canonical/canonical-matrix.yaml
@@ -328229,7 +328229,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-paper-regles-papier-extracted-histoires-blagues-dictons-et-proverbes"
     unit_type: "source_document"
-    domain: "rules"
+    domain: "D12-world"
     title: "data/legacy/paper/regles-papier/extracted/histoires/blagues-dictons-et-proverbes.md"
     status: covered
     sources:
@@ -328265,7 +328265,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-paper-regles-papier-extracted-histoires-cultes-et-religions"
     unit_type: "source_document"
-    domain: "rules"
+    domain: "D12-religions"
     title: "data/legacy/paper/regles-papier/extracted/histoires/cultes-et-religions.md"
     status: covered
     sources:
@@ -328301,7 +328301,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-paper-regles-papier-extracted-histoires-la-creation-des-terres-oubliees"
     unit_type: "source_document"
-    domain: "rules"
+    domain: "D12-world"
     title: "data/legacy/paper/regles-papier/extracted/histoires/la-creation-des-terres-oubliees.md"
     status: covered
     sources:
@@ -328337,7 +328337,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-paper-regles-papier-extracted-histoires-nations"
     unit_type: "source_document"
-    domain: "rules"
+    domain: "D12-world"
     title: "data/legacy/paper/regles-papier/extracted/histoires/nations.md"
     status: covered
     sources:
@@ -328373,7 +328373,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-paper-regles-papier-extracted-histoires-organisations"
     unit_type: "source_document"
-    domain: "rules"
+    domain: "D12-organisations"
     title: "data/legacy/paper/regles-papier/extracted/histoires/organisations.md"
     status: covered
     sources:
@@ -328409,7 +328409,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-paper-regles-papier-extracted-histoires-us-et-coutumes"
     unit_type: "source_document"
-    domain: "rules"
+    domain: "D12-world"
     title: "data/legacy/paper/regles-papier/extracted/histoires/us-et-coutumes.md"
     status: covered
     sources:
@@ -331577,7 +331577,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-carte-du-monde-index"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/carte-du-monde/index.md"
     status: covered
     sources:
@@ -331613,7 +331613,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-1"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-1.md"
     status: covered
     sources:
@@ -331649,7 +331649,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-15"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-15.md"
     status: covered
     sources:
@@ -331685,7 +331685,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-16"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-16.md"
     status: covered
     sources:
@@ -331721,7 +331721,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-18"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-18.md"
     status: covered
     sources:
@@ -331757,7 +331757,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-2"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-2.md"
     status: covered
     sources:
@@ -331793,7 +331793,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-20"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-20.md"
     status: covered
     sources:
@@ -331829,7 +331829,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-23"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-23.md"
     status: covered
     sources:
@@ -331865,7 +331865,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-26"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-26.md"
     status: covered
     sources:
@@ -331901,7 +331901,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-27"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-27.md"
     status: covered
     sources:
@@ -331937,7 +331937,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-28"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-28.md"
     status: covered
     sources:
@@ -331973,7 +331973,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-29"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-29.md"
     status: covered
     sources:
@@ -332009,7 +332009,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-3"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-3.md"
     status: covered
     sources:
@@ -332045,7 +332045,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-31"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-31.md"
     status: covered
     sources:
@@ -332081,7 +332081,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-4"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-4.md"
     status: covered
     sources:
@@ -332117,7 +332117,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-5"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-5.md"
     status: covered
     sources:
@@ -332153,7 +332153,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-6"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-6.md"
     status: covered
     sources:
@@ -332189,7 +332189,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-lieux-place-7"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/lieux/place-7.md"
     status: covered
     sources:
@@ -332225,7 +332225,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-regions-land-13"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/regions/land-13.md"
     status: covered
     sources:
@@ -332261,7 +332261,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-regions-land-21"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/regions/land-21.md"
     status: covered
     sources:
@@ -332297,7 +332297,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-regions-land-24"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/regions/land-24.md"
     status: covered
     sources:
@@ -332333,7 +332333,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-regions-land-8"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/regions/land-8.md"
     status: covered
     sources:
@@ -332369,7 +332369,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-regions-land-9"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/regions/land-9.md"
     status: covered
     sources:
@@ -332405,7 +332405,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-tous-les-lieux-index"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/tous-les-lieux/index.md"
     status: covered
     sources:
@@ -332441,7 +332441,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-villes-city-10"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/villes/city-10.md"
     status: covered
     sources:
@@ -332477,7 +332477,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-villes-city-11"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/villes/city-11.md"
     status: covered
     sources:
@@ -332513,7 +332513,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-villes-city-12"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/villes/city-12.md"
     status: covered
     sources:
@@ -332549,7 +332549,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-villes-city-14"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/villes/city-14.md"
     status: covered
     sources:
@@ -332585,7 +332585,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-villes-city-17"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/villes/city-17.md"
     status: covered
     sources:
@@ -332621,7 +332621,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-villes-city-19"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/villes/city-19.md"
     status: covered
     sources:
@@ -332657,7 +332657,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-villes-city-22"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/villes/city-22.md"
     status: covered
     sources:
@@ -332693,7 +332693,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-villes-city-25"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/villes/city-25.md"
     status: covered
     sources:
@@ -332729,7 +332729,7 @@ units:
       evidence: "Source document only."
   - unit_id: "source:data-legacy-web-scraped-monde-villes-city-30"
     unit_type: "source_document"
-    domain: "unclassified"
+    domain: "D12-world"
     title: "data/legacy/web-scraped/monde/villes/city-30.md"
     status: covered
     sources:

--- a/docs/canonical/nomos/canonical-matrix.yaml
+++ b/docs/canonical/nomos/canonical-matrix.yaml
@@ -173363,7 +173363,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-BLAGUES-DICTONS-ET-PROVERBES
     unit_type: catalog_entry
     name: data/legacy/paper/regles-papier/extracted/histoires/blagues-dictons-et-proverbes.md
-    domain: rules
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-BLAGUES-DICTONS-ET-PROVERBES
@@ -173380,7 +173380,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-CULTES-ET-RELIGIONS
     unit_type: catalog_entry
     name: data/legacy/paper/regles-papier/extracted/histoires/cultes-et-religions.md
-    domain: rules
+    domain: d12-religions
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-CULTES-ET-RELIGIONS
@@ -173397,7 +173397,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-LA-CREATION-DES-TERRES-OUBLIEES
     unit_type: catalog_entry
     name: data/legacy/paper/regles-papier/extracted/histoires/la-creation-des-terres-oubliees.md
-    domain: rules
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-LA-CREATION-DES-TERRES-OUBLIEES
@@ -173414,7 +173414,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-NATIONS
     unit_type: catalog_entry
     name: data/legacy/paper/regles-papier/extracted/histoires/nations.md
-    domain: rules
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-NATIONS
@@ -173431,7 +173431,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-ORGANISATIONS
     unit_type: catalog_entry
     name: data/legacy/paper/regles-papier/extracted/histoires/organisations.md
-    domain: rules
+    domain: d12-organisations
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-ORGANISATIONS
@@ -173448,7 +173448,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-US-ET-COUTUMES
     unit_type: catalog_entry
     name: data/legacy/paper/regles-papier/extracted/histoires/us-et-coutumes.md
-    domain: rules
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-US-ET-COUTUMES
@@ -174918,7 +174918,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-CARTE-DU-MONDE-INDEX
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/carte-du-monde/index.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-CARTE-DU-MONDE-INDEX
@@ -174933,7 +174933,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-1
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-1.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-1
@@ -174948,7 +174948,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-15
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-15.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-15
@@ -174963,7 +174963,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-16
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-16.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-16
@@ -174978,7 +174978,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-18
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-18.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-18
@@ -174993,7 +174993,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-2
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-2.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-2
@@ -175008,7 +175008,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-20
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-20.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-20
@@ -175023,7 +175023,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-23
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-23.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-23
@@ -175038,7 +175038,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-26
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-26.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-26
@@ -175053,7 +175053,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-27
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-27.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-27
@@ -175068,7 +175068,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-28
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-28.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-28
@@ -175083,7 +175083,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-29
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-29.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-29
@@ -175098,7 +175098,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-3
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-3.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-3
@@ -175113,7 +175113,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-31
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-31.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-31
@@ -175128,7 +175128,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-4
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-4.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-4
@@ -175143,7 +175143,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-5
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-5.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-5
@@ -175158,7 +175158,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-6
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-6.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-6
@@ -175173,7 +175173,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-7
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/lieux/place-7.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-7
@@ -175188,7 +175188,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-13
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/regions/land-13.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-13
@@ -175203,7 +175203,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-21
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/regions/land-21.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-21
@@ -175218,7 +175218,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-24
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/regions/land-24.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-24
@@ -175233,7 +175233,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-8
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/regions/land-8.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-8
@@ -175248,7 +175248,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-9
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/regions/land-9.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-9
@@ -175263,7 +175263,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-TOUS-LES-LIEUX-INDEX
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/tous-les-lieux/index.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-TOUS-LES-LIEUX-INDEX
@@ -175278,7 +175278,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-10
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/villes/city-10.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-10
@@ -175293,7 +175293,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-11
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/villes/city-11.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-11
@@ -175308,7 +175308,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-12
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/villes/city-12.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-12
@@ -175323,7 +175323,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-14
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/villes/city-14.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-14
@@ -175338,7 +175338,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-17
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/villes/city-17.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-17
@@ -175353,7 +175353,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-19
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/villes/city-19.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-19
@@ -175368,7 +175368,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-22
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/villes/city-22.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-22
@@ -175383,7 +175383,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-25
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/villes/city-25.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-25
@@ -175398,7 +175398,7 @@ units:
   - unit_id: SOURCE-DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-30
     unit_type: catalog_entry
     name: data/legacy/web-scraped/monde/villes/city-30.md
-    domain: unclassified
+    domain: d12-world
     criticality: low
     source_refs:
       - source_id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-30

--- a/docs/canonical/nomos/source-manifest.yaml
+++ b/docs/canonical/nomos/source-manifest.yaml
@@ -12797,7 +12797,7 @@ sources:
   - id: DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-BLAGUES-DICTONS-ET-PROVERBES
     path: data/legacy/paper/regles-papier/extracted/histoires/blagues-dictons-et-proverbes.md
     type: markdown
-    domain: rules
+    domain: D12-world
     priority: legacy
     status: active
     hash: 2a9fe277335e50a68969f1fdbb03a761ac2d0cc04e637dc2d69a8093c68ae55d
@@ -12811,7 +12811,7 @@ sources:
   - id: DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-CULTES-ET-RELIGIONS
     path: data/legacy/paper/regles-papier/extracted/histoires/cultes-et-religions.md
     type: markdown
-    domain: rules
+    domain: D12-religions
     priority: legacy
     status: active
     hash: 87bdbb2b25fdd3979cf874f8dca16d09b5fb3405ff7925e616224a1e7122488f
@@ -12825,7 +12825,7 @@ sources:
   - id: DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-LA-CREATION-DES-TERRES-OUBLIEES
     path: data/legacy/paper/regles-papier/extracted/histoires/la-creation-des-terres-oubliees.md
     type: markdown
-    domain: rules
+    domain: D12-world
     priority: legacy
     status: active
     hash: 15b0509915f87723aedc54a3c5c966c275aec5eba67c53eed1e3755e0fc462b0
@@ -12839,7 +12839,7 @@ sources:
   - id: DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-NATIONS
     path: data/legacy/paper/regles-papier/extracted/histoires/nations.md
     type: markdown
-    domain: rules
+    domain: D12-world
     priority: legacy
     status: active
     hash: c67eec84b34d50659e8719bd2775aa572214404e0b9c3714ff849cea46259cf4
@@ -12853,7 +12853,7 @@ sources:
   - id: DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-ORGANISATIONS
     path: data/legacy/paper/regles-papier/extracted/histoires/organisations.md
     type: markdown
-    domain: rules
+    domain: D12-organisations
     priority: legacy
     status: active
     hash: 8c3baffca26e9ff48237fb34cc5856b389d2a9b40a0babdfdec0b3a64523777b
@@ -12867,7 +12867,7 @@ sources:
   - id: DATA-LEGACY-PAPER-REGLES-PAPIER-EXTRACTED-HISTOIRES-US-ET-COUTUMES
     path: data/legacy/paper/regles-papier/extracted/histoires/us-et-coutumes.md
     type: markdown
-    domain: rules
+    domain: D12-world
     priority: legacy
     status: active
     hash: 7734298132eb8f15d149e8e0f01b793828ab8ccc85933315ddf487c7cef1a2c9
@@ -14099,7 +14099,7 @@ sources:
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-CARTE-DU-MONDE-INDEX
     path: data/legacy/web-scraped/monde/carte-du-monde/index.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: d90779b59e7bd17613d70dddac199eb00bf81ae6b557d92afdd5ade31db95bb0
@@ -14109,11 +14109,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-1
     path: data/legacy/web-scraped/monde/lieux/place-1.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 6e55b8909f0b5c45160ab006f644a760828ee4fb37e1bc58ad1163699ee07b4f
@@ -14123,11 +14123,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-15
     path: data/legacy/web-scraped/monde/lieux/place-15.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 4a592b8e804ff8dab787894a1faf3f29299660845029c10c72f2a3ed164847ab
@@ -14137,11 +14137,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-16
     path: data/legacy/web-scraped/monde/lieux/place-16.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 3519223956745f9a59a28558f3b5f9c5b37455916396ab1a4140f29da9c6ef1b
@@ -14151,11 +14151,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-18
     path: data/legacy/web-scraped/monde/lieux/place-18.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 60614f78cad26b8c32d860487564a003a818e3caec1146c3c62358334a5948ac
@@ -14165,11 +14165,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-2
     path: data/legacy/web-scraped/monde/lieux/place-2.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: ab2d2b31553c5290219ba5b7befe4024a6575831528e5aaa8b67833edc615ac7
@@ -14179,11 +14179,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-20
     path: data/legacy/web-scraped/monde/lieux/place-20.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 0b24214e03b2624be45e54a4fecbc21c9ec3ff99b3ddd73d54b56a0043d60dac
@@ -14193,11 +14193,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-23
     path: data/legacy/web-scraped/monde/lieux/place-23.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 0bce6faa906b50c6a01ed5198b89f9e3a70889d736646efda7a5a1c74b26352a
@@ -14207,11 +14207,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-26
     path: data/legacy/web-scraped/monde/lieux/place-26.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 515c2e1e671dbbdbe5db5e2eb0e522abfa58dacba544cf71aee838d86d08e0ae
@@ -14221,11 +14221,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-27
     path: data/legacy/web-scraped/monde/lieux/place-27.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: a9a06d16342ee1787334b83bc9e5a6fff12b0415e146b96f97692b66a083a92d
@@ -14235,11 +14235,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-28
     path: data/legacy/web-scraped/monde/lieux/place-28.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: cadccff04d05ecf7b5512c715ea304f39d052835ecea34057c147a20f08e19bf
@@ -14249,11 +14249,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-29
     path: data/legacy/web-scraped/monde/lieux/place-29.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 593f1a781860bc3951f0ebc652baf183f394a2e60f7a6877cb83c1136ed7a70e
@@ -14263,11 +14263,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-3
     path: data/legacy/web-scraped/monde/lieux/place-3.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: e0ecdc99781280bc6e6902a3b2b7447328896c18c741a97fb9b6e487644da780
@@ -14277,11 +14277,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-31
     path: data/legacy/web-scraped/monde/lieux/place-31.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 4b3d42b199cd5c15be78888b7b50ba6d7872b7facfbdbabb507c7dfd2d163f3b
@@ -14291,11 +14291,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-4
     path: data/legacy/web-scraped/monde/lieux/place-4.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: f98a95df0c9a47b2217ee295e6588ef6a69ac5b7e7b3be8f58532b54eb558d43
@@ -14305,11 +14305,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-5
     path: data/legacy/web-scraped/monde/lieux/place-5.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: bec8c3ed5b2828c696fe7f347ee71c26952858e94fc95db794ac26f5f70ed2f8
@@ -14319,11 +14319,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-6
     path: data/legacy/web-scraped/monde/lieux/place-6.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: c4f66e0de5b65974bb35a1ea19d66a832619408088ea307eb2e9ff6faa06edfc
@@ -14333,11 +14333,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-LIEUX-PLACE-7
     path: data/legacy/web-scraped/monde/lieux/place-7.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: e5a8221083c41f6f7b29ebd9fdedac7f54c62be11bc554227266e508e3bd8341
@@ -14347,11 +14347,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-13
     path: data/legacy/web-scraped/monde/regions/land-13.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 52f7c46fe447fff6b3cb963d4652e51b21fb56d89845251831293ee6ace5e48f
@@ -14361,11 +14361,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-21
     path: data/legacy/web-scraped/monde/regions/land-21.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 3d7ac73a3fa3e18ebeca1718c941b5bc890e7cb76f406b3f6c46bff16e31d96d
@@ -14375,11 +14375,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-24
     path: data/legacy/web-scraped/monde/regions/land-24.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 587e4d273d24e52c525a44e6c393a8d88c1f66b0dd449ce8e8d8ca955a8b10ed
@@ -14389,11 +14389,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-8
     path: data/legacy/web-scraped/monde/regions/land-8.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: de639a46895687463b1341a1c12fa8350c663e3cabb359aee6a31c0db7372e8a
@@ -14403,11 +14403,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-REGIONS-LAND-9
     path: data/legacy/web-scraped/monde/regions/land-9.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 143659258163215e0603ef2545595c19c72ed186be3c6e3456f23eaa11bc035b
@@ -14417,11 +14417,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-TOUS-LES-LIEUX-INDEX
     path: data/legacy/web-scraped/monde/tous-les-lieux/index.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: b559e45b09cd00fe585acfeb26fd38a5a156c66dde61d4991b61bf76d7075fc2
@@ -14431,11 +14431,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-10
     path: data/legacy/web-scraped/monde/villes/city-10.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 5592fbc1907f092d504ef4fce67620f61a1e533c900e0900254ee382a8280959
@@ -14445,11 +14445,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-11
     path: data/legacy/web-scraped/monde/villes/city-11.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 82dd81dc21604591bffb4d883062fc91ad13fa1a8b66e549022a53745bde3338
@@ -14459,11 +14459,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-12
     path: data/legacy/web-scraped/monde/villes/city-12.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: e5e23fe1c79f8fe1d127a17b2a745780f6670657cd4c8d2d03b5bf539e826801
@@ -14473,11 +14473,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-14
     path: data/legacy/web-scraped/monde/villes/city-14.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: f39d0575e94b74f5afb65f4f0bdbfa58a6d1d2d6d00e27af4d191d29348aa90f
@@ -14487,11 +14487,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-17
     path: data/legacy/web-scraped/monde/villes/city-17.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: d168a9addba03994428d23146997c4d3aa3dcd263d483e65566509d28c6a7bbc
@@ -14501,11 +14501,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-19
     path: data/legacy/web-scraped/monde/villes/city-19.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 120a8d40c15c9049ba47988ede7c917c2e9c644e7843506db8b6a51c2bf46ba2
@@ -14515,11 +14515,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-22
     path: data/legacy/web-scraped/monde/villes/city-22.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: a0e22b49e71e4e1686394c2ee88a9623b737859a2f298f03ec79df5c23fdc33a
@@ -14529,11 +14529,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-25
     path: data/legacy/web-scraped/monde/villes/city-25.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 0343880064a244a216277c6b29e62b62a0dcd7da4372e482c2662c359dc6ff88
@@ -14543,11 +14543,11 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-MONDE-VILLES-CITY-30
     path: data/legacy/web-scraped/monde/villes/city-30.md
     type: source_code
-    domain: unclassified
+    domain: D12-world
     priority: reference
     status: active
     hash: 02ce93a7fc9111aab96f0b60bf508c90f44adb5d41cec335df6cee2a769d2a58
@@ -14557,7 +14557,7 @@ sources:
     allowed_uses:
       - vector_index
       - citation_internal
-    notes: Registered source requiring later classification.
+    notes: Scraped legacy world lore source.
   - id: DATA-LEGACY-WEB-SCRAPED-OUTILS-ASSISTANT-COMBAT-INDEX
     path: data/legacy/web-scraped/outils/assistant-combat/index.md
     type: source_code

--- a/docs/canonical/source-manifest.yaml
+++ b/docs/canonical/source-manifest.yaml
@@ -8153,8 +8153,8 @@ sources:
     source_type: legacy_paper_extract
     priority: 70
     status: active
-    domains: ["rules"]
-    contains: ["paper_extract"]
+    domains: ["D12-world", "lore"]
+    contains: ["folklore", "proverbs"]
     notes: "Extracted paper source."
   - id: "data-legacy-paper-regles-papier-extracted-histoires-cultes-et-religions"
     path: "data/legacy/paper/regles-papier/extracted/histoires/cultes-et-religions.md"
@@ -8162,8 +8162,8 @@ sources:
     source_type: legacy_paper_extract
     priority: 70
     status: active
-    domains: ["rules"]
-    contains: ["paper_extract"]
+    domains: ["D12-religions", "D12-world", "lore"]
+    contains: ["religions", "deities"]
     notes: "Extracted paper source."
   - id: "data-legacy-paper-regles-papier-extracted-histoires-la-creation-des-terres-oubliees"
     path: "data/legacy/paper/regles-papier/extracted/histoires/la-creation-des-terres-oubliees.md"
@@ -8171,8 +8171,8 @@ sources:
     source_type: legacy_paper_extract
     priority: 70
     status: active
-    domains: ["rules"]
-    contains: ["paper_extract"]
+    domains: ["D12-world", "lore"]
+    contains: ["creation_myth", "world_lore"]
     notes: "Extracted paper source."
   - id: "data-legacy-paper-regles-papier-extracted-histoires-nations"
     path: "data/legacy/paper/regles-papier/extracted/histoires/nations.md"
@@ -8180,8 +8180,8 @@ sources:
     source_type: legacy_paper_extract
     priority: 70
     status: active
-    domains: ["rules"]
-    contains: ["paper_extract"]
+    domains: ["D12-world", "lore"]
+    contains: ["nations", "regional_lore"]
     notes: "Extracted paper source."
   - id: "data-legacy-paper-regles-papier-extracted-histoires-organisations"
     path: "data/legacy/paper/regles-papier/extracted/histoires/organisations.md"
@@ -8189,8 +8189,8 @@ sources:
     source_type: legacy_paper_extract
     priority: 70
     status: active
-    domains: ["rules"]
-    contains: ["paper_extract"]
+    domains: ["D12-organisations", "lore"]
+    contains: ["organisations"]
     notes: "Extracted paper source."
   - id: "data-legacy-paper-regles-papier-extracted-histoires-us-et-coutumes"
     path: "data/legacy/paper/regles-papier/extracted/histoires/us-et-coutumes.md"
@@ -8198,8 +8198,8 @@ sources:
     source_type: legacy_paper_extract
     priority: 70
     status: active
-    domains: ["rules"]
-    contains: ["paper_extract"]
+    domains: ["D12-world", "lore"]
+    contains: ["cultures", "customs"]
     notes: "Extracted paper source."
   - id: "data-legacy-paper-regles-papier-extracted-infos-champignons-toxiques"
     path: "data/legacy/paper/regles-papier/extracted/infos/champignons-toxiques.md"
@@ -8990,297 +8990,297 @@ sources:
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-1"
     path: "data/legacy/web-scraped/monde/lieux/place-1.md"
     sha256: "6e55b8909f0b5c45160ab006f644a760828ee4fb37e1bc58ad1163699ee07b4f"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-15"
     path: "data/legacy/web-scraped/monde/lieux/place-15.md"
     sha256: "4a592b8e804ff8dab787894a1faf3f29299660845029c10c72f2a3ed164847ab"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-16"
     path: "data/legacy/web-scraped/monde/lieux/place-16.md"
     sha256: "3519223956745f9a59a28558f3b5f9c5b37455916396ab1a4140f29da9c6ef1b"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-18"
     path: "data/legacy/web-scraped/monde/lieux/place-18.md"
     sha256: "60614f78cad26b8c32d860487564a003a818e3caec1146c3c62358334a5948ac"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-2"
     path: "data/legacy/web-scraped/monde/lieux/place-2.md"
     sha256: "ab2d2b31553c5290219ba5b7befe4024a6575831528e5aaa8b67833edc615ac7"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-20"
     path: "data/legacy/web-scraped/monde/lieux/place-20.md"
     sha256: "0b24214e03b2624be45e54a4fecbc21c9ec3ff99b3ddd73d54b56a0043d60dac"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-23"
     path: "data/legacy/web-scraped/monde/lieux/place-23.md"
     sha256: "0bce6faa906b50c6a01ed5198b89f9e3a70889d736646efda7a5a1c74b26352a"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-26"
     path: "data/legacy/web-scraped/monde/lieux/place-26.md"
     sha256: "515c2e1e671dbbdbe5db5e2eb0e522abfa58dacba544cf71aee838d86d08e0ae"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-27"
     path: "data/legacy/web-scraped/monde/lieux/place-27.md"
     sha256: "a9a06d16342ee1787334b83bc9e5a6fff12b0415e146b96f97692b66a083a92d"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-28"
     path: "data/legacy/web-scraped/monde/lieux/place-28.md"
     sha256: "cadccff04d05ecf7b5512c715ea304f39d052835ecea34057c147a20f08e19bf"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-29"
     path: "data/legacy/web-scraped/monde/lieux/place-29.md"
     sha256: "593f1a781860bc3951f0ebc652baf183f394a2e60f7a6877cb83c1136ed7a70e"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-3"
     path: "data/legacy/web-scraped/monde/lieux/place-3.md"
     sha256: "e0ecdc99781280bc6e6902a3b2b7447328896c18c741a97fb9b6e487644da780"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-31"
     path: "data/legacy/web-scraped/monde/lieux/place-31.md"
     sha256: "4b3d42b199cd5c15be78888b7b50ba6d7872b7facfbdbabb507c7dfd2d163f3b"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-4"
     path: "data/legacy/web-scraped/monde/lieux/place-4.md"
     sha256: "f98a95df0c9a47b2217ee295e6588ef6a69ac5b7e7b3be8f58532b54eb558d43"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-5"
     path: "data/legacy/web-scraped/monde/lieux/place-5.md"
     sha256: "bec8c3ed5b2828c696fe7f347ee71c26952858e94fc95db794ac26f5f70ed2f8"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-6"
     path: "data/legacy/web-scraped/monde/lieux/place-6.md"
     sha256: "c4f66e0de5b65974bb35a1ea19d66a832619408088ea307eb2e9ff6faa06edfc"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-lieux-place-7"
     path: "data/legacy/web-scraped/monde/lieux/place-7.md"
     sha256: "e5a8221083c41f6f7b29ebd9fdedac7f54c62be11bc554227266e508e3bd8341"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["locations", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-regions-land-13"
     path: "data/legacy/web-scraped/monde/regions/land-13.md"
     sha256: "52f7c46fe447fff6b3cb963d4652e51b21fb56d89845251831293ee6ace5e48f"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["regions", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-regions-land-21"
     path: "data/legacy/web-scraped/monde/regions/land-21.md"
     sha256: "3d7ac73a3fa3e18ebeca1718c941b5bc890e7cb76f406b3f6c46bff16e31d96d"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["regions", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-regions-land-24"
     path: "data/legacy/web-scraped/monde/regions/land-24.md"
     sha256: "587e4d273d24e52c525a44e6c393a8d88c1f66b0dd449ce8e8d8ca955a8b10ed"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["regions", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-regions-land-8"
     path: "data/legacy/web-scraped/monde/regions/land-8.md"
     sha256: "de639a46895687463b1341a1c12fa8350c663e3cabb359aee6a31c0db7372e8a"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["regions", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-regions-land-9"
     path: "data/legacy/web-scraped/monde/regions/land-9.md"
     sha256: "143659258163215e0603ef2545595c19c72ed186be3c6e3456f23eaa11bc035b"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["regions", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-tous-les-lieux-index"
     path: "data/legacy/web-scraped/monde/tous-les-lieux/index.md"
     sha256: "b559e45b09cd00fe585acfeb26fd38a5a156c66dde61d4991b61bf76d7075fc2"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-villes-city-10"
     path: "data/legacy/web-scraped/monde/villes/city-10.md"
     sha256: "5592fbc1907f092d504ef4fce67620f61a1e533c900e0900254ee382a8280959"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["cities", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-villes-city-11"
     path: "data/legacy/web-scraped/monde/villes/city-11.md"
     sha256: "82dd81dc21604591bffb4d883062fc91ad13fa1a8b66e549022a53745bde3338"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["cities", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-villes-city-12"
     path: "data/legacy/web-scraped/monde/villes/city-12.md"
     sha256: "e5e23fe1c79f8fe1d127a17b2a745780f6670657cd4c8d2d03b5bf539e826801"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["cities", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-villes-city-14"
     path: "data/legacy/web-scraped/monde/villes/city-14.md"
     sha256: "f39d0575e94b74f5afb65f4f0bdbfa58a6d1d2d6d00e27af4d191d29348aa90f"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["cities", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-villes-city-17"
     path: "data/legacy/web-scraped/monde/villes/city-17.md"
     sha256: "d168a9addba03994428d23146997c4d3aa3dcd263d483e65566509d28c6a7bbc"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["cities", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-villes-city-19"
     path: "data/legacy/web-scraped/monde/villes/city-19.md"
     sha256: "120a8d40c15c9049ba47988ede7c917c2e9c644e7843506db8b6a51c2bf46ba2"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["cities", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-villes-city-22"
     path: "data/legacy/web-scraped/monde/villes/city-22.md"
     sha256: "a0e22b49e71e4e1686394c2ee88a9623b737859a2f298f03ec79df5c23fdc33a"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["cities", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-villes-city-25"
     path: "data/legacy/web-scraped/monde/villes/city-25.md"
     sha256: "0343880064a244a216277c6b29e62b62a0dcd7da4372e482c2662c359dc6ff88"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["cities", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-monde-villes-city-30"
     path: "data/legacy/web-scraped/monde/villes/city-30.md"
     sha256: "02ce93a7fc9111aab96f0b60bf508c90f44adb5d41cec335df6cee2a769d2a58"
     source_type: other
     priority: 20
     status: active
-    domains: ["unclassified"]
-    contains: ["other"]
-    notes: "Registered source requiring later classification."
+    domains: ["D12-world", "lore"]
+    contains: ["cities", "world_lore"]
+    notes: "Scraped legacy world lore source."
   - id: "data-legacy-web-scraped-outils-assistant-combat-index"
     path: "data/legacy/web-scraped/outils/assistant-combat/index.md"
     sha256: "aa5b3b85caa7ef025366bbdda0ea1d8c3c56f7fc288133b1cf53b11bf0023c42"

--- a/tools/canonical.test.ts
+++ b/tools/canonical.test.ts
@@ -39,6 +39,27 @@ describe('canonical compliance artifacts', () => {
             path: 'apps/legacy-php-site/includes/PHPMailer/vendor.php',
             source_type: 'third_party',
             status: 'out_of_scope'
+          }),
+          expect.objectContaining({
+            contains: ['nations', 'regional_lore'],
+            domains: ['D12-world', 'lore'],
+            path: 'data/legacy/paper/regles-papier/extracted/histoires/nations.md',
+            source_type: 'legacy_paper_extract',
+            status: 'active'
+          }),
+          expect.objectContaining({
+            contains: ['religions', 'deities'],
+            domains: ['D12-religions', 'D12-world', 'lore'],
+            path: 'data/legacy/paper/regles-papier/extracted/histoires/cultes-et-religions.md',
+            source_type: 'legacy_paper_extract',
+            status: 'active'
+          }),
+          expect.objectContaining({
+            contains: ['locations', 'world_lore'],
+            domains: ['D12-world', 'lore'],
+            path: 'data/legacy/web-scraped/monde/lieux/place-1.md',
+            source_type: 'other',
+            status: 'active'
           })
         ])
       );
@@ -449,7 +470,11 @@ async function createFixtureRepo(): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'kw-canonical-'));
   await mkdir(join(root, 'docs/rules'), { recursive: true });
   await mkdir(join(root, 'data/catalogs'), { recursive: true });
+  await mkdir(join(root, 'data/legacy/paper/regles-papier/extracted/histoires'), {
+    recursive: true
+  });
   await mkdir(join(root, 'data/legacy/web-scraped/raw-html/details'), { recursive: true });
+  await mkdir(join(root, 'data/legacy/web-scraped/monde/lieux'), { recursive: true });
   await mkdir(join(root, 'apps/legacy-php-site/includes/PHPMailer'), { recursive: true });
   await writeFile(join(root, 'docs/rules/01-resolution.md'), '### R-1.17 - Echec critique\n');
   await writeFile(
@@ -463,6 +488,18 @@ async function createFixtureRepo(): Promise<string> {
   await writeFile(
     join(root, 'data/legacy/web-scraped/raw-html/details/character-detail.php_id-87.html'),
     '<html>Aveline</html>'
+  );
+  await writeFile(
+    join(root, 'data/legacy/paper/regles-papier/extracted/histoires/nations.md'),
+    '# Nations\n'
+  );
+  await writeFile(
+    join(root, 'data/legacy/paper/regles-papier/extracted/histoires/cultes-et-religions.md'),
+    '# Cultes et religions\n'
+  );
+  await writeFile(
+    join(root, 'data/legacy/web-scraped/monde/lieux/place-1.md'),
+    '# Tour de Port-Sel\n'
   );
   await writeFile(join(root, 'apps/legacy-php-site/includes/PHPMailer/vendor.php'), '<?php');
   return root;

--- a/tools/canonical.ts
+++ b/tools/canonical.ts
@@ -1132,6 +1132,16 @@ function classifySource(path: string): Omit<SourceEntry, 'id' | 'path' | 'sha256
       'Scraped legacy web source.'
     );
   }
+  if (path.startsWith('data/legacy/web-scraped/monde/') && path.endsWith('.md')) {
+    return classify(
+      'other',
+      20,
+      'active',
+      containsForLegacyWeb(path),
+      domainsForLegacyWeb(path),
+      'Scraped legacy world lore source.'
+    );
+  }
   if (path.startsWith('data/legacy/paper/') && path.includes('/extracted/')) {
     return classify(
       'legacy_paper_extract',
@@ -1242,6 +1252,7 @@ function containsForCatalog(path: string): string[] {
 function domainsForLegacyWeb(path: string): string[] {
   if (path.includes('character-detail')) return ['legacy-characters', 'lore'];
   if (path.includes('play.php')) return ['legacy-sessions', 'lore'];
+  if (path.includes('/monde/')) return ['D12-world', 'lore'];
   if (path.includes('spells')) return ['D8-magic'];
   if (path.includes('classes')) return ['D4-classes'];
   if (path.includes('skills')) return ['D5-skills'];
@@ -1253,6 +1264,10 @@ function domainsForLegacyWeb(path: string): string[] {
 function containsForLegacyWeb(path: string): string[] {
   if (path.includes('character-detail')) return ['legacy_character'];
   if (path.includes('play.php')) return ['legacy_session_page', 'forum_posts'];
+  if (path.includes('/monde/lieux/')) return ['locations', 'world_lore'];
+  if (path.includes('/monde/villes/')) return ['cities', 'world_lore'];
+  if (path.includes('/monde/regions/')) return ['regions', 'world_lore'];
+  if (path.includes('/monde/')) return ['world_lore'];
   if (path.includes('spells')) return ['spells'];
   if (path.includes('classes')) return ['orientations', 'classes'];
   if (path.includes('skills')) return ['skills', 'specializations'];
@@ -1267,8 +1282,11 @@ function domainsForPaperExtract(path: string): string[] {
   if (path.includes('lexique') || path.includes('atouts')) return ['D4-assets'];
   if (path.includes('bestiaire')) return ['D3-races', 'D11-creatures'];
   if (path.includes('experience')) return ['D7-progression'];
+  if (path.includes('/histoires/nations')) return ['D12-world', 'lore'];
+  if (path.includes('/histoires/cultes')) return ['D12-religions', 'D12-world', 'lore'];
+  if (path.includes('/histoires/organisations')) return ['D12-organisations', 'lore'];
+  if (path.includes('/histoires/')) return ['D12-world', 'lore'];
   if (path.includes('regles')) return ['rules'];
-  if (path.includes('nations') || path.includes('cultes')) return ['D12-world'];
   return ['legacy-paper'];
 }
 
@@ -1278,6 +1296,13 @@ function containsForPaperExtract(path: string): string[] {
   if (path.includes('lexique')) return ['lexicon', 'assets', 'handicaps'];
   if (path.includes('atouts')) return ['level_assets', 'assets'];
   if (path.includes('bestiaire')) return ['races', 'creatures'];
+  if (path.includes('/histoires/nations')) return ['nations', 'regional_lore'];
+  if (path.includes('/histoires/cultes')) return ['religions', 'deities'];
+  if (path.includes('/histoires/organisations')) return ['organisations'];
+  if (path.includes('/histoires/us-et-coutumes')) return ['cultures', 'customs'];
+  if (path.includes('/histoires/la-creation')) return ['creation_myth', 'world_lore'];
+  if (path.includes('/histoires/blagues')) return ['folklore', 'proverbs'];
+  if (path.includes('/histoires/')) return ['world_lore'];
   return ['paper_extract'];
 }
 

--- a/tools/index-knowledge-base.test.ts
+++ b/tools/index-knowledge-base.test.ts
@@ -23,12 +23,36 @@ describe('knowledge base index plan', () => {
         }),
         expect.objectContaining({
           sourcePath: 'data/legacy/web-scraped/raw-html/details/character-detail.php_id-126.html'
+        }),
+        expect.objectContaining({
+          domains: ['D12-world', 'lore'],
+          sourceKind: 'lore_markdown',
+          sourcePath: 'data/legacy/paper/regles-papier/extracted/histoires/nations.md'
+        }),
+        expect.objectContaining({
+          domains: ['D12-religions', 'D12-world', 'lore'],
+          sourceKind: 'lore_markdown',
+          sourcePath: 'data/legacy/paper/regles-papier/extracted/histoires/cultes-et-religions.md'
+        }),
+        expect.objectContaining({
+          domains: ['D12-world', 'lore'],
+          sourceKind: 'lore_markdown',
+          sourcePath: 'data/legacy/web-scraped/monde/lieux/place-1.md'
         })
       ])
     );
 
     expect(plan.chunks).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            contains: ['nations', 'regional_lore'],
+            domain: 'D12-world',
+            source_type: 'legacy_paper_extract'
+          }),
+          sourceKind: 'lore_markdown',
+          sourcePath: 'data/legacy/paper/regles-papier/extracted/histoires/nations.md'
+        }),
         expect.objectContaining({
           sourcePath: 'data/legacy/web-scraped/raw-html/details/character-detail.php_id-126.html',
           metadata: expect.objectContaining({

--- a/tools/index-knowledge-base.ts
+++ b/tools/index-knowledge-base.ts
@@ -253,11 +253,20 @@ function sourceKindFor(source: SourceEntry): KnowledgeSourceKind {
     return 'catalog_yaml';
   }
 
-  if (source.path === 'docs/game/knightandwizard-game-foundation.md') {
+  if (isLoreMarkdownSource(source.path)) {
     return 'lore_markdown';
   }
 
   return source.source_type;
+}
+
+function isLoreMarkdownSource(path: string): boolean {
+  return (
+    path.endsWith('.md') &&
+    (path === 'docs/game/knightandwizard-game-foundation.md' ||
+      path.includes('/histoires/') ||
+      path.includes('data/legacy/web-scraped/monde/'))
+  );
 }
 
 function sourceMetadata(source: KnowledgeIndexSource): Partial<KnowledgeChunkMetadata> {


### PR DESCRIPTION
## Summary
- classify paper histoires and web monde markdown as D12/lore sources in the canonical manifest
- index those markdown sources as lore_markdown chunks for RAG instead of generic legacy/other buckets
- add regression coverage for canonical source classification and knowledge index metadata

## Validation
- pnpm validate

Closes #197