### PR TITLE
feat(game): #167 convert quest points

### DIFF
--- a/apps/game/src/features/character-sheet/CharacterSheet.tsx
+++ b/apps/game/src/features/character-sheet/CharacterSheet.tsx
@@ -19,6 +19,7 @@ import {
   type ToastTone
 } from '@knightandwizard/ui';
 
+import { getClientApiBaseUrl } from '../../lib/api';
 import {
   addInventoryItem,
   attributeRollOutcomeLabels,
@@ -77,10 +78,13 @@ export function CharacterSheet({
   spells
 }: Readonly<CharacterSheetProps>) {
   const [mode, setMode] = useState<CharacterSheetMode>('complete');
+  const [sheetCharacter, setSheetCharacter] = useState(character);
   const [inventory, setInventory] = useState(initialInventory);
   const [lastRoll, setLastRoll] = useState<AttributeRollResult | null>(null);
   const [equipmentSearch, setEquipmentSearch] = useState('');
   const [rollHistory, setRollHistory] = useState<AttributeRollResult[]>([]);
+  const [questConversionPending, setQuestConversionPending] = useState(false);
+  const [questConversionError, setQuestConversionError] = useState<string | null>(null);
 
   function addEquipment(equipmentId: string) {
     const option = equipmentCatalog.find((entry) => entry.id === equipmentId);
@@ -100,18 +104,18 @@ export function CharacterSheet({
     );
   }
   const view = useMemo(
-    () => buildCharacterSheetView({ character, inventory, mode, spells }),
-    [character, inventory, mode, spells]
+    () => buildCharacterSheetView({ character: sheetCharacter, inventory, mode, spells }),
+    [sheetCharacter, inventory, mode, spells]
   );
   const attributeTotal = attributeOrder.reduce(
-    (total, key) => total + character.attributes[key],
+    (total, key) => total + sheetCharacter.attributes[key],
     0
   );
-  const allSkillRows = skillTreeRows(character.skills, skillCatalog);
+  const allSkillRows = skillTreeRows(sheetCharacter.skills, skillCatalog);
   const skills = visibleSkillTreeRows(allSkillRows);
   const trainedSkillCount = skills.length;
-  const combatStatuses = combatStatusesFromMetadata(character.metadata.combat);
-  const showGrimoire = shouldShowGrimoire(character, spells);
+  const combatStatuses = combatStatusesFromMetadata(sheetCharacter.metadata.combat);
+  const showGrimoire = shouldShowGrimoire(sheetCharacter, spells);
   const filteredEquipmentCatalog = useMemo(
     () => filterEquipmentCatalog(equipmentCatalog, equipmentSearch, 8),
     [equipmentCatalog, equipmentSearch]
@@ -119,7 +123,7 @@ export function CharacterSheet({
 
   function roll(attribute: AttributeKey) {
     const result = rollAttributeCheck(
-      character,
+      sheetCharacter,
       attribute,
       7,
       (sides) => Math.floor(Math.random() * sides) + 1
@@ -127,6 +131,47 @@ export function CharacterSheet({
 
     setLastRoll(result);
     setRollHistory((current) => [result, ...current].slice(0, 6));
+  }
+
+  async function convertQuestPointGauge() {
+    if (questConversionPending || sheetCharacter.progression.questPoints <= 0) {
+      return;
+    }
+
+    setQuestConversionPending(true);
+    setQuestConversionError(null);
+
+    try {
+      const response = await fetch(
+        `${getClientApiBaseUrl()}/characters/${encodeURIComponent(sheetCharacter.id)}/quest-points/convert`,
+        {
+          body: JSON.stringify({
+            actorId: 'player',
+            reason: 'Fin de quête'
+          }),
+          headers: { 'content-type': 'application/json' },
+          method: 'POST'
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const result = (await response.json()) as { character?: Character };
+
+      if (!result.character) {
+        throw new Error('Réponse de conversion incomplète');
+      }
+
+      setSheetCharacter(result.character);
+    } catch (error) {
+      setQuestConversionError(
+        error instanceof Error ? error.message : 'Conversion de quête impossible'
+      );
+    } finally {
+      setQuestConversionPending(false);
+    }
   }
 
   const tabItems = modes.map((item) => {
@@ -181,7 +226,7 @@ export function CharacterSheet({
                 {socialAttributeKeys.map((attribute) => (
                   <AttributeButton
                     attribute={attribute}
-                    baseValue={character.attributes[attribute]}
+                    baseValue={sheetCharacter.attributes[attribute]}
                     effectiveValue={view.attributes[attribute]}
                     key={attribute}
                     label={attributeLabels[attribute]}
@@ -191,9 +236,9 @@ export function CharacterSheet({
               </div>
             </SectionCard>
             <SectionCard title="Réputation et relations">
-              <InfoLine label="Réputation" value={String(character.metadata.reputation)} />
-              <InfoLine label="Divinité" value={String(character.metadata.deity)} />
-              <InfoLine label="Citation" value={String(character.metadata.quote)} />
+              <InfoLine label="Réputation" value={String(sheetCharacter.metadata.reputation)} />
+              <InfoLine label="Divinité" value={String(sheetCharacter.metadata.deity)} />
+              <InfoLine label="Citation" value={String(sheetCharacter.metadata.quote)} />
             </SectionCard>
           </div>
         );
@@ -208,7 +253,7 @@ export function CharacterSheet({
               ))}
             </SectionCard>
             <SectionCard title="Notes privées MJ">
-              <InfoLine label="MJ" value={String(character.metadata.gmNotes)} />
+              <InfoLine label="MJ" value={String(sheetCharacter.metadata.gmNotes)} />
             </SectionCard>
           </div>
         );
@@ -225,13 +270,13 @@ export function CharacterSheet({
               title="9 aptitudes"
             >
               <p className="kw-sheet__muted">
-                Total création {attributeTotal}/{character.race.category}
+                Total création {attributeTotal}/{sheetCharacter.race.category}
               </p>
               <div className="kw-sheet__attribute-grid">
                 {attributeOrder.map((attribute) => (
                   <AttributeButton
                     attribute={attribute}
-                    baseValue={character.attributes[attribute]}
+                    baseValue={sheetCharacter.attributes[attribute]}
                     effectiveValue={view.attributes[attribute]}
                     key={attribute}
                     label={attributeLabels[attribute]}
@@ -261,7 +306,7 @@ export function CharacterSheet({
                 {trainedSkillCount} compétence{trainedSkillCount > 1 ? 's' : ''} ou spécialisation
                 {trainedSkillCount > 1 ? 's' : ''} notée{trainedSkillCount > 1 ? 's' : ''}.
               </p>
-              {character.orientation.isMagical && (
+              {sheetCharacter.orientation.isMagical && (
                 <Toast title="Magicien" tone="info">
                   Pas de compétence primaire mécanique, les sorts comptent double en progression.
                 </Toast>
@@ -285,9 +330,10 @@ export function CharacterSheet({
             <Seal>PJ</Seal>
             <div>
               <Label>Fiche PJ</Label>
-              <h1>{character.name}</h1>
+              <h1>{sheetCharacter.name}</h1>
               <p>
-                {character.race.name} · {character.orientation.name} · {character.classProfile.name}
+                {sheetCharacter.race.name} · {sheetCharacter.orientation.name} ·{' '}
+                {sheetCharacter.classProfile.name}
               </p>
             </div>
           </div>
@@ -297,20 +343,37 @@ export function CharacterSheet({
               {dataSourceLabel}
             </Badge>
             <Badge tone="success">
-              XP {character.progression.experiencePoints} / {character.progression.experienceTotal}
+              XP {sheetCharacter.progression.experiencePoints} /{' '}
+              {sheetCharacter.progression.experienceTotal}
             </Badge>
-            {character.progression.questPoints > 0 ? (
-              <Badge tone="info">Quête {character.progression.questPoints}</Badge>
+            {sheetCharacter.progression.questPoints > 0 ? (
+              <>
+                <Badge tone="info">Quête {sheetCharacter.progression.questPoints}</Badge>
+                <Button
+                  disabled={questConversionPending}
+                  onClick={convertQuestPointGauge}
+                  type="button"
+                  variant="secondary"
+                >
+                  {questConversionPending ? 'Conversion...' : 'Convertir la quête'}
+                </Button>
+              </>
             ) : null}
           </div>
         </div>
 
+        {questConversionError ? (
+          <Toast title="Conversion quête" tone="danger">
+            {questConversionError}
+          </Toast>
+        ) : null}
+
         <div className="kw-sheet__resources" aria-label="Ressources personnage">
           <ProgressBar
             label="Vitalité"
-            max={character.vitality.max}
+            max={sheetCharacter.vitality.max}
             tone="danger"
-            value={character.vitality.current}
+            value={sheetCharacter.vitality.current}
           />
           {view.vitalityState.weakened ? (
             <Badge tone="danger">
@@ -324,18 +387,18 @@ export function CharacterSheet({
               {status}
             </Badge>
           ))}
-          {character.energy.max > 0 || character.energy.current > 0 ? (
+          {sheetCharacter.energy.max > 0 || sheetCharacter.energy.current > 0 ? (
             <ProgressBar
               label="Énergie"
-              max={character.energy.max}
+              max={sheetCharacter.energy.max}
               tone="info"
-              value={character.energy.current}
+              value={sheetCharacter.energy.current}
             />
           ) : null}
           <StatBlock
             items={[
-              { label: 'Facteur vitesse', value: character.speedFactor },
-              { label: 'Facteur volonté', value: character.willFactor }
+              { label: 'Facteur vitesse', value: sheetCharacter.speedFactor },
+              { label: 'Facteur volonté', value: sheetCharacter.willFactor }
             ]}
           />
         </div>
@@ -432,7 +495,7 @@ export function CharacterSheet({
                 { label: 'Énergie', value: view.spellSummary.energyAvailable }
               ]}
             />
-            {character.orientation.isMagical && (
+            {sheetCharacter.orientation.isMagical && (
               <InfoLine
                 label="Création"
                 value={`${view.creationBudget.spellPoints} points de sort = ${view.creationBudget.freeSpellPoints} gratuits + ${view.creationBudget.extraSpellPoints} achetés.`}

--- a/apps/server/src/characters/finalize.ts
+++ b/apps/server/src/characters/finalize.ts
@@ -19,6 +19,7 @@ import {
   type CharacterSkill,
   type CharacterSpell,
   type CombatStatus,
+  convertQuestPoints,
   type RaceProfile,
   gainXP,
   learnSkill
@@ -91,6 +92,12 @@ export interface CharacterSkillImprovementUpdate {
   reason?: string;
   sessionSlug?: string;
   skillId: string;
+}
+
+export interface CharacterQuestPointConversionUpdate {
+  actorId?: string;
+  reason?: string;
+  sessionSlug?: string;
 }
 
 interface CharacterCreationCatalog {
@@ -554,6 +561,74 @@ export async function improvePersistedCharacterSkill(
   }
 }
 
+export async function convertPersistedCharacterQuestPoints(
+  id: string,
+  input: CharacterQuestPointConversionUpdate = {},
+  scope: CharacterPersistenceScope = {}
+): Promise<CharacterPersistenceResult> {
+  const sql = createSqlClient();
+  const db = createDbClient(sql);
+
+  try {
+    const rows = await db
+      .select({ character: characters.payload })
+      .from(characters)
+      .where(
+        scope.userId
+          ? and(eq(characters.id, id), eq(characters.userId, scope.userId))
+          : eq(characters.id, id)
+      )
+      .limit(1);
+    const row = rows[0];
+
+    if (row === undefined) {
+      throw new CharacterNotFoundError(id);
+    }
+
+    const previousQuestPoints = row.character.progression.questPoints;
+    const converted = convertQuestPoints(row.character);
+    const convertedAt = new Date().toISOString();
+    const conversionRecords =
+      previousQuestPoints > 0
+        ? [
+            ...readRecordArray(converted.metadata.questPointConversions),
+            {
+              ...(input.actorId ? { actorId: input.actorId } : {}),
+              convertedAt,
+              ...(input.reason ? { reason: input.reason } : {}),
+              ...(input.sessionSlug ? { sessionSlug: input.sessionSlug } : {}),
+              questPoints: previousQuestPoints
+            }
+          ]
+        : readRecordArray(converted.metadata.questPointConversions);
+    const character: Character = {
+      ...converted,
+      metadata: {
+        ...converted.metadata,
+        questPointConversions: conversionRecords
+      }
+    };
+    const updatedRows = await db
+      .update(characters)
+      .set({
+        payload: character,
+        updatedAt: drizzleSql`now()`
+      })
+      .where(
+        scope.userId
+          ? and(eq(characters.id, id), eq(characters.userId, scope.userId))
+          : eq(characters.id, id)
+      )
+      .returning({ character: characters.payload });
+
+    return {
+      character: updatedRows[0]!.character
+    };
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
 async function loadCharacterCreationCatalog(): Promise<CharacterCreationCatalog> {
   const [races, orientations, classes, weapons, protections, potions] = await Promise.all([
     loadValidatedCatalog('races.yaml'),
@@ -581,14 +656,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function readXpAwardRecords(value: unknown): Record<string, unknown>[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value.filter(isRecord);
+  return readRecordArray(value);
 }
 
 function readXpSpendRecords(value: unknown): Record<string, unknown>[] {
+  return readRecordArray(value);
+}
+
+function readRecordArray(value: unknown): Record<string, unknown>[] {
   if (!Array.isArray(value)) {
     return [];
   }

--- a/apps/server/src/routes/characters.test.ts
+++ b/apps/server/src/routes/characters.test.ts
@@ -221,6 +221,74 @@ describe('character routes', () => {
     });
   });
 
+  it('converts persisted quest points into usable XP when the quest ends', async () => {
+    const draftId = `route-quest-convert-character-${randomUUID()}`;
+
+    await app.inject({
+      method: 'PUT',
+      payload: sampleDraft('Aveline Queteuse'),
+      url: `/character-drafts/${draftId}`
+    });
+    await app.inject({
+      method: 'POST',
+      payload: { draftId },
+      url: '/characters/finalize'
+    });
+    await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        amount: 2,
+        questPoints: 3,
+        reason: 'Trois seances de quete',
+        sessionSlug: 'quete-brumeval'
+      },
+      url: `/characters/${draftId}/xp-awards`
+    });
+
+    const convertResponse = await app.inject({
+      method: 'POST',
+      payload: {
+        actorId: 'gm',
+        reason: 'Quete terminee et personnage survivant',
+        sessionSlug: 'quete-brumeval'
+      },
+      url: `/characters/${draftId}/quest-points/convert`
+    });
+    const readResponse = await app.inject({
+      method: 'GET',
+      url: `/characters/${draftId}`
+    });
+
+    expect(convertResponse.statusCode).toBe(200);
+    expect(convertResponse.json()).toMatchObject({
+      character: {
+        id: draftId,
+        metadata: {
+          questPointConversions: [
+            {
+              actorId: 'gm',
+              questPoints: 3,
+              reason: 'Quete terminee et personnage survivant',
+              sessionSlug: 'quete-brumeval'
+            }
+          ]
+        },
+        progression: {
+          experiencePoints: 5,
+          experienceTotal: 5,
+          questPoints: 0
+        }
+      },
+      status: 'updated'
+    });
+    expect(readResponse.json().character.progression).toEqual({
+      experiencePoints: 5,
+      experienceTotal: 5,
+      questPoints: 0
+    });
+  });
+
   it('spends persisted XP to improve an existing skill', async () => {
     const draftId = `route-skill-xp-character-${randomUUID()}`;
 

--- a/apps/server/src/routes/characters.ts
+++ b/apps/server/src/routes/characters.ts
@@ -4,12 +4,14 @@ import {
   CharacterDraftNotFoundError,
   CharacterNotFoundError,
   awardPersistedCharacterXp,
+  convertPersistedCharacterQuestPoints,
   finalizeCharacterDraft,
   getPersistedCharacter,
   improvePersistedCharacterSkill,
   listPersistedCharacterActiveSpells,
   updatePersistedCharacterCombatState,
   type CharacterCombatStateUpdate,
+  type CharacterQuestPointConversionUpdate,
   type CharacterSkillImprovementUpdate,
   type CharacterXpAwardUpdate
 } from '../characters/finalize.js';
@@ -42,6 +44,12 @@ interface ImproveCharacterSkillRequestBody {
   skillId?: unknown;
 }
 
+interface ConvertQuestPointsRequestBody {
+  actorId?: unknown;
+  reason?: unknown;
+  sessionSlug?: unknown;
+}
+
 interface CharacterParams {
   id: string;
 }
@@ -50,6 +58,9 @@ export async function registerCharacterRoutes(app: FastifyInstance): Promise<voi
   app.options('/characters/finalize', async (_request, reply) => reply.code(204).send());
   app.options('/characters/:id/active-spells', async (_request, reply) => reply.code(204).send());
   app.options('/characters/:id/combat-state', async (_request, reply) => reply.code(204).send());
+  app.options('/characters/:id/quest-points/convert', async (_request, reply) =>
+    reply.code(204).send()
+  );
   app.options('/characters/:id/skill-improvements', async (_request, reply) =>
     reply.code(204).send()
   );
@@ -185,6 +196,35 @@ export async function registerCharacterRoutes(app: FastifyInstance): Promise<voi
         const result = await improvePersistedCharacterSkill(request.params.id, validation.input, {
           userId: resolveRequestUserId(request)
         });
+
+        return {
+          character: result.character,
+          status: 'updated'
+        };
+      } catch (error) {
+        return sendCharacterRouteError(error, reply);
+      }
+    }
+  );
+
+  app.post<{ Body: ConvertQuestPointsRequestBody; Params: CharacterParams }>(
+    '/characters/:id/quest-points/convert',
+    async (request, reply) => {
+      const validation = validateQuestPointConversion(request.body ?? {});
+
+      if (!validation.valid) {
+        return reply.code(400).send({
+          errors: validation.errors,
+          status: 'invalid'
+        });
+      }
+
+      try {
+        const result = await convertPersistedCharacterQuestPoints(
+          request.params.id,
+          validation.input,
+          { userId: resolveRequestUserId(request) }
+        );
 
         return {
           character: result.character,
@@ -381,6 +421,42 @@ function validateSkillImprovement(
       ...(input.reason ? { reason: input.reason } : {}),
       ...(input.sessionSlug ? { sessionSlug: input.sessionSlug } : {}),
       skillId: input.skillId
+    },
+    valid: true
+  };
+}
+
+function validateQuestPointConversion(
+  body: ConvertQuestPointsRequestBody
+):
+  | { input: CharacterQuestPointConversionUpdate; valid: true }
+  | { errors: string[]; valid: false } {
+  const errors: string[] = [];
+  const actorId = normalizeOptionalString(body.actorId);
+  const reason = normalizeOptionalString(body.reason);
+  const sessionSlug = normalizeOptionalString(body.sessionSlug);
+
+  if (body.actorId !== undefined && actorId === undefined) {
+    errors.push('actorId must be a non-empty string');
+  }
+
+  if (body.reason !== undefined && reason === undefined) {
+    errors.push('reason must be a non-empty string');
+  }
+
+  if (body.sessionSlug !== undefined && sessionSlug === undefined) {
+    errors.push('sessionSlug must be a non-empty string');
+  }
+
+  if (errors.length > 0) {
+    return { errors, valid: false };
+  }
+
+  return {
+    input: {
+      ...(actorId ? { actorId } : {}),
+      ...(reason ? { reason } : {}),
+      ...(sessionSlug ? { sessionSlug } : {})
     },
     valid: true
   };

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -415,6 +415,9 @@ test.describe('K&W player and GM application flows', () => {
     await expect(page.getByRole('heading', { name: 'Aveline Cockpit' })).toBeVisible();
     await expect(page.getByText('XP 1 / 1')).toBeVisible();
     await expect(page.getByText('Quête 1')).toBeVisible();
+    await page.getByRole('button', { name: 'Convertir la quête' }).click();
+    await expect(page.getByText('XP 2 / 2')).toBeVisible();
+    await expect(page.getByText('Quête 1')).toHaveCount(0);
 
     await page.goto(`/mj?slug=${slug}`);
     await expect(page.getByLabel('Gabarit PNJ')).toBeVisible();


### PR DESCRIPTION
Refs #167. Changes: adds POST /characters/:id/quest-points/convert, persists quest-point conversion metadata, reuses rules-core convertQuestPoints, adds a character-sheet Convertir la quête action, and extends the cockpit -> fiche e2e to verify Quête 1 becomes XP 2 / 2. Validation: pnpm test -- apps/server/src/routes/characters.test.ts packages/rules-core/src/progression.test.ts --runInBand; pnpm --filter @knightandwizard/server typecheck; pnpm --filter @knightandwizard/game typecheck; pnpm validate.