### PR TITLE
feat(game): #167 add effective XP award controls

### DIFF
--- a/apps/game/src/features/gm-cockpit/GmCockpit.tsx
+++ b/apps/game/src/features/gm-cockpit/GmCockpit.tsx
@@ -56,6 +56,8 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
   const view = useMemo(() => buildGmCockpitView(state), [state]);
   const [selectedXpTarget, setSelectedXpTarget] = useState(view.xpTargets[0]?.characterId ?? '');
   const [awardQuestPoint, setAwardQuestPoint] = useState(false);
+  const [xpBonus, setXpBonus] = useState(0);
+  const [xpEffectiveHours, setXpEffectiveHours] = useState(1);
   const [selectedNpcTemplateId, setSelectedNpcTemplateId] = useState(
     bestiaryNpcTemplates[0]?.id ?? ''
   );
@@ -81,6 +83,7 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
     bestiaryNpcTemplates.find((template) => template.id === selectedNpcTemplateId) ??
     bestiaryNpcTemplates[0];
   const structuredChangeLabel = changeRequestStructuredLabel(changeKind);
+  const xpAwardAmount = clampXpAward(xpEffectiveHours + xpBonus);
   const effectiveRollbackSequence =
     rollbackSequence.length > 0
       ? Number.parseInt(rollbackSequence, 10)
@@ -110,13 +113,14 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
     }
 
     const questPoints = awardQuestPoint ? 1 : 0;
+    const reason = `Fin de session (${xpEffectiveHours} h effectives + ${xpBonus} bonus MJ)`;
 
     void run('xp', async () => {
       await awardCharacterXp(effectiveXpTarget.characterId, {
         actorId: 'gm',
-        amount: 1,
+        amount: xpAwardAmount,
         ...(questPoints > 0 ? { questPoints } : {}),
-        reason: 'Fin de session',
+        reason,
         sessionSlug: state.slug
       });
       await appendGmRulingToSession(state.slug, {
@@ -125,8 +129,10 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
           characterId: effectiveXpTarget.characterId,
           kind: 'xp_award',
           ...(questPoints > 0 ? { questPoints } : {}),
-          text: `XP attribue a ${effectiveXpTarget.name}${questPoints > 0 ? ' + 1 point de quête' : ''}`,
-          xp: 1
+          effectiveHours: xpEffectiveHours,
+          text: `${xpAwardAmount === 1 ? 'XP attribue' : `${xpAwardAmount} XP attribues`} a ${effectiveXpTarget.name}${questPoints > 0 ? ' + 1 point de quête' : ''}`,
+          xp: xpAwardAmount,
+          xpBonus
         }
       });
     });
@@ -623,6 +629,34 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
               Bestiaire indisponible pour cette session.
             </p>
           )}
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <label className="block text-sm font-semibold text-ink/70" htmlFor="gm-xp-hours">
+              Heures effectives
+              <input
+                className="mt-2 w-full rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-semibold text-ink"
+                id="gm-xp-hours"
+                max={8}
+                min={1}
+                onChange={(event) =>
+                  setXpEffectiveHours(clampIntegerInput(event.target.value, 1, 8))
+                }
+                type="number"
+                value={xpEffectiveHours}
+              />
+            </label>
+            <label className="block text-sm font-semibold text-ink/70" htmlFor="gm-xp-bonus">
+              Bonus MJ
+              <input
+                className="mt-2 w-full rounded-md border border-ink/12 bg-paper px-3 py-2 text-sm font-semibold text-ink"
+                id="gm-xp-bonus"
+                max={7}
+                min={0}
+                onChange={(event) => setXpBonus(clampIntegerInput(event.target.value, 0, 7))}
+                type="number"
+                value={xpBonus}
+              />
+            </label>
+          </div>
           <label className="mt-4 flex items-center gap-2 text-sm font-semibold text-ink/70">
             <input
               checked={awardQuestPoint}
@@ -641,7 +675,7 @@ export function GmCockpit({ bestiaryNpcTemplates = [], initialState }: Readonly<
               type="button"
             >
               <CheckCircle2 aria-hidden="true" className="size-4" />
-              Attribuer 1 XP
+              Attribuer {xpAwardAmount} XP
             </button>
             <button
               className="inline-flex items-center gap-2 rounded-md bg-ink px-3 py-2 text-sm font-semibold text-white disabled:opacity-50"
@@ -803,6 +837,20 @@ function changeRequestStructuredPayload(changeKind: string, value: string): Reco
   }
 
   return { requestedValue: value };
+}
+
+function clampIntegerInput(value: string, min: number, max: number): number {
+  const parsed = Number.parseInt(value, 10);
+
+  if (!Number.isFinite(parsed)) {
+    return min;
+  }
+
+  return Math.min(max, Math.max(min, parsed));
+}
+
+function clampXpAward(value: number): number {
+  return Math.min(8, Math.max(1, value));
 }
 
 function defaultAssistantPrompt(view: ReturnType<typeof buildGmCockpitView>): string {

--- a/tests/e2e/app-features.spec.ts
+++ b/tests/e2e/app-features.spec.ts
@@ -407,16 +407,19 @@ test.describe('K&W player and GM application flows', () => {
     await expect(proposalPanel.getByText('Le MJ decrit les details visibles')).toBeVisible();
     await expect(proposalPanel.getByText(/Sources \d+ · Mémoire \d+/)).toBeVisible();
 
+    await page.getByLabel('Heures effectives').fill('2');
     await page.getByLabel('Point de quête').check();
-    await page.getByRole('button', { name: 'Attribuer 1 XP' }).click();
-    await expect(page.getByText('XP attribue a Aveline Cockpit + 1 point de quête')).toBeVisible();
+    await page.getByRole('button', { name: 'Attribuer 2 XP' }).click();
+    await expect(
+      page.getByText('2 XP attribues a Aveline Cockpit + 1 point de quête')
+    ).toBeVisible();
 
     await page.goto(`/character?characterId=${draftId}`);
     await expect(page.getByRole('heading', { name: 'Aveline Cockpit' })).toBeVisible();
-    await expect(page.getByText('XP 1 / 1')).toBeVisible();
+    await expect(page.getByText('XP 2 / 2')).toBeVisible();
     await expect(page.getByText('Quête 1')).toBeVisible();
     await page.getByRole('button', { name: 'Convertir la quête' }).click();
-    await expect(page.getByText('XP 2 / 2')).toBeVisible();
+    await expect(page.getByText('XP 3 / 3')).toBeVisible();
     await expect(page.getByText('Quête 1')).toHaveCount(0);
 
     await page.goto(`/mj?slug=${slug}`);


### PR DESCRIPTION
Refs #167. Changes: replaces the fixed GM cockpit 1 XP button with effective-hours plus GM-bonus inputs, clamps the award to the canonical 1-8 range, persists the computed amount through the existing XP endpoint, and records effectiveHours/xpBonus in the session journal. E2E now verifies a 2-hour award plus quest point and quest conversion. Validation: pnpm --filter @knightandwizard/game typecheck; pnpm test -- apps/game/src/features/gm-cockpit/model.test.ts apps/game/src/features/session-manager/persistence.test.ts --runInBand; pnpm validate.