### PR TITLE
feat(game): #188 add narrative cadence

### DIFF
--- a/apps/game/src/features/gm-cockpit/GmCockpit.tsx
+++ b/apps/game/src/features/gm-cockpit/GmCockpit.tsx
@@ -1,15 +1,17 @@
 'use client';
 
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import {
   ArrowUpRight,
   Bot,
   CheckCircle2,
+  Clock,
   Gavel,
   PlusCircle,
   RotateCcw,
   ScrollText,
+  Sparkles,
   Swords,
   Users,
   XCircle
@@ -17,6 +19,7 @@ import {
 
 import type { SessionManagerState } from '../session-manager/model';
 import {
+  advancePersistedNarrative,
   appendGmRulingToSession,
   appendPersistedSessionEvent,
   awardCharacterXp,
@@ -29,6 +32,10 @@ import {
 } from '../session-manager/persistence';
 
 import { buildGmCockpitView } from './model';
+
+const narrativeCadenceOptions = [0, 0.5, 1, 2] as const;
+
+type NarrativeCadenceMultiplier = (typeof narrativeCadenceOptions)[number];
 
 interface GmCockpitProps {
   initialState: SessionManagerState;
@@ -46,6 +53,8 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
   const [rollbackSequence, setRollbackSequence] = useState(
     view.rollbackTargets[0]?.sequence.toString() ?? ''
   );
+  const [narrativeCadence, setNarrativeCadence] = useState<NarrativeCadenceMultiplier>(1);
+  const narrativeCadenceRef = useRef<NarrativeCadenceMultiplier>(1);
   const [assistantPrompt, setAssistantPrompt] = useState(() => defaultAssistantPrompt(view));
   const [assistantResult, setAssistantResult] = useState<GameMasterSceneDescription | null>(null);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
@@ -123,6 +132,20 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
         }
       });
     });
+  }
+
+  function skipNarrativeTime(by: { days?: number; hours?: number; minutes?: number }) {
+    void run('narrative-advance', async () =>
+      advancePersistedNarrative(state.slug, {
+        actorId: 'gm',
+        by: { ...by, cadenceMultiplier: narrativeCadenceRef.current }
+      })
+    );
+  }
+
+  function selectNarrativeCadence(option: NarrativeCadenceMultiplier) {
+    narrativeCadenceRef.current = option;
+    setNarrativeCadence(option);
   }
 
   function describeWithAssistant() {
@@ -236,7 +259,7 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
         ) : null}
       </section>
 
-      <section className="grid gap-4 lg:grid-cols-[1.2fr_0.8fr]">
+      <section className="grid gap-4 xl:grid-cols-[1.1fr_0.8fr_0.9fr]">
         <article className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
           <div className="flex items-center gap-2">
             <ScrollText aria-hidden="true" className="size-5 text-forest" />
@@ -286,6 +309,93 @@ export function GmCockpit({ initialState }: Readonly<GmCockpitProps>) {
               </li>
             ))}
           </ol>
