### PR TITLE
feat(server): renew active spells

### DIFF
--- a/apps/game/src/features/session-manager/model.ts
+++ b/apps/game/src/features/session-manager/model.ts
@@ -174,6 +174,7 @@ const eventLabels: Record<SessionEventType, string> = {
   rollback_requested: 'Renvoi demandé',
   scene_opened: 'Scène ouverte',
   spell_cast: 'Sort lancé',
+  spell_renewed: 'Sort renouvelé',
   spell_dispelled: 'Sort dissipé'
 };
 

--- a/apps/server/src/characters/finalize.ts
+++ b/apps/server/src/characters/finalize.ts
@@ -54,6 +54,7 @@ export interface CharacterActiveSpellReadModel {
   durationUnit: string;
   expiresAtCombatDt?: number;
   expiresAtNarrativeSeconds?: number;
+  lastRenewedAt?: string;
   sourceCasterId?: string;
   spellId?: string;
   status: string;
@@ -98,6 +99,7 @@ interface CharacterActiveSpellRow {
   duration_unit: string;
   expires_at_combat_dt: null | number;
   expires_at_narrative_seconds: null | number | string;
+  last_renewed_at: null | string;
   session_slug: string;
   source_caster_id: null | string;
   spell_id: null | string;
@@ -322,6 +324,7 @@ export async function listPersistedCharacterActiveSpells(
         cas.successes_count,
         cas.expires_at_narrative_seconds,
         cas.expires_at_combat_dt,
+        cas.last_renewed_at::text AS last_renewed_at,
         cas.status,
         gs.slug AS session_slug
       FROM character_active_spells cas
@@ -637,6 +640,7 @@ function toCharacterActiveSpellReadModel(
     ...(row.expires_at_narrative_seconds !== null
       ? { expiresAtNarrativeSeconds: Number(row.expires_at_narrative_seconds) }
       : {}),
+    ...(row.last_renewed_at !== null ? { lastRenewedAt: row.last_renewed_at } : {}),
     ...(row.source_caster_id !== null ? { sourceCasterId: row.source_caster_id } : {}),
     ...(row.spell_id !== null ? { spellId: row.spell_id } : {}),
     status: row.status,

--- a/apps/server/src/routes/sessions.test.ts
+++ b/apps/server/src/routes/sessions.test.ts
@@ -1022,6 +1022,120 @@ describe('session routes', () => {
     });
   });
 
+  it('renews active character spells without a new cast roll (R-8.7-bis)', async () => {
+    const slug = `character-spell-renewal-${randomUUID()}`;
+    const characterId = `active-spell-renewal-target-${randomUUID()}`;
+
+    await app.inject({
+      method: 'PUT',
+      payload: sampleCharacterDraft('Aveline Renouvelee'),
+      url: `/character-drafts/${characterId}`
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { draftId: characterId },
+      url: '/characters/finalize'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { mode: 'digital_human_gm', slug, title: 'Character Spell Renewal API' },
+      url: '/sessions'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        eventType: 'spell_cast',
+        payload: {
+          activeSpellId: 'spell-renewable-character',
+          durationAmount: 10,
+          durationUnit: 'minute',
+          spellId: 'aura-renouvelee',
+          successesCount: 3,
+          targetId: characterId
+        }
+      },
+      url: `/sessions/${slug}/events`
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { actorId: 'gm', eventType: 'narrative_time_advanced', payload: { minutes: 5 } },
+      url: `/sessions/${slug}/events`
+    });
+    const renewalResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        eventType: 'spell_renewed',
+        payload: {
+          activeSpellId: 'spell-renewable-character',
+          targetId: characterId
+        }
+      },
+      url: `/sessions/${slug}/events`
+    });
+    const sessionAfterRenewal = await app.inject({ method: 'GET', url: `/sessions/${slug}` });
+    const activeAfterRenewal = await app.inject({
+      method: 'GET',
+      url: `/characters/${characterId}/active-spells`
+    });
+
+    expect(renewalResponse.statusCode).toBe(201);
+    expect(sessionAfterRenewal.json().state.activeSpells).toMatchObject([
+      {
+        castAtSeconds: 300,
+        durationAmount: 10,
+        durationUnit: 'minute',
+        id: 'spell-renewable-character'
+      }
+    ]);
+    expect(activeAfterRenewal.statusCode).toBe(200);
+    expect(activeAfterRenewal.json()).toEqual({
+      activeSpells: [
+        {
+          activeSpellId: 'spell-renewable-character',
+          castAtNarrativeSeconds: 0,
+          castAtSequence: 1,
+          characterId,
+          durationAmount: 10,
+          durationUnit: 'minute',
+          expiresAtNarrativeSeconds: 900,
+          lastRenewedAt: expect.any(String),
+          sourceCasterId: 'gm',
+          spellId: 'aura-renouvelee',
+          status: 'active',
+          successesCount: 3,
+          sessionSlug: slug
+        }
+      ],
+      status: 'found'
+    });
+
+    await app.inject({
+      method: 'POST',
+      payload: { actorId: 'gm', eventType: 'narrative_time_advanced', payload: { minutes: 5 } },
+      url: `/sessions/${slug}/events`
+    });
+    const stillActive = await app.inject({
+      method: 'GET',
+      url: `/characters/${characterId}/active-spells`
+    });
+
+    expect(stillActive.json().activeSpells).toHaveLength(1);
+
+    await app.inject({
+      method: 'POST',
+      payload: { actorId: 'gm', eventType: 'narrative_time_advanced', payload: { minutes: 5 } },
+      url: `/sessions/${slug}/events`
+    });
+    const expired = await app.inject({
+      method: 'GET',
+      url: `/characters/${characterId}/active-spells`
+    });
+
+    expect(expired.json()).toEqual({ activeSpells: [], status: 'found' });
+  });
+
   it('rejects invalid session payloads', async () => {
     const response = await app.inject({
       method: 'POST',

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -639,6 +639,7 @@ export async function registerSessionRoutes(app: FastifyInstance): Promise<void>
           const sequence = sequenceRows[0]!.next_sequence;
           const needsPriorEventRows =
             eventType === 'spell_cast' ||
+            eventType === 'spell_renewed' ||
             eventType === 'narrative_time_advanced' ||
             eventType === 'combat_ended';
           const priorEventRows = needsPriorEventRows
@@ -2514,6 +2515,59 @@ async function persistCharacterActiveSpellEvent(
         dispelled_at_sequence = null,
         updated_at = now()
     `;
+    return;
+  }
+
+  if (event.event_type === 'spell_renewed') {
+    const stateBeforeRenewal = buildSessionState(session, priorEventRows, []);
+    const activeSpellId =
+      readNonEmptyString(event.payload.activeSpellId) ?? readNonEmptyString(event.payload.id);
+
+    if (activeSpellId === undefined) {
+      return;
+    }
+
+    await expireCharacterActiveSpells(sql, session.id, stateBeforeRenewal.narrativeSeconds);
+
+    const targetId = readNonEmptyString(event.payload.targetId);
+    const rows = await sql<
+      Array<{
+        duration_amount: number | string;
+        duration_unit: string;
+        id: string;
+      }>
+    >`
+      SELECT id, duration_amount, duration_unit
+      FROM character_active_spells
+      WHERE session_id = ${session.id}
+        AND active_spell_id = ${activeSpellId}
+        AND status = 'active'
+        ${targetId !== undefined ? sql`AND character_id = ${targetId}` : sql``}
+    `;
+
+    for (const row of rows) {
+      const durationUnit = readSpellDurationUnit(row.duration_unit);
+
+      if (durationUnit === undefined) {
+        continue;
+      }
+
+      const durationAmount = Number(row.duration_amount);
+      const durationSeconds = durationToSeconds(durationAmount, durationUnit);
+      const expiresAtNarrativeSeconds =
+        durationSeconds === null ? null : stateBeforeRenewal.narrativeSeconds + durationSeconds;
+      const expiresAtCombatDt = durationUnit === 'DT' ? Math.floor(durationAmount) : null;
+
+      await sql`
+        UPDATE character_active_spells
+        SET
+          expires_at_narrative_seconds = ${expiresAtNarrativeSeconds},
+          expires_at_combat_dt = ${expiresAtCombatDt},
+          last_renewed_at = now(),
+          updated_at = now()
+        WHERE id = ${row.id}
+      `;
+    }
     return;
   }
 

--- a/packages/rules-core/src/session.test.ts
+++ b/packages/rules-core/src/session.test.ts
@@ -13,6 +13,7 @@ import {
   rebuildSessionStateFromEvents,
   requestSessionRollback,
   resolveGmDecision,
+  renewSessionSpell,
   revertSessionToSequence
 } from './session.js';
 
@@ -402,6 +403,48 @@ describe('session narrative clock (R-8.20 — temps double)', () => {
 
     const dispelled = dispelSessionSpell(farFuture, { actorId: 'gm', activeSpellId: 'spell-ward' });
     expect(dispelled.activeSpells).toEqual([]);
+  });
+
+  it('renews an active spell from the current narrative instant without a new cast', () => {
+    const session = newSession();
+    const cast = castSessionSpell(session, {
+      activeSpellId: 'spell-aura',
+      durationAmount: 10,
+      durationUnit: 'minute'
+    });
+    const fiveMinutesLater = advanceSessionNarrative(cast, { by: { minutes: 5 } });
+    const renewed = renewSessionSpell(fiveMinutesLater, {
+      actorId: 'gm',
+      activeSpellId: 'spell-aura'
+    });
+
+    expect(renewed.events.map((event) => event.type)).toEqual([
+      'spell_cast',
+      'narrative_time_advanced',
+      'spell_renewed'
+    ]);
+    expect(renewed.activeSpells).toMatchObject([
+      { castAtSeconds: 300, durationAmount: 10, durationUnit: 'minute', id: 'spell-aura' }
+    ]);
+
+    const originalExpiry = advanceSessionNarrative(renewed, { by: { minutes: 5 } });
+    expect(originalExpiry.activeSpells.map((spell) => spell.id)).toEqual(['spell-aura']);
+
+    const renewedExpiry = advanceSessionNarrative(originalExpiry, { by: { minutes: 5 } });
+    expect(renewedExpiry.activeSpells).toEqual([]);
+  });
+
+  it('does not resurrect an already expired spell on renewal', () => {
+    const session = newSession();
+    const cast = castSessionSpell(session, {
+      activeSpellId: 'spell-short',
+      durationAmount: 1,
+      durationUnit: 'minute'
+    });
+    const expired = advanceSessionNarrative(cast, { by: { minutes: 1 } });
+    const renewed = renewSessionSpell(expired, { activeSpellId: 'spell-short' });
+
+    expect(renewed.activeSpells).toEqual([]);
   });
 
   it('rewinds the clock and resurrects a lapsed spell when reverting (rollback rewinds time)', () => {

--- a/packages/rules-core/src/session.ts
+++ b/packages/rules-core/src/session.ts
@@ -5,7 +5,8 @@ import {
   SPELL_DURATION_UNITS,
   advanceNarrative,
   endCombat,
-  expireActiveSpells
+  expireActiveSpells,
+  isActiveSpellExpired
 } from './narrative-time.js';
 
 export const SESSION_MODES = [
@@ -35,6 +36,7 @@ export const SESSION_EVENT_TYPES = [
   'narrative_time_advanced',
   'combat_ended',
   'spell_cast',
+  'spell_renewed',
   'spell_dispelled'
 ] as const;
 
@@ -649,6 +651,11 @@ export interface DispelSessionSpellInput {
   activeSpellId: string;
 }
 
+export interface RenewSessionSpellInput {
+  actorId?: string;
+  activeSpellId: string;
+}
+
 interface NarrativeClock {
   /** Instant narratif courant en secondes (R-8.20). */
   narrativeSeconds: number;
@@ -700,6 +707,23 @@ export function castSessionSpell(
         targetId: input.targetId
       },
       type: 'spell_cast'
+    },
+    options
+  );
+}
+
+/** Renouvelle un sort actif sans nouveau jet : même durée/réussites, nouveau départ d'expiration. */
+export function renewSessionSpell(
+  state: SessionState,
+  input: RenewSessionSpellInput,
+  options: SessionMutationOptions = {}
+): SessionState {
+  return appendSessionEvent(
+    state,
+    {
+      actorId: input.actorId,
+      payload: { activeSpellId: input.activeSpellId },
+      type: 'spell_renewed'
     },
     options
   );
@@ -781,6 +805,25 @@ function reduceNarrativeEvent(clock: NarrativeClock, event: SessionEvent): Narra
       const spell = activeSpellFromEvent(event, clock.narrativeSeconds);
 
       return spell === undefined ? clock : { ...clock, spells: [...clock.spells, spell] };
+    }
+    case 'spell_renewed': {
+      const id = optionalString(event.payload.activeSpellId) ?? optionalString(event.payload.id);
+
+      if (id === undefined) {
+        return clock;
+      }
+
+      let renewed = false;
+      const spells = clock.spells.map((spell) => {
+        if (spell.id !== id || isActiveSpellExpired(spell, clock.narrativeSeconds)) {
+          return spell;
+        }
+
+        renewed = true;
+        return { ...spell, castAtSeconds: clock.narrativeSeconds };
+      });
+
+      return renewed ? { ...clock, spells } : clock;
     }
     case 'spell_dispelled': {
       const id = optionalString(event.payload.activeSpellId) ?? optionalString(event.payload.id);


### PR DESCRIPTION
## Summary
- add the spell_renewed session event for R-8.7-bis renewal without a new cast roll
- keep original spell successes while restarting active session expiry from the current narrative instant
- persist character active spell renewal with last_renewed_at and recalculated expiry
- expose renewed active spell rows through the character active-spells read model and session UI event labels

## Validation
- pnpm validate

Refs #188
