### PR TITLE
feat(server): #167 spend xp on skills

### DIFF
--- a/apps/server/src/characters/finalize.ts
+++ b/apps/server/src/characters/finalize.ts
@@ -20,7 +20,8 @@ import {
   type CharacterSpell,
   type CombatStatus,
   type RaceProfile,
-  gainXP
+  gainXP,
+  learnSkill
 } from '@knightandwizard/rules-core';
 import { and, eq, sql as drizzleSql } from 'drizzle-orm';
 import { z } from 'zod';
@@ -81,6 +82,15 @@ export interface CharacterXpAwardUpdate {
   questPoints?: number;
   reason?: string;
   sessionSlug?: string;
+}
+
+export interface CharacterSkillImprovementUpdate {
+  actorId?: string;
+  isMain?: boolean;
+  parentId?: string | null;
+  reason?: string;
+  sessionSlug?: string;
+  skillId: string;
 }
 
 interface CharacterCreationCatalog {
@@ -472,6 +482,78 @@ export async function awardPersistedCharacterXp(
   }
 }
 
+export async function improvePersistedCharacterSkill(
+  id: string,
+  input: CharacterSkillImprovementUpdate,
+  scope: CharacterPersistenceScope = {}
+): Promise<CharacterPersistenceResult> {
+  const sql = createSqlClient();
+  const db = createDbClient(sql);
+
+  try {
+    const rows = await db
+      .select({ character: characters.payload })
+      .from(characters)
+      .where(
+        scope.userId
+          ? and(eq(characters.id, id), eq(characters.userId, scope.userId))
+          : eq(characters.id, id)
+      )
+      .limit(1);
+    const row = rows[0];
+
+    if (row === undefined) {
+      throw new CharacterNotFoundError(id);
+    }
+
+    const previousSkill = row.character.skills.find((skill) => skill.id === input.skillId);
+    const improved = learnSkill(row.character, input.skillId, {
+      hasNarrativeAccess: true,
+      ...(input.isMain !== undefined ? { isMain: input.isMain } : {}),
+      ...(input.parentId !== undefined ? { parentId: input.parentId } : {})
+    });
+    const nextSkill = improved.skills.find((skill) => skill.id === input.skillId);
+    const spentAt = new Date().toISOString();
+    const spendRecord = {
+      ...(input.actorId ? { actorId: input.actorId } : {}),
+      cost: row.character.progression.experiencePoints - improved.progression.experiencePoints,
+      kind: 'skill_improvement',
+      nextPoints: nextSkill?.points ?? previousSkill?.points ?? 0,
+      ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
+      previousPoints: previousSkill?.points ?? 0,
+      ...(input.reason ? { reason: input.reason } : {}),
+      ...(input.sessionSlug ? { sessionSlug: input.sessionSlug } : {}),
+      skillId: input.skillId,
+      spentAt
+    };
+    const character: Character = {
+      ...improved,
+      metadata: {
+        ...improved.metadata,
+        xpSpends: [...readXpSpendRecords(improved.metadata.xpSpends), spendRecord]
+      }
+    };
+    const updatedRows = await db
+      .update(characters)
+      .set({
+        payload: character,
+        updatedAt: drizzleSql`now()`
+      })
+      .where(
+        scope.userId
+          ? and(eq(characters.id, id), eq(characters.userId, scope.userId))
+          : eq(characters.id, id)
+      )
+      .returning({ character: characters.payload });
+
+    return {
+      character: updatedRows[0]!.character
+    };
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
 async function loadCharacterCreationCatalog(): Promise<CharacterCreationCatalog> {
   const [races, orientations, classes, weapons, protections, potions] = await Promise.all([
     loadValidatedCatalog('races.yaml'),
@@ -499,6 +581,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function readXpAwardRecords(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value.filter(isRecord);
+}
+
+function readXpSpendRecords(value: unknown): Record<string, unknown>[] {
   if (!Array.isArray(value)) {
     return [];
   }

--- a/apps/server/src/routes/characters.test.ts
+++ b/apps/server/src/routes/characters.test.ts
@@ -218,6 +218,115 @@ describe('character routes', () => {
       questPoints: 0
     });
   });
+
+  it('spends persisted XP to improve an existing skill', async () => {
+    const draftId = `route-skill-xp-character-${randomUUID()}`;
+
+    await app.inject({
+      method: 'PUT',
+      payload: sampleDraft('Aveline Studieuse'),
+      url: `/character-drafts/${draftId}`
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { draftId },
+      url: '/characters/finalize'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { amount: 20, reason: 'Reserve de progression' },
+      url: `/characters/${draftId}/xp-awards`
+    });
+    const improvementResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        reason: 'Entrainement valide par le MJ',
+        sessionSlug: 'mvp-xp',
+        skillId: 'epee-a-une-main'
+      },
+      url: `/characters/${draftId}/skill-improvements`
+    });
+    const readResponse = await app.inject({
+      method: 'GET',
+      url: `/characters/${draftId}`
+    });
+
+    expect(improvementResponse.statusCode).toBe(200);
+    expect(improvementResponse.json()).toMatchObject({
+      character: {
+        id: draftId,
+        metadata: {
+          xpSpends: [
+            {
+              actorId: 'gm',
+              cost: 12,
+              kind: 'skill_improvement',
+              previousPoints: 4,
+              reason: 'Entrainement valide par le MJ',
+              sessionSlug: 'mvp-xp',
+              skillId: 'epee-a-une-main'
+            }
+          ]
+        },
+        progression: {
+          experiencePoints: 8,
+          experienceTotal: 20,
+          questPoints: 0
+        },
+        skills: expect.arrayContaining([
+          expect.objectContaining({ id: 'epee-a-une-main', points: 5 })
+        ])
+      },
+      status: 'updated'
+    });
+    expect(readResponse.json().character.skills).toContainEqual({
+      id: 'epee-a-une-main',
+      isMain: true,
+      points: 5
+    });
+    expect(readResponse.json().character.progression.experiencePoints).toBe(8);
+  });
+
+  it('learns an unaffiliated specialization without materializing the zero-point parent skill', async () => {
+    const draftId = `route-specialization-xp-character-${randomUUID()}`;
+
+    await app.inject({
+      method: 'PUT',
+      payload: sampleDraft('Aveline Specialisee'),
+      url: `/character-drafts/${draftId}`
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { draftId },
+      url: '/characters/finalize'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { amount: 3, reason: 'Reserve de specialisation' },
+      url: `/characters/${draftId}/xp-awards`
+    });
+    const improvementResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        parentId: 'competence-non-achetee',
+        skillId: 'specialisation-libre'
+      },
+      url: `/characters/${draftId}/skill-improvements`
+    });
+    const skills = improvementResponse.json().character.skills;
+
+    expect(improvementResponse.statusCode).toBe(200);
+    expect(skills).toContainEqual({
+      id: 'specialisation-libre',
+      parentId: 'competence-non-achetee',
+      points: 1
+    });
+    expect(skills.some((skill: { id: string }) => skill.id === 'competence-non-achetee')).toBe(
+      false
+    );
+    expect(improvementResponse.json().character.progression.experiencePoints).toBe(0);
+  });
 });
 
 function sampleDraft(name: string) {

--- a/apps/server/src/routes/characters.ts
+++ b/apps/server/src/routes/characters.ts
@@ -1,13 +1,16 @@
 import type { FastifyInstance, FastifyReply } from 'fastify';
+import { ProgressionError } from '@knightandwizard/rules-core';
 import {
   CharacterDraftNotFoundError,
   CharacterNotFoundError,
   awardPersistedCharacterXp,
   finalizeCharacterDraft,
   getPersistedCharacter,
+  improvePersistedCharacterSkill,
   listPersistedCharacterActiveSpells,
   updatePersistedCharacterCombatState,
   type CharacterCombatStateUpdate,
+  type CharacterSkillImprovementUpdate,
   type CharacterXpAwardUpdate
 } from '../characters/finalize.js';
 import { resolveRequestUserId } from '../auth/user.js';
@@ -30,6 +33,15 @@ interface AwardCharacterXpRequestBody {
   sessionSlug?: unknown;
 }
 
+interface ImproveCharacterSkillRequestBody {
+  actorId?: unknown;
+  isMain?: unknown;
+  parentId?: unknown;
+  reason?: unknown;
+  sessionSlug?: unknown;
+  skillId?: unknown;
+}
+
 interface CharacterParams {
   id: string;
 }
@@ -38,6 +50,9 @@ export async function registerCharacterRoutes(app: FastifyInstance): Promise<voi
   app.options('/characters/finalize', async (_request, reply) => reply.code(204).send());
   app.options('/characters/:id/active-spells', async (_request, reply) => reply.code(204).send());
   app.options('/characters/:id/combat-state', async (_request, reply) => reply.code(204).send());
+  app.options('/characters/:id/skill-improvements', async (_request, reply) =>
+    reply.code(204).send()
+  );
   app.options('/characters/:id/xp-awards', async (_request, reply) => reply.code(204).send());
   app.options('/characters/:id', async (_request, reply) => reply.code(204).send());
 
@@ -153,6 +168,33 @@ export async function registerCharacterRoutes(app: FastifyInstance): Promise<voi
       }
     }
   );
