### PR TITLE
feat(server): vectorize GM memories

### DIFF
--- a/apps/server/drizzle/0010_gm_memory_embeddings.sql
+++ b/apps/server/drizzle/0010_gm_memory_embeddings.sql
@@ -1,0 +1,5 @@
+ALTER TABLE gm_memories
+  ADD COLUMN IF NOT EXISTS embedding vector(1536);
+
+CREATE INDEX IF NOT EXISTS gm_memories_embedding_hnsw_idx
+  ON gm_memories USING hnsw (embedding vector_cosine_ops);

--- a/apps/server/src/db/schema.test.ts
+++ b/apps/server/src/db/schema.test.ts
@@ -35,16 +35,16 @@ describe('database schema', () => {
     }
   });
 
-  it('stores GM memory provenance columns', async () => {
+  it('stores GM memory provenance and embedding columns', async () => {
     const rows = await sql<{ column_name: string }[]>`
       SELECT column_name
       FROM information_schema.columns
       WHERE table_schema = 'public'
         AND table_name = 'gm_memories'
-        AND column_name = 'provenance_type'
+        AND column_name IN ('embedding', 'provenance_type')
     `;
 
-    expect(rows).toEqual([{ column_name: 'provenance_type' }]);
+    expect(rows.map((row) => row.column_name).sort()).toEqual(['embedding', 'provenance_type']);
   });
 
   it('stores knowledge source metadata columns', async () => {

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -325,6 +325,7 @@ export const gmMemories = pgTable(
       .$type<Record<string, unknown>>()
       .notNull()
       .default(sql`'{}'::jsonb`),
+    embedding: vector('embedding'),
     occurredAt: timestamp('occurred_at', { withTimezone: true }).notNull().defaultNow(),
     createdAt: now(),
     updatedAt: updatedNow()

--- a/apps/server/src/knowledge/repository.ts
+++ b/apps/server/src/knowledge/repository.ts
@@ -312,7 +312,7 @@ function extractEmbedding(payload: { embedding?: unknown; embeddings?: unknown }
   return candidate;
 }
 
-function toVectorLiteral(vector: number[]): string {
+export function toVectorLiteral(vector: number[]): string {
   return `[${vector.map((value) => formatVectorNumber(value)).join(',')}]`;
 }
 

--- a/apps/server/src/llm/episodic-memory.test.ts
+++ b/apps/server/src/llm/episodic-memory.test.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createSqlClient } from '../db/client.js';
 import { runMigrations } from '../db/migrate.js';
+import type { EmbeddingProvider } from '../knowledge/repository.js';
 import {
   buildEpisodicMemoryContext,
   createDatabaseEpisodicMemoryStore,
@@ -102,6 +103,59 @@ describe('game master episodic memory', () => {
     });
   });
 
+  it('stores memory embeddings and recalls vector matches before lexical fallback', async () => {
+    const sessionKey = `test-memory-${randomUUID()}`;
+    const semanticEmbeddingProvider = new SemanticMemoryEmbeddingProvider();
+    const memory = await recordGmMemory(
+      sql,
+      {
+        importance: 3,
+        kind: 'npc_encounter',
+        provenanceType: 'session_fact',
+        sessionKey,
+        source: 'game-master',
+        subject: 'Sergent Malo',
+        summary: 'Le Sergent Malo tient la porte nord de Brumeval.'
+      },
+      { embeddingProvider: semanticEmbeddingProvider }
+    );
+
+    await recordGmMemory(
+      sql,
+      {
+        importance: 5,
+        kind: 'weather',
+        provenanceType: 'session_fact',
+        sessionKey,
+        source: 'game-master',
+        subject: 'Averse du soir',
+        summary: 'Une pluie froide transforme la route en boue.'
+      },
+      { embeddingProvider: semanticEmbeddingProvider }
+    );
+
+    const embeddingRows = await sql<{ has_embedding: boolean }[]>`
+      SELECT embedding IS NOT NULL AS has_embedding
+      FROM gm_memories
+      WHERE id = ${memory.id}
+    `;
+    const memories = await searchGmMemories(
+      sql,
+      {
+        limit: 2,
+        query: 'vigile des remparts',
+        sessionKey
+      },
+      { embeddingProvider: semanticEmbeddingProvider }
+    );
+
+    expect(embeddingRows).toEqual([{ has_embedding: true }]);
+    expect(memories[0]).toMatchObject({
+      subject: 'Sergent Malo'
+    });
+    expect(memories[0]?.score).toBeGreaterThan(0.9);
+  });
+
   it('requires canonical sources for canonical lore memories', async () => {
     const sessionKey = `test-memory-${randomUUID()}`;
 
@@ -131,3 +185,25 @@ describe('game master episodic memory', () => {
     });
   });
 });
+
+class SemanticMemoryEmbeddingProvider implements EmbeddingProvider {
+  readonly dimensions = 1536;
+
+  async embed(text: string): Promise<number[]> {
+    const vector = new Array<number>(this.dimensions).fill(0);
+    const normalized = text
+      .toLowerCase()
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '');
+
+    if (/(malo|nord|porte|rempart|sergent|vigile)/.test(normalized)) {
+      vector[0] = 1;
+    }
+
+    if (/(averse|boue|pluie|route)/.test(normalized)) {
+      vector[1] = 1;
+    }
+
+    return vector;
+  }
+}

--- a/apps/server/src/llm/episodic-memory.ts
+++ b/apps/server/src/llm/episodic-memory.ts
@@ -1,5 +1,10 @@
 import type { SqlClient } from '../db/client.js';
 import { createSqlClient } from '../db/client.js';
+import {
+  createDefaultEmbeddingProvider,
+  toVectorLiteral,
+  type EmbeddingProvider
+} from '../knowledge/repository.js';
 import type postgres from 'postgres';
 
 export type GmMemoryProvenanceType = 'canonical_lore' | 'hypothesis' | 'session_fact';
@@ -43,6 +48,10 @@ export interface EpisodicMemoryStore {
   record(input: GmMemoryInput): Promise<GmMemoryEntry | undefined>;
 }
 
+export interface GmMemoryPersistenceOptions {
+  embeddingProvider?: EmbeddingProvider;
+}
+
 interface GmMemoryRow {
   id: string;
   importance: number;
@@ -56,13 +65,23 @@ interface GmMemoryRow {
   summary: string;
 }
 
+interface GmMemoryVectorRow extends GmMemoryRow {
+  score: number | string;
+}
+
 const DEFAULT_RECALL_LIMIT = 5;
 
-export async function recordGmMemory(sql: SqlClient, input: GmMemoryInput): Promise<GmMemoryEntry> {
+export async function recordGmMemory(
+  sql: SqlClient,
+  input: GmMemoryInput,
+  options: GmMemoryPersistenceOptions = {}
+): Promise<GmMemoryEntry> {
   const provenanceType = input.provenanceType ?? 'session_fact';
   const source = input.source ?? 'game-master';
 
   assertMemoryProvenance({ provenanceType, source });
+
+  const embedding = await buildMemoryVectorLiteral(input, options);
 
   const rows = await sql<GmMemoryRow[]>`
     INSERT INTO gm_memories (
@@ -74,6 +93,7 @@ export async function recordGmMemory(sql: SqlClient, input: GmMemoryInput): Prom
       importance,
       source,
       payload,
+      embedding,
       occurred_at
     )
     VALUES (
@@ -85,6 +105,7 @@ export async function recordGmMemory(sql: SqlClient, input: GmMemoryInput): Prom
       ${input.importance ?? 1},
       ${source},
       ${sql.json((input.payload ?? {}) as postgres.JSONValue)}::jsonb,
+      ${embedding}::vector,
       ${input.occurredAt ?? new Date()}
     )
     RETURNING id, session_key, memory_kind, provenance_type, subject, summary, importance, source, payload, occurred_at
@@ -100,12 +121,22 @@ export async function recordGmMemory(sql: SqlClient, input: GmMemoryInput): Prom
 
 export async function searchGmMemories(
   sql: SqlClient,
-  input: GmMemoryRecallInput
+  input: GmMemoryRecallInput,
+  options: GmMemoryPersistenceOptions = {}
 ): Promise<GmMemoryEntry[]> {
   const limit = input.limit ?? DEFAULT_RECALL_LIMIT;
   const tokens = significantTokens(input.query);
   const provenanceTypes =
     input.provenanceTypes === undefined ? undefined : new Set(input.provenanceTypes);
+
+  if (input.query.trim().length > 0) {
+    const vectorMatches = await searchVectorGmMemories(sql, input, options, provenanceTypes, limit);
+
+    if (vectorMatches.length > 0) {
+      return vectorMatches;
+    }
+  }
+
   const rows = await sql<GmMemoryRow[]>`
     SELECT id, session_key, memory_kind, provenance_type, subject, summary, importance, source, payload, occurred_at
     FROM gm_memories
@@ -148,7 +179,10 @@ export async function searchGmMemories(
     .slice(0, limit);
 }
 
-export function createDatabaseEpisodicMemoryStore(sql?: SqlClient): EpisodicMemoryStore {
+export function createDatabaseEpisodicMemoryStore(
+  sql?: SqlClient,
+  options: GmMemoryPersistenceOptions = {}
+): EpisodicMemoryStore {
   const client = sql ?? createSqlClient();
   const shouldCloseClient = sql === undefined;
 
@@ -159,10 +193,10 @@ export function createDatabaseEpisodicMemoryStore(sql?: SqlClient): EpisodicMemo
       }
     },
     recall(input) {
-      return searchGmMemories(client, input);
+      return searchGmMemories(client, input, options);
     },
     record(input) {
-      return recordGmMemory(client, input);
+      return recordGmMemory(client, input, options);
     }
   };
 }
@@ -197,6 +231,79 @@ function isCanonicalMemorySource(source: string): boolean {
     source.startsWith('rule:') ||
     source.startsWith('source:')
   );
+}
+
+async function searchVectorGmMemories(
+  sql: SqlClient,
+  input: GmMemoryRecallInput,
+  options: GmMemoryPersistenceOptions,
+  provenanceTypes: Set<GmMemoryProvenanceType> | undefined,
+  limit: number
+): Promise<GmMemoryEntry[]> {
+  const vector = await buildQueryVectorLiteral(input.query, options);
+
+  if (vector === undefined) {
+    return [];
+  }
+
+  const rows = await sql<GmMemoryVectorRow[]>`
+    SELECT
+      id,
+      session_key,
+      memory_kind,
+      provenance_type,
+      subject,
+      summary,
+      importance,
+      source,
+      payload,
+      occurred_at,
+      1 - (embedding <=> ${vector}::vector) AS score
+    FROM gm_memories
+    WHERE session_key = ${input.sessionKey}
+      AND embedding IS NOT NULL
+    ORDER BY embedding <=> ${vector}::vector
+    LIMIT 200
+  `;
+  const scopedRows =
+    provenanceTypes === undefined
+      ? rows
+      : rows.filter((row) => provenanceTypes.has(row.provenance_type));
+
+  return scopedRows.slice(0, limit).map((row) => ({
+    ...toMemoryEntry(row),
+    score: Number(row.score)
+  }));
+}
+
+async function buildMemoryVectorLiteral(
+  input: GmMemoryInput,
+  options: GmMemoryPersistenceOptions
+): Promise<string | null> {
+  return (
+    (await buildVectorLiteral(`${input.subject}\n${input.summary}`, options.embeddingProvider)) ??
+    null
+  );
+}
+
+async function buildQueryVectorLiteral(
+  query: string,
+  options: GmMemoryPersistenceOptions
+): Promise<string | undefined> {
+  return buildVectorLiteral(query, options.embeddingProvider);
+}
+
+async function buildVectorLiteral(
+  text: string,
+  embeddingProvider: EmbeddingProvider | undefined
+): Promise<string | undefined> {
+  const provider = embeddingProvider ?? createDefaultEmbeddingProvider();
+
+  try {
+    return toVectorLiteral(await provider.embed(text));
+  } catch {
+    return undefined;
+  }
 }
 
 function toMemoryEntry(row: GmMemoryRow): GmMemoryEntry {


### PR DESCRIPTION
## Summary
- add a pgvector embedding column and HNSW index for gm_memories
- persist embeddings when GM episodic memories are recorded
- prefer vector recall for episodic memory retrieval, with lexical fallback when vectors are unavailable
- cover schema migration and vector recall behavior with tests

## Validation
- pnpm validate

Refs #169
