### PR TITLE
feat(server): #166 apply class reclassification requests

### DIFF
--- a/apps/game/src/features/gm-cockpit/GmCockpit.tsx
+++ b/apps/game/src/features/gm-cockpit/GmCockpit.tsx
@@ -60,6 +60,7 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
     bestiaryNpcTemplates[0]?.id ?? ''
   );
   const [changeKind, setChangeKind] = useState('predilection_target');
+  const [changeStructuredValue, setChangeStructuredValue] = useState('');
   const [changeSummary, setChangeSummary] = useState('Changement a valider par le MJ.');
   const [changeTargetId, setChangeTargetId] = useState(view.xpTargets[0]?.characterId ?? '');
   const [changeTargetType, setChangeTargetType] = useState('character');
@@ -79,6 +80,7 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
   const effectiveNpcTemplate =
     bestiaryNpcTemplates.find((template) => template.id === selectedNpcTemplateId) ??
     bestiaryNpcTemplates[0];
+  const structuredChangeLabel = changeRequestStructuredLabel(changeKind);
   const effectiveRollbackSequence =
     rollbackSequence.length > 0
       ? Number.parseInt(rollbackSequence, 10)
@@ -224,6 +226,7 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
     const title = changeTitle.trim();
     const summary = changeSummary.trim();
     const targetId = changeTargetId.trim();
+    const structuredValue = changeStructuredValue.trim();
 
     if (!title || !summary) {
       return;
@@ -234,7 +237,10 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
         assignedTo: 'human_gm',
         authority: 'human_gm',
         changeKind,
-        payload: { source: 'gm-cockpit' },
+        payload: {
+          source: 'gm-cockpit',
+          ...changeRequestStructuredPayload(changeKind, structuredValue)
+        },
         priority: 'normal',
         requestedBy: 'gm',
         summary,
@@ -244,6 +250,7 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
       });
       setChangeTitle('Changer une predilection');
       setChangeSummary('Changement a valider par le MJ.');
+      setChangeStructuredValue('');
     });
   }
 
@@ -709,6 +716,15 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
               value={changeTargetId}
             />
           </label>
+          <label className="block text-sm font-semibold text-ink/70" htmlFor="gm-change-value">
+            {structuredChangeLabel}
+            <input
+              className="mt-2 w-full rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-semibold text-ink"
+              id="gm-change-value"
+              onChange={(event) => setChangeStructuredValue(event.target.value)}
+              value={changeStructuredValue}
+            />
+          </label>
           <label
             className="block text-sm font-semibold text-ink/70 md:col-span-2"
             htmlFor="gm-change-summary"
@@ -751,6 +767,42 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
       </section>
     </main>
   );
+}
+
+function changeRequestStructuredLabel(changeKind: string): string {
+  if (changeKind === 'class_reclassification') {
+    return 'Classe demandée';
+  }
+
+  if (changeKind === 'predilection_target') {
+    return 'Cible demandée';
+  }
+
+  if (changeKind === 'feat_target') {
+    return 'Atout ou cible';
+  }
+
+  return 'Valeur structurée';
+}
+
+function changeRequestStructuredPayload(changeKind: string, value: string): Record<string, string> {
+  if (value.length === 0) {
+    return {};
+  }
+
+  if (changeKind === 'class_reclassification') {
+    return { requestedClassId: value };
+  }
+
+  if (changeKind === 'predilection_target') {
+    return { requestedTarget: value };
+  }
+
+  if (changeKind === 'feat_target') {
+    return { requestedTarget: value };
+  }
+
+  return { requestedValue: value };
 }
 
 function defaultAssistantPrompt(view: ReturnType<typeof buildGmCockpitView>): string {

--- a/apps/server/src/routes/sessions.test.ts
+++ b/apps/server/src/routes/sessions.test.ts
@@ -661,6 +661,109 @@ describe('session routes', () => {
     });
   });
 