+
+  app.post<{ Body: ImproveCharacterSkillRequestBody; Params: CharacterParams }>(
+    '/characters/:id/skill-improvements',
+    async (request, reply) => {
+      const validation = validateSkillImprovement(request.body ?? {});
+
+      if (!validation.valid) {
+        return reply.code(400).send({
+          errors: validation.errors,
+          status: 'invalid'
+        });
+      }
+
+      try {
+        const result = await improvePersistedCharacterSkill(request.params.id, validation.input, {
+          userId: resolveRequestUserId(request)
+        });
+
+        return {
+          character: result.character,
+          status: 'updated'
+        };
+      } catch (error) {
+        return sendCharacterRouteError(error, reply);
+      }
+    }
+  );
 }
 
 function normalizeOptionalString(value: unknown): string | undefined {
@@ -168,6 +210,10 @@ function normalizeOptionalString(value: unknown): string | undefined {
 function sendCharacterRouteError(error: unknown, reply: FastifyReply) {
   if (error instanceof CharacterDraftNotFoundError || error instanceof CharacterNotFoundError) {
     return reply.code(404).send({ status: 'not_found' });
+  }
+
+  if (error instanceof ProgressionError) {
+    return reply.code(400).send({ errors: [error.message], status: 'invalid' });
   }
 
   throw error;
@@ -268,6 +314,73 @@ function validateXpAward(
       ...(questPoints.value !== undefined ? { questPoints: questPoints.value } : {}),
       ...(reason ? { reason } : {}),
       ...(sessionSlug ? { sessionSlug } : {})
+    },
+    valid: true
+  };
+}
+
+function validateSkillImprovement(
+  body: ImproveCharacterSkillRequestBody
+): { input: CharacterSkillImprovementUpdate; valid: true } | { errors: string[]; valid: false } {
+  const errors: string[] = [];
+  const actorId = normalizeOptionalString(body.actorId);
+  const reason = normalizeOptionalString(body.reason);
+  const sessionSlug = normalizeOptionalString(body.sessionSlug);
+  const skillId = normalizeOptionalString(body.skillId);
+  const input: Partial<CharacterSkillImprovementUpdate> = {};
+
+  if (!skillId) {
+    errors.push('skillId is required');
+  } else {
+    input.skillId = skillId;
+  }
+
+  if (body.isMain !== undefined) {
+    if (typeof body.isMain !== 'boolean') {
+      errors.push('isMain must be a boolean');
+    } else {
+      input.isMain = body.isMain;
+    }
+  }
+
+  if (body.parentId !== undefined) {
+    if (body.parentId === null) {
+      input.parentId = null;
+    } else {
+      const parentId = normalizeOptionalString(body.parentId);
+
+      if (!parentId) {
+        errors.push('parentId must be a non-empty string or null');
+      } else {
+        input.parentId = parentId;
+      }
+    }
+  }
+
+  if (actorId) {
+    input.actorId = actorId;
+  }
+
+  if (reason) {
+    input.reason = reason;
+  }
+
+  if (sessionSlug) {
+    input.sessionSlug = sessionSlug;
+  }
+
+  if (errors.length > 0 || input.skillId === undefined) {
+    return { errors, valid: false };
+  }
+
+  return {
+    input: {
+      ...(input.actorId ? { actorId: input.actorId } : {}),
+      ...(input.isMain !== undefined ? { isMain: input.isMain } : {}),
+      ...(input.parentId !== undefined ? { parentId: input.parentId } : {}),
+      ...(input.reason ? { reason: input.reason } : {}),
+      ...(input.sessionSlug ? { sessionSlug: input.sessionSlug } : {}),
+      skillId: input.skillId
     },
     valid: true
   };


### PR DESCRIPTION
Refs #167\n\n## What changed\n- Adds POST /characters/:id/skill-improvements for persisted XP spend on skills.\n- Reuses rules-core learnSkill so costs, XP reserve, existing skills, and new specializations stay canonical.\n- Records metadata.xpSpends with actor/session/reason/cost/previous/next point trace.\n- Preserves the invariant that zero-point parent skills are conceptual only: a specialization can be learned with parentId without materializing the parent skill.\n\n## Validation\n- pnpm test -- apps/server/src/routes/characters.test.ts --runInBand\n- pnpm validate\n