### PR TITLE
feat(game): add cockpit GM assistant

### DIFF
--- a/apps/game/src/features/gm-cockpit/GmCockpit.tsx
+++ b/apps/game/src/features/gm-cockpit/GmCockpit.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useMemo, useState } from 'react';
 import {
   ArrowUpRight,
+  Bot,
   CheckCircle2,
   Gavel,
   PlusCircle,
@@ -17,8 +18,11 @@ import {
 import type { SessionManagerState } from '../session-manager/model';
 import {
   appendGmRulingToSession,
+  appendPersistedSessionEvent,
   awardCharacterXp,
+  describeGameMasterScene,
   fetchPersistedSessionState,
+  type GameMasterSceneDescription,
   queuePersistedChangeRequest,
   requestPersistedRollback,
   resolvePersistedChangeRequest
@@ -42,6 +46,8 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
   const [rollbackSequence, setRollbackSequence] = useState(
     view.rollbackTargets[0]?.sequence.toString() ?? ''
   );
+  const [assistantPrompt, setAssistantPrompt] = useState(() => defaultAssistantPrompt(view));
+  const [assistantResult, setAssistantResult] = useState<GameMasterSceneDescription | null>(null);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -114,6 +120,34 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
         payload: {
           kind: 'session_closed',
           text: 'Fin de session marquee par le MJ'
+        }
+      });
+    });
+  }
+
+  function describeWithAssistant() {
+    const sceneDescription = assistantPrompt.trim();
+
+    if (!sceneDescription) {
+      return;
+    }
+
+    void run('assistant', async () => {
+      const result = await describeGameMasterScene({
+        sceneDescription,
+        sessionId: state.slug
+      });
+      setAssistantResult(result);
+      await appendPersistedSessionEvent(state.slug, {
+        actorId: 'llm',
+        eventType: 'narration',
+        payload: {
+          citationCount: result.knowledge?.citations?.length ?? 0,
+          kind: 'gm_assistant',
+          memoryCount: result.episodicMemory?.memories?.length ?? 0,
+          model: result.model,
+          provider: result.provider,
+          text: result.narration
         }
       });
     });
@@ -252,6 +286,53 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
               </li>
             ))}
           </ol>
+        </article>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-[0.9fr_1.1fr]">
+        <article className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
+          <div className="flex items-center gap-2">
+            <Bot aria-hidden="true" className="size-5 text-gold" />
+            <h2 className="text-lg font-semibold text-ink">Assistant MJ</h2>
+          </div>
+          <label
+            className="mt-4 block text-sm font-semibold text-ink/70"
+            htmlFor="gm-assistant-prompt"
+          >
+            Brief de scène
+            <textarea
+              className="mt-2 min-h-28 w-full rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-semibold leading-6 text-ink"
+              id="gm-assistant-prompt"
+              onChange={(event) => setAssistantPrompt(event.target.value)}
+              value={assistantPrompt}
+            />
+          </label>
+          <button
+            className="mt-3 inline-flex items-center gap-2 rounded-md bg-ink px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+            disabled={pendingAction !== null || !assistantPrompt.trim()}
+            onClick={describeWithAssistant}
+            type="button"
+          >
+            <Bot aria-hidden="true" className="size-4" />
+            Décrire
+          </button>
+        </article>
+
+        <article className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
+          <h2 className="text-lg font-semibold text-ink">Proposition</h2>
+          {assistantResult ? (
+            <>
+              <p className="mt-4 text-sm leading-6 text-ink/75">{assistantResult.narration}</p>
+              <p className="mt-3 text-xs font-semibold uppercase tracking-[0.12em] text-ink/50">
+                Sources {assistantResult.knowledge?.citations?.length ?? 0} · Mémoire{' '}
+                {assistantResult.episodicMemory?.memories?.length ?? 0}
+              </p>
+            </>
+          ) : (
+            <p className="mt-4 text-sm leading-6 text-ink/60">
+              {view.activeScene?.description ?? 'Aucune proposition inscrite.'}
+            </p>
+          )}
         </article>
       </section>
 
@@ -494,6 +575,16 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
       </section>
     </main>
   );