+        </article>
+
+        <article className="rounded-md border border-ink/10 bg-white/72 p-4 shadow-sm">
+          <div className="flex items-center gap-2">
+            <Clock aria-hidden="true" className="size-5 text-forest" />
+            <h2 className="text-lg font-semibold text-ink">Horloge narrative</h2>
+          </div>
+          <p
+            className="mt-4 font-mono text-2xl font-semibold text-ink"
+            data-testid="gm-narrative-instant"
+          >
+            {view.narrativeClock.instantLabel}
+          </p>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <span className="text-xs font-semibold uppercase tracking-[0.12em] text-ink/62">
+              Cadence
+            </span>
+            <div className="flex rounded-md border border-ink/10 bg-paper p-1">
+              {narrativeCadenceOptions.map((option) => (
+                <button
+                  aria-pressed={narrativeCadence === option}
+                  className={`h-8 min-w-12 rounded px-3 text-sm font-semibold transition ${
+                    narrativeCadence === option
+                      ? 'bg-forest text-paper'
+                      : 'text-ink/62 hover:bg-forest/10 hover:text-forest'
+                  }`}
+                  disabled={pendingAction !== null}
+                  key={option}
+                  onClick={() => selectNarrativeCadence(option)}
+                  type="button"
+                >
+                  x{option}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              className="rounded-md bg-forest px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+              disabled={pendingAction !== null}
+              onClick={() => skipNarrativeTime({ minutes: 10 })}
+              type="button"
+            >
+              +10 min
+            </button>
+            <button
+              className="rounded-md bg-forest px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+              disabled={pendingAction !== null}
+              onClick={() => skipNarrativeTime({ hours: 1 })}
+              type="button"
+            >
+              +1 h
+            </button>
+            <button
+              className="rounded-md bg-forest px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
+              disabled={pendingAction !== null}
+              onClick={() => skipNarrativeTime({ days: 1 })}
+              type="button"
+            >
+              Passer la journée
+            </button>
+          </div>
+          <div className="mt-4 border-t border-ink/10 pt-3">
+            <div className="flex items-center gap-2">
+              <Sparkles aria-hidden="true" className="size-4 text-wine" />
+              <h3 className="text-sm font-semibold uppercase tracking-[0.12em] text-ink/62">
+                Sorts actifs
+              </h3>
+            </div>
+            {view.narrativeClock.activeSpells.length === 0 ? (
+              <p className="mt-2 rounded-md bg-paper px-3 py-2 text-sm font-semibold text-ink/55">
+                Aucun sort actif
+              </p>
+            ) : (
+              <ul className="mt-2 grid gap-2">
+                {view.narrativeClock.activeSpells.map((spell) => (
+                  <li className="rounded-md bg-paper px-3 py-2" key={spell.id}>
+                    <span className="block text-sm font-semibold text-ink">{spell.label}</span>
+                    <span className="block text-xs font-medium text-ink/55">
+                      {spell.target ? `Cible : ${spell.target} · ` : ''}
+                      {spell.remainingLabel}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         </article>
       </section>
 

--- a/apps/game/src/features/gm-cockpit/model.test.ts
+++ b/apps/game/src/features/gm-cockpit/model.test.ts
@@ -46,6 +46,14 @@ describe('GM cockpit model', () => {
           payload: { text: 'Ouverture de table.' },
           sequence: 1,
           type: 'narration'
+        },
+        {
+          actorId: 'gm',
+          createdAt: '2026-05-29T08:02:00.000Z',
+          id: 'event-2',
+          payload: { minutes: 30 },
+          sequence: 2,
+          type: 'narrative_time_advanced'
         }
       ],
       players: [
@@ -109,6 +117,7 @@ describe('GM cockpit model', () => {
     ]);
     expect(view.primaryCombatHref).toBe('/combat?slug=brumeval&characterId=pc-aveline');
     expect(view.sessionHref).toBe('/session?slug=brumeval');
+    expect(view.narrativeClock.instantLabel).toBe('Jour 1 · 00:30:00');
     expect(view.xpTargets).toEqual([
       {
         characterId: 'pc-aveline',
@@ -116,6 +125,9 @@ describe('GM cockpit model', () => {
         name: 'Aveline'
       }
     ]);
-    expect(view.rollbackTargets).toEqual([{ label: '#1 narration', sequence: 1 }]);
+    expect(view.rollbackTargets).toEqual([
+      { label: '#2 temps narratif avancé', sequence: 2 },
+      { label: '#1 narration', sequence: 1 }
+    ]);
   });
 });

--- a/apps/game/src/features/gm-cockpit/model.ts
+++ b/apps/game/src/features/gm-cockpit/model.ts
@@ -53,6 +53,7 @@ export interface GmCockpitXpTarget {
 export interface GmCockpitView {
   activeScene?: SessionScene;
   metrics: SessionManagerView['metrics'];
+  narrativeClock: SessionManagerView['narrativeClock'];
   participants: GmCockpitParticipant[];
   pendingChangeRequests: GmCockpitChangeRequest[];
   pendingDecisions: GmCockpitDecision[];
@@ -79,6 +80,7 @@ export function buildGmCockpitView(state: SessionManagerState): GmCockpitView {
   return {
     activeScene: session.activeScene,
     metrics: session.metrics,
+    narrativeClock: session.narrativeClock,
     participants: session.playerRows.map((player) => ({
       ...(player.characterId
         ? {

--- a/apps/game/src/features/session-manager/SessionManager.tsx
+++ b/apps/game/src/features/session-manager/SessionManager.tsx
@@ -46,6 +46,10 @@ const priorityClasses = {
   urgent: 'bg-wine/12 text-wine'
 };
 
+const narrativeCadenceOptions = [0, 0.5, 1, 2] as const;
+
+type NarrativeCadenceMultiplier = (typeof narrativeCadenceOptions)[number];
+
 interface SessionManagerProps {
   currentPlayerId?: string;
   initialState: SessionManagerState;
@@ -56,6 +60,8 @@ export function SessionManager({ currentPlayerId, initialState }: Readonly<Sessi
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
   const [postText, setPostText] = useState('');
+  const [narrativeCadence, setNarrativeCadence] = useState<NarrativeCadenceMultiplier>(1);
+  const narrativeCadenceRef = useRef<NarrativeCadenceMultiplier>(1);
   const view = useMemo(() => buildSessionManagerView(state), [state]);
   const [rollbackSequence, setRollbackSequence] = useState(
     view.rollbackTargets[0]?.sequence.toString() ?? ''
@@ -124,8 +130,16 @@ export function SessionManager({ currentPlayerId, initialState }: Readonly<Sessi
 
   function skipNarrativeTime(by: { days?: number; hours?: number; minutes?: number }) {
     void runPersistedAction('narrative-advance', async (slug) => {
-      await advancePersistedNarrative(slug, { actorId: 'gm', by });
+      await advancePersistedNarrative(slug, {
+        actorId: 'gm',
+        by: { ...by, cadenceMultiplier: narrativeCadenceRef.current }
+      });
     });
+  }
+
+  function selectNarrativeCadence(option: NarrativeCadenceMultiplier) {
+    narrativeCadenceRef.current = option;
+    setNarrativeCadence(option);
   }
 
   function resolvePostText(fallback: string) {
@@ -343,6 +357,29 @@ export function SessionManager({ currentPlayerId, initialState }: Readonly<Sessi
           >
             {view.narrativeClock.instantLabel}
           </p>
+          <div className="mt-3 flex flex-wrap items-center gap-2">
+            <span className="text-xs font-semibold uppercase tracking-[0.12em] text-ink/62">
+              Cadence
+            </span>
+            <div className="flex rounded-md border border-ink/10 bg-paper p-1">
+              {narrativeCadenceOptions.map((option) => (
+                <button
+                  aria-pressed={narrativeCadence === option}
+                  className={`h-8 min-w-12 rounded px-3 text-sm font-semibold transition ${
+                    narrativeCadence === option
+                      ? 'bg-forest text-paper'
+                      : 'text-ink/62 hover:bg-forest/10 hover:text-forest'
+                  }`}
+                  disabled={busy}
+                  key={option}
+                  onClick={() => selectNarrativeCadence(option)}
+                  type="button"
+                >
+                  x{option}
+                </button>
+              ))}
+            </div>
+          </div>
           <div className="mt-3 flex flex-wrap gap-2">
             <TimeSkipButton
               disabled={busy}

--- a/apps/game/src/features/session-manager/persistence.test.ts
+++ b/apps/game/src/features/session-manager/persistence.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  advancePersistedNarrative,
   appendCombatResolutionToSession,
   appendDiceRollToSession,
   appendGmRulingToSession,
@@ -201,6 +202,27 @@ describe('session manager persistence', () => {
         actorId: 'gm',
         eventType: 'gm_ruling',
         payload: { characterId: 'pc-aveline', kind: 'xp_award', xp: 1 }
+      }),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST'
+    });
+  });
+
+  it('appends a narrative time advance with the selected cadence multiplier', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'http://browser-api.test';
+    const fetchMock = vi.fn().mockResolvedValue(okJson({ status: 'created' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await advancePersistedNarrative('brumeval', {
+      actorId: 'gm',
+      by: { cadenceMultiplier: 0.5, hours: 1 }
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith('http://browser-api.test/sessions/brumeval/events', {
+      body: JSON.stringify({
+        actorId: 'gm',
+        eventType: 'narrative_time_advanced',
+        payload: { cadenceMultiplier: 0.5, hours: 1 }
       }),
       headers: { 'content-type': 'application/json' },
       method: 'POST'

--- a/apps/game/src/features/session-manager/persistence.ts
+++ b/apps/game/src/features/session-manager/persistence.ts
@@ -271,7 +271,13 @@ export async function resolvePersistedChangeRequest(
 
 export interface AdvancePersistedNarrativeInput {
   actorId: string;
-  by: { days?: number; hours?: number; minutes?: number; seconds?: number };
+  by: {
+    cadenceMultiplier?: 0 | 0.5 | 1 | 2;
+    days?: number;
+    hours?: number;
+    minutes?: number;
+    seconds?: number;
+  };
 }
 
 export interface DispelPersistedSpellInput {

--- a/apps/server/src/routes/sessions.test.ts
+++ b/apps/server/src/routes/sessions.test.ts
@@ -984,6 +984,68 @@ describe('session routes', () => {
     expect(expiredState.activeSpells).toEqual([]);
   });
 
+  it('applies cadence multipliers when projecting narrative time advances', async () => {
+    const slug = `clock-cadence-session-${randomUUID()}`;
+
+    await app.inject({
+      method: 'POST',
+      payload: { mode: 'digital_human_gm', slug, title: 'Clock Cadence API' },
+      url: '/sessions'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        eventType: 'narrative_time_advanced',
+        payload: { cadenceMultiplier: 0.5, hours: 2 }
+      },
+      url: `/sessions/${slug}/events`
+    });
+    await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        eventType: 'spell_cast',
+        payload: {
+          activeSpellId: 'spell-cadence',
+          durationAmount: 10,
+          durationUnit: 'minute',
+          spellId: 'aura-lente',
+          targetId: 'aveline'
+        }
+      },
+      url: `/sessions/${slug}/events`
+    });
+    await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        eventType: 'narrative_time_advanced',
+        payload: { cadenceMultiplier: 0, minutes: 30 }
+      },
+      url: `/sessions/${slug}/events`
+    });
+
+    const paused = await app.inject({ method: 'GET', url: `/sessions/${slug}` });
+
+    expect(paused.json().state.narrativeSeconds).toBe(3_600);
+    expect(paused.json().state.activeSpells).toMatchObject([{ id: 'spell-cadence' }]);
+
+    await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        eventType: 'narrative_time_advanced',
+        payload: { cadenceMultiplier: 2, minutes: 5 }
+      },
+      url: `/sessions/${slug}/events`
+    });
+    const expired = await app.inject({ method: 'GET', url: `/sessions/${slug}` });
+
+    expect(expired.json().state.narrativeSeconds).toBe(4_200);
+    expect(expired.json().state.activeSpells).toEqual([]);
+  });
+
   it('persists active spell instances per target character from session events (R-8.20)', async () => {
     const slug = `character-spell-session-${randomUUID()}`;
     const characterId = `active-spell-target-${randomUUID()}`;

--- a/packages/rules-core/src/narrative-time.ts
+++ b/packages/rules-core/src/narrative-time.ts
@@ -8,8 +8,8 @@
  * sort de durée DT comme un sort de durée min/heure/jour expire sur la même horloge, ce qui gère
  * automatiquement la conversion « si le combat se termine avant l'expiration ».
  *
- * Le multiplicateur de cadence (× temps réel) agit sur le *rythme d'avancée* en appli/UI, **pas** sur
- * les durées intrinsèques (R-8.20) ; il n'appartient donc pas à ce modèle pur.
+ * Le multiplicateur de cadence (×0/×0.5/×1/×2) agit sur les avances explicites du MJ sans modifier
+ * les durées intrinsèques des sorts déjà posées sur l'horloge.
  */
 
 /** 1 DT = 0,2 seconde narrative (R-8.20). */
@@ -24,6 +24,8 @@ export const NARRATIVE_UNIT_SECONDS = {
 
 export const SPELL_DURATION_UNITS = ['DT', 'minute', 'hour', 'day', 'permanent'] as const;
 export type SpellDurationUnit = (typeof SPELL_DURATION_UNITS)[number];
+export const NARRATIVE_CADENCE_MULTIPLIERS = [0, 0.5, 1, 2] as const;
+export type NarrativeCadenceMultiplier = (typeof NARRATIVE_CADENCE_MULTIPLIERS)[number];
 
 /**
  * Un sort actif sur l'horloge narrative. `durationAmount` est la quantité **résolue** (déjà mise à
@@ -40,6 +42,7 @@ export interface ActiveSpell {
 }
 
 export interface NarrativeAdvance {
+  cadenceMultiplier?: NarrativeCadenceMultiplier;
   days?: number;
   hours?: number;
   minutes?: number;
@@ -109,8 +112,14 @@ export function advanceNarrative(nowSeconds: number, by: NarrativeAdvance): numb
     (by.hours ?? 0) * NARRATIVE_UNIT_SECONDS.hour +
     (by.minutes ?? 0) * NARRATIVE_UNIT_SECONDS.minute +
     (by.seconds ?? 0);
+  const cadenceMultiplier = by.cadenceMultiplier ?? 1;
+
+  if (!NARRATIVE_CADENCE_MULTIPLIERS.some((allowed) => allowed === cadenceMultiplier)) {
+    throw new Error('cadenceMultiplier must be one of 0, 0.5, 1 or 2');
+  }
+
   assertNonNegativeFinite('advance delta', delta);
-  return nowSeconds + delta;
+  return nowSeconds + delta * cadenceMultiplier;
 }
 
 /**

--- a/packages/rules-core/src/session.test.ts
+++ b/packages/rules-core/src/session.test.ts
@@ -346,6 +346,26 @@ describe('session narrative clock (R-8.20 — temps double)', () => {
     expect(later.events.map((event) => event.type)).toEqual(['narrative_time_advanced']);
   });
 
+  it('applies the MJ cadence multiplier to narrative time advances', () => {
+    const session = newSession();
+    const halfSpeed = advanceSessionNarrative(session, {
+      actorId: 'gm',
+      by: { cadenceMultiplier: 0.5, hours: 2 }
+    });
+    const paused = advanceSessionNarrative(halfSpeed, {
+      actorId: 'gm',
+      by: { cadenceMultiplier: 0, hours: 4 }
+    });
+    const doubleSpeed = advanceSessionNarrative(paused, {
+      actorId: 'gm',
+      by: { cadenceMultiplier: 2, minutes: 15 }
+    });
+
+    expect(halfSpeed.narrativeSeconds).toBe(3_600);
+    expect(paused.narrativeSeconds).toBe(3_600);
+    expect(doubleSpeed.narrativeSeconds).toBe(5_400);
+  });
+
   it('folds the elapsed combat DT back into the narrative clock at end of combat', () => {
     const session = newSession();
     // 50 DT of combat = 10 narrative seconds (1 DT = 0,2 s).

--- a/packages/rules-core/src/session.ts
+++ b/packages/rules-core/src/session.ts
@@ -1,7 +1,9 @@
 import {
   type ActiveSpell,
   type NarrativeAdvance,
+  type NarrativeCadenceMultiplier,
   type SpellDurationUnit,
+  NARRATIVE_CADENCE_MULTIPLIERS,
   SPELL_DURATION_UNITS,
   advanceNarrative,
   endCombat,
@@ -839,11 +841,19 @@ function reduceNarrativeEvent(clock: NarrativeClock, event: SessionEvent): Narra
 
 function narrativeAdvanceFromPayload(payload: Record<string, unknown>): NarrativeAdvance {
   return {
+    cadenceMultiplier: readNarrativeCadenceMultiplier(payload.cadenceMultiplier),
     days: nonNegativeNumber(payload.days),
     hours: nonNegativeNumber(payload.hours),
     minutes: nonNegativeNumber(payload.minutes),
     seconds: nonNegativeNumber(payload.seconds)
   };
+}
+
+function readNarrativeCadenceMultiplier(value: unknown): NarrativeCadenceMultiplier | undefined {
+  return typeof value === 'number' &&
+    NARRATIVE_CADENCE_MULTIPLIERS.some((multiplier) => multiplier === value)
+    ? (value as NarrativeCadenceMultiplier)
+    : undefined;
 }
 
 function activeSpellFromEvent(event: SessionEvent, castAtSeconds: number): ActiveSpell | undefined {


### PR DESCRIPTION
Refs #188

## What changed
- Adds R-8.20 narrative cadence multipliers x0/x0.5/x1/x2 to the pure rules-core narrative clock.
- Persists `cadenceMultiplier` on narrative time advances and projects active spell expiry with the scaled clock.
- Exposes cadence controls on both `/session` and the MVP `/mj` cockpit, with race-free click handling.

## Validation
- `pnpm test -- apps/game/src/features/gm-cockpit/model.test.ts apps/game/src/features/session-manager/persistence.test.ts apps/server/src/routes/sessions.test.ts packages/rules-core/src/session.test.ts packages/rules-core/src/narrative-time.test.ts --runInBand`
- `pnpm validate`
- Browser check on `/mj?slug=cadence-check-188f`: `x0.5` + `+1 h` projects `Jour 1 · 00:30:00`; no browser console/request errors.

## Notes
- Chrome extension control is unavailable locally: the selected Chrome profile does not have the Codex Chrome Extension installed and the native-host registry key is absent. I verified with Playwright Chromium instead.
