### PR TITLE
feat(game): #167 add quest point award

### DIFF
--- a/apps/game/src/features/character-sheet/CharacterSheet.tsx
+++ b/apps/game/src/features/character-sheet/CharacterSheet.tsx
@@ -299,6 +299,9 @@ export function CharacterSheet({
             <Badge tone="success">
               XP {character.progression.experiencePoints} / {character.progression.experienceTotal}
             </Badge>
+            {character.progression.questPoints > 0 ? (
+              <Badge tone="info">Quête {character.progression.questPoints}</Badge>
+            ) : null}
           </div>
         </div>
 

--- a/apps/game/src/features/gm-cockpit/GmCockpit.tsx
+++ b/apps/game/src/features/gm-cockpit/GmCockpit.tsx
@@ -55,6 +55,7 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
   const [state, setState] = useState(initialState);
   const view = useMemo(() => buildGmCockpitView(state), [state]);
   const [selectedXpTarget, setSelectedXpTarget] = useState(view.xpTargets[0]?.characterId ?? '');
+  const [awardQuestPoint, setAwardQuestPoint] = useState(false);
   const [selectedNpcTemplateId, setSelectedNpcTemplateId] = useState(
     bestiaryNpcTemplates[0]?.id ?? ''
   );
@@ -106,10 +107,13 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
       return;
     }
 
+    const questPoints = awardQuestPoint ? 1 : 0;
+
     void run('xp', async () => {
       await awardCharacterXp(effectiveXpTarget.characterId, {
         actorId: 'gm',
         amount: 1,
+        ...(questPoints > 0 ? { questPoints } : {}),
         reason: 'Fin de session',
         sessionSlug: state.slug
       });
@@ -118,7 +122,8 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
         payload: {
           characterId: effectiveXpTarget.characterId,
           kind: 'xp_award',
-          text: `XP attribue a ${effectiveXpTarget.name}`,
+          ...(questPoints > 0 ? { questPoints } : {}),
+          text: `XP attribue a ${effectiveXpTarget.name}${questPoints > 0 ? ' + 1 point de quête' : ''}`,
           xp: 1
         }
       });
@@ -611,6 +616,16 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
               Bestiaire indisponible pour cette session.
             </p>
           )}
+          <label className="mt-4 flex items-center gap-2 text-sm font-semibold text-ink/70">
+            <input
+              checked={awardQuestPoint}
+              className="size-4 rounded border-ink/20 text-forest"
+              disabled={pendingAction !== null}
+              onChange={(event) => setAwardQuestPoint(event.target.checked)}
+              type="checkbox"
+            />
+            Point de quête
+          </label>
           <div className="mt-3 flex flex-wrap gap-2">
             <button
               className="inline-flex items-center gap-2 rounded-md bg-forest px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"

--- a/apps/game/src/features/session-manager/persistence.test.ts
+++ b/apps/game/src/features/session-manager/persistence.test.ts
@@ -237,6 +237,7 @@ describe('session manager persistence', () => {
     await awardCharacterXp('pc-aveline', {
       actorId: 'gm',
       amount: 1,
+      questPoints: 1,
       reason: 'Fin de session',
       sessionSlug: 'brumeval'
     });
@@ -247,6 +248,7 @@ describe('session manager persistence', () => {
         body: JSON.stringify({
           actorId: 'gm',
           amount: 1,
+          questPoints: 1,
           reason: 'Fin de session',
           sessionSlug: 'brumeval'
         }),

--- a/apps/server/src/routes/characters.test.ts
+++ b/apps/server/src/routes/characters.test.ts
@@ -180,6 +180,7 @@ describe('character routes', () => {
       payload: {
         actorId: 'gm',
         amount: 2,
+        questPoints: 1,
         reason: 'Fin de session',
         sessionSlug: 'mvp-xp'
       },
@@ -199,6 +200,7 @@ describe('character routes', () => {
             {
               actorId: 'gm',
               amount: 2,
+              questPoints: 1,
               reason: 'Fin de session',
               sessionSlug: 'mvp-xp'
             }
@@ -207,7 +209,7 @@ describe('character routes', () => {
         progression: {
           experiencePoints: 2,
           experienceTotal: 2,
-          questPoints: 0
+          questPoints: 1
         }
       },
       status: 'updated'
@@ -215,7 +217,7 @@ describe('character routes', () => {
     expect(readResponse.json().character.progression).toEqual({
       experiencePoints: 2,
       experienceTotal: 2,
-      questPoints: 0
+      questPoints: 1
     });
   });
 

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -407,12 +407,14 @@ test.describe('K&W player and GM application flows', () => {
     await expect(proposalPanel.getByText('Le MJ decrit les details visibles')).toBeVisible();
     await expect(proposalPanel.getByText(/Sources \d+ · Mémoire \d+/)).toBeVisible();
 
+    await page.getByLabel('Point de quête').check();
     await page.getByRole('button', { name: 'Attribuer 1 XP' }).click();
-    await expect(page.getByText('XP attribue a Aveline Cockpit')).toBeVisible();
+    await expect(page.getByText('XP attribue a Aveline Cockpit + 1 point de quête')).toBeVisible();
 
     await page.goto(`/character?characterId=${draftId}`);
     await expect(page.getByRole('heading', { name: 'Aveline Cockpit' })).toBeVisible();
     await expect(page.getByText('XP 1 / 1')).toBeVisible();
+    await expect(page.getByText('Quête 1')).toBeVisible();
 
     await page.goto(`/mj?slug=${slug}`);
     await expect(page.getByLabel('Gabarit PNJ')).toBeVisible();


### PR DESCRIPTION
Refs #167. Changes: adds a Point de quête checkbox to GM XP awards, persists questPoints through the character XP API, displays accumulated quest points on the character sheet, and extends server/frontend/e2e coverage. Validation: pnpm test -- apps/server/src/routes/characters.test.ts apps/game/src/features/session-manager/persistence.test.ts --runInBand; pnpm --filter @knightandwizard/game typecheck; pnpm validate.