+}
+
+function defaultAssistantPrompt(view: ReturnType<typeof buildGmCockpitView>): string {
+  const scene = view.activeScene;
+
+  if (!scene) {
+    return 'La table reprend sans scene active.';
+  }
+
+  return [scene.title, scene.location, scene.description].filter(Boolean).join(' · ');
 }
 
 function CockpitLink({ href, label }: Readonly<{ href: string; label: string }>) {

--- a/apps/game/src/features/session-manager/persistence.test.ts
+++ b/apps/game/src/features/session-manager/persistence.test.ts
@@ -6,6 +6,7 @@ import {
   appendGmRulingToSession,
   appendThreadPostToSession,
   awardCharacterXp,
+  describeGameMasterScene,
   queuePersistedChangeRequest,
   queuePersistedGmDecision,
   requestPersistedRollback,
@@ -151,6 +152,38 @@ describe('session manager persistence', () => {
         method: 'PATCH'
       }
     );
+  });
+
+  it('describes a GM scene through the assistant API', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://browser-api.test';
+    const fetchMock = vi.fn().mockResolvedValue(
+      okJson({
+        knowledge: { citations: [{ sourcePath: 'docs/rules/08-magie.md' }] },
+        model: 'ollama/qwen2.5:7b',
+        narration: 'La brume avale les bruits de la porte nord.',
+        provider: 'deterministic-dev',
+        status: 'described'
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await describeGameMasterScene({
+      sceneDescription: 'La porte nord disparait dans la brume.',
+      sessionId: 'brumeval'
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('http://browser-api.test/game-master/scenes/describe', {
+      body: JSON.stringify({
+        sceneDescription: 'La porte nord disparait dans la brume.',
+        sessionId: 'brumeval'
+      }),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST'
+    });
+    expect(result).toMatchObject({
+      narration: 'La brume avale les bruits de la porte nord.',
+      provider: 'deterministic-dev'
+    });
   });
 
   it('appends a GM ruling event for cockpit actions', async () => {

--- a/apps/game/src/features/session-manager/persistence.ts
+++ b/apps/game/src/features/session-manager/persistence.ts
@@ -85,10 +85,44 @@ export interface AwardCharacterXpInput {
   sessionSlug?: string;
 }
 
+export interface DescribeGameMasterSceneInput {
+  sceneDescription: string;
+  sessionId: string;
+}
+
+export interface GameMasterSceneDescription {
+  episodicMemory?: {
+    memories?: unknown[];
+  };
+  knowledge?: {
+    citations?: unknown[];
+  };
+  model: string;
+  narration: string;
+  provider: string;
+}
+
 export async function fetchPersistedSessionState(slug: string): Promise<SessionManagerState> {
   const snapshot = await getPersistedSessionSnapshot(slug);
 
   return toSessionManagerState(snapshot);
+}
+
+export async function describeGameMasterScene(
+  input: DescribeGameMasterSceneInput
+): Promise<GameMasterSceneDescription> {
+  const baseUrl = getClientApiBaseUrl();
+  const response = await fetch(`${baseUrl}/game-master/scenes/describe`, {
+    body: JSON.stringify(input),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST'
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unable to describe GM scene ${input.sessionId}: HTTP ${response.status}`);
+  }
+
+  return (await response.json()) as GameMasterSceneDescription;
 }
 
 export async function appendDiceRollToSession(

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -397,6 +397,15 @@ test.describe('K&W player and GM application flows', () => {
       'href',
       `/combat?slug=${slug}&characterId=${draftId}`
     );
+    await expect(page.getByRole('heading', { name: 'Assistant MJ' })).toBeVisible();
+
+    await page.getByLabel('Brief de scène').fill('La brume cache un guetteur pres de la porte.');
+    await page.getByRole('button', { name: 'Décrire' }).click();
+    const proposalPanel = page.locator('article').filter({
+      has: page.getByRole('heading', { name: 'Proposition' })
+    });
+    await expect(proposalPanel.getByText('Le MJ decrit les details visibles')).toBeVisible();
+    await expect(proposalPanel.getByText(/Sources \d+ · Mémoire \d+/)).toBeVisible();
 
     await page.getByRole('button', { name: 'Attribuer 1 XP' }).click();
     await expect(page.getByText('XP attribue a Aveline Cockpit')).toBeVisible();


### PR DESCRIPTION
## Summary
- add an Assistant MJ panel to the /mj cockpit
- call the existing /game-master/scenes/describe backend route from the game client
- display the generated proposition with source and memory counts
- append the assistant narration back into the session journal

## Validation
- pnpm validate
- Browser plugin DOM interaction: /mj assistant visible, Décrire produces a proposition, console has no warnings/errors. Screenshot capture failed in the Browser runtime with Page.captureScreenshot timeout, but DOM and console evidence passed.

Refs #168