+  it('applies approved class reclassification requests to linked session characters', async () => {
+    const slug = `change-request-class-session-${randomUUID()}`;
+    const characterId = `change-request-class-character-${randomUUID()}`;
+
+    await app.inject({
+      method: 'PUT',
+      payload: sampleCharacterDraft('Aveline Reclassee'),
+      url: `/character-drafts/${characterId}`
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { draftId: characterId },
+      url: '/characters/finalize'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: {
+        mode: 'digital_human_gm',
+        slug,
+        status: 'active',
+        title: 'Class Apply API'
+      },
+      url: '/sessions'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: {
+        characterId,
+        name: 'Aveline Reclassee',
+        playerId: 'player-aveline',
+        role: 'player'
+      },
+      url: `/sessions/${slug}/players`
+    });
+
+    const createResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        assignedTo: 'human_gm',
+        authority: 'human_gm',
+        changeKind: 'class_reclassification',
+        payload: {
+          requestedClassId: 'duelliste'
+        },
+        priority: 'normal',
+        requestedBy: 'player-aveline',
+        summary: 'Aveline demande un reclassement apres duel judiciaire.',
+        targetId: characterId,
+        targetType: 'character',
+        title: 'Reclasser Aveline'
+      },
+      url: `/sessions/${slug}/change-requests`
+    });
+    const changeRequest = createResponse.json().changeRequest;
+
+    const resolveResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        resolution: { ruling: 'Valide apres audience au greffe.' },
+        status: 'approved'
+      },
+      url: `/sessions/${slug}/change-requests/${changeRequest.id}/resolve`
+    });
+    const characterResponse = await app.inject({
+      method: 'GET',
+      url: `/characters/${characterId}`
+    });
+
+    expect(resolveResponse.statusCode).toBe(200);
+    expect(resolveResponse.json().changeRequest.resolution).toMatchObject({
+      appliedChange: {
+        changeKind: 'class_reclassification',
+        classId: 'duelliste',
+        className: 'Duelliste',
+        previousClassId: 'garde',
+        targetId: characterId,
+        type: 'character_class_reclassified'
+      },
+      ruling: 'Valide apres audience au greffe.'
+    });
+    expect(characterResponse.json().character.classProfile).toMatchObject({
+      id: 'duelliste',
+      name: 'Duelliste',
+      orientationId: 'guerrier',
+      primarySkillIds: ['epee-a-une-main']
+    });
+    expect(characterResponse.json().character.orientation).toMatchObject({
+      id: 'guerrier',
+      name: 'Guerrier'
+    });
+    expect(characterResponse.json().character.metadata.governanceChangeRequests).toMatchObject([
+      {
+        actorId: 'gm',
+        changeKind: 'class_reclassification',
+        changeRequestId: changeRequest.id,
+        nextClassId: 'duelliste',
+        previousClassId: 'garde',
+        sessionSlug: slug
+      }
+    ]);
+  });
+
   it('records rollback requests without deleting previous events', async () => {
     const slug = `rollback-session-${randomUUID()}`;
 

--- a/apps/server/src/routes/sessions.ts
+++ b/apps/server/src/routes/sessions.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { loadValidatedCatalog, type ClassesCatalog } from '@knightandwizard/catalogs';
 import type { FastifyInstance } from 'fastify';
 import {
   PREDILECTION_KINDS,
@@ -21,6 +22,7 @@ import {
   ProgressionError,
   revertSessionToSequence,
   type Character,
+  type CharacterClassProfile,
   type PredilectionKind,
   type SpellDurationUnit
 } from '@knightandwizard/rules-core';
@@ -1681,7 +1683,21 @@ interface AppliedSkillImprovementChangeRequest {
   type: 'character_skill_improved';
 }
 
-type AppliedChangeRequest = AppliedPredilectionChangeRequest | AppliedSkillImprovementChangeRequest;
+interface AppliedClassReclassificationChangeRequest {
+  changeKind: string;
+  classId: string;
+  className: string;
+  orientationId: string;
+  previousClassId: string;
+  previousClassName: string;
+  targetId: string;
+  type: 'character_class_reclassified';
+}
+
+type AppliedChangeRequest =
+  | AppliedClassReclassificationChangeRequest
+  | AppliedPredilectionChangeRequest
+  | AppliedSkillImprovementChangeRequest;
 
 type ChangeRequestApplicationResult =
   | { appliedChange?: undefined; status: 'skipped' }
@@ -2033,6 +2049,10 @@ async function applyApprovedChangeRequest(
     return applyApprovedSkillImprovementChangeRequest(tx, session, changeRequest, actorId);
   }
 
+  if (changeRequest.change_kind === 'class_reclassification') {
+    return applyApprovedClassReclassificationChangeRequest(tx, session, changeRequest, actorId);
+  }
+
   return { status: 'skipped' };
 }
 
@@ -2225,6 +2245,123 @@ async function applyApprovedSkillImprovementChangeRequest(
   `;
 
   return { appliedChange, status: 'applied' };
+}
+
+async function applyApprovedClassReclassificationChangeRequest(
+  tx: postgres.TransactionSql,
+  session: SessionRow,
+  changeRequest: ChangeRequestRow,
+  actorId: string
+): Promise<ChangeRequestApplicationResult> {
+  const targetId = changeRequest.target_id;
+  const requestedClassId =
+    readNonEmptyString(changeRequest.payload.classId) ??
+    readNonEmptyString(changeRequest.payload.requestedClassId) ??
+    readNonEmptyString(changeRequest.payload.newClassId) ??
+    readNonEmptyString(changeRequest.payload.value);
+
+  if (targetId === null || requestedClassId === undefined) {
+    return { status: 'skipped' };
+  }
+
+  const classProfile = await loadActiveClassProfile(requestedClassId);
+
+  if (classProfile === undefined) {
+    return {
+      error: `class_reclassification target class ${requestedClassId} is not active`,
+      status: 'invalid'
+    };
+  }
+
+  const characterRows = await tx<CharacterPayloadRow[]>`
+    SELECT c.payload
+    FROM characters c
+    JOIN session_players sp ON sp.character_id = c.id
+    WHERE c.id = ${targetId}
+      AND sp.session_id = ${session.id}
+    FOR UPDATE OF c
+  `;
+  const row = characterRows[0];
+
+  if (row === undefined) {
+    return { status: 'target_not_found' };
+  }
+
+  if (classProfile.orientationId !== row.payload.orientation.id) {
+    return {
+      error: `class_reclassification cannot change orientation from ${row.payload.orientation.id} to ${classProfile.orientationId}`,
+      status: 'invalid'
+    };
+  }
+
+  const appliedAt = new Date().toISOString();
+  const appliedChange: AppliedChangeRequest = {
+    changeKind: changeRequest.change_kind,
+    classId: classProfile.id,
+    className: classProfile.name,
+    orientationId: classProfile.orientationId,
+    previousClassId: row.payload.classProfile.id,
+    previousClassName: row.payload.classProfile.name,
+    targetId,
+    type: 'character_class_reclassified'
+  };
+  const character: Character = {
+    ...row.payload,
+    classProfile,
+    metadata: {
+      ...row.payload.metadata,
+      governanceChangeRequests: [
+        ...readRecordArray(row.payload.metadata.governanceChangeRequests),
+        {
+          actorId,
+          appliedAt,
+          changeKind: changeRequest.change_kind,
+          changeRequestId: changeRequest.id,
+          nextClassId: classProfile.id,
+          previousClassId: row.payload.classProfile.id,
+          sessionSlug: session.slug
+        }
+      ]
+    }
+  };
+
+  await tx`
+    UPDATE characters
+    SET payload = ${tx.json(character as unknown as postgres.JSONValue)}::jsonb,
+        updated_at = now()
+    WHERE id = ${targetId}
+  `;
+
+  return { appliedChange, status: 'applied' };
+}
+
+async function loadActiveClassProfile(classId: string): Promise<CharacterClassProfile | undefined> {
+  const catalog = await loadValidatedCatalog('classes.yaml');
+  const entry = (catalog as ClassesCatalog).classes.find(
+    (candidate) =>
+      candidate.status === 'active' &&
+      candidate.id === classId &&
+      candidate.name &&
+      candidate.orientation_id
+  );
+
+  if (entry === undefined) {
+    return undefined;
+  }
+
+  return {
+    id: entry.id,
+    name: cleanCatalogName(entry.name),
+    orientationId: entry.orientation_id,
+    primarySkillIds: entry.primary_skill_id ? [entry.primary_skill_id] : []
+  };
+}
+
+function cleanCatalogName(name: string): string {
+  return name
+    .replace(/,\s*-.*/, '')
+    .replace(/\s*\/.*$/, '')
+    .trim();
 }
 
 function validateRollbackBody(body: RollbackRequestBody): ValidationResult {

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -418,6 +418,21 @@ test.describe('K&W player and GM application flows', () => {
 
     await page.goto(`/mj?slug=${slug}`);
     await expect(page.getByLabel('Gabarit PNJ')).toBeVisible();
+    await page.getByLabel('Minute').fill('Reclasser Aveline');
+    await page.getByLabel('Type').selectOption('class_reclassification');
+    await expect(page.getByLabel('Classe demandée')).toBeVisible();
+    await page.getByLabel('Identifiant').fill(draftId);
+    await page.getByLabel('Classe demandée').fill('duelliste');
+    await page.getByLabel('Résumé').fill('Reclassement valide apres duel judiciaire.');
+    await page.getByRole('button', { name: 'Inscrire' }).click();
+    await expect(page.getByText('Reclasser Aveline').first()).toBeVisible();
+    await page.getByRole('button', { name: 'Approuver' }).first().click();
+
+    await page.goto(`/character?characterId=${draftId}`);
+    await expect(page.getByText('Humain · Guerrier · Duelliste')).toBeVisible();
+
+    await page.goto(`/mj?slug=${slug}`);
+    await expect(page.getByLabel('Gabarit PNJ')).toBeVisible();
     await page.getByLabel('Gabarit PNJ').selectOption('squelette');
     await page.getByRole('button', { name: 'PNJ bestiaire' }).click();
     await expect(page.getByText('Squelette ajoute au suivi MJ depuis le bestiaire')).toBeVisible();


### PR DESCRIPTION
Refs #166. Changes: approved class_reclassification change requests now apply a concrete linked-character class mutation for same-orientation classes, record appliedChange and governance metadata, and reject orientation-changing class requests instead of silently corrupting derived state. The GM cockpit now has a structured value field that maps reclassement to requestedClassId. Validation: pnpm test -- apps/server/src/routes/sessions.test.ts --runInBand; pnpm --filter @knightandwizard/server typecheck; pnpm --filter @knightandwizard/game typecheck; pnpm validate